### PR TITLE
Permit custom identifier hashing

### DIFF
--- a/.changeset/rude-carrots-peel.md
+++ b/.changeset/rude-carrots-peel.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': minor
+---
+
+Users can now provide a custom identifier hashing function

--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Different formatting of identifiers (e.g. class names, keyframes, CSS Vars, etc)
 
 - `short` identifiers are a 7+ character hash. e.g. `hnw5tz3`
 - `debug` identifiers contain human readable prefixes representing the owning filename and a potential rule level debug name. e.g. `myfile_mystyle_hnw5tz3`
+- A function accepting three parameters: A scope name, an index, and an optional rule level debug name, and returning the identifier.
 
 Each integration will set a default value based on the configuration options passed to the bundler.
 

--- a/packages/css/src/identifier.test.ts
+++ b/packages/css/src/identifier.test.ts
@@ -1,3 +1,4 @@
+import { removeAdapter, setAdapter } from './adapter';
 import { setFileScope, endFileScope } from './fileScope';
 import { generateIdentifier } from './identifier';
 
@@ -24,5 +25,33 @@ describe('identifier', () => {
     expect(generateIdentifier('debug and more')).toMatchInlineSnapshot(
       `"debug_and_more__skkcyc2"`,
     );
+  });
+
+  describe('with custom callback', () => {
+    beforeAll(() => {
+      setAdapter({
+        appendCss: () => {},
+        registerClassName: () => {},
+        onEndFileScope: () => {},
+        registerComposition: () => {},
+        markCompositionUsed: () => {},
+        getIdentOption: () => (scope, index, dbg) =>
+          `abc_${dbg}_${scope}_${index}`,
+      });
+    });
+
+    afterAll(() => {
+      removeAdapter();
+    });
+
+    it('defers to a custom callback', () => {
+      expect(generateIdentifier(`a`)).toMatchInlineSnapshot(`"abc_a_test_3"`);
+    });
+
+    it('rejects invalid identifiers', () => {
+      // getIdentOption() does not remove spaces from the debug info so the
+      // resulting identifier should be invalid here.
+      expect(() => generateIdentifier(`a b`)).toThrow();
+    });
   });
 });

--- a/packages/css/src/identifier.ts
+++ b/packages/css/src/identifier.ts
@@ -56,7 +56,7 @@ export function generateIdentifier(debugId: string | undefined) {
     identifier = opt(fileScopeStr, refCount, debugId);
 
     if (!identifier.match(/^[A-Z_][0-9A-Z_]+$/i)) {
-      throw new Error(`Invalid identifier:"${identifier}"`);
+      throw new Error(`Identifier function returned invalid indentifier: "${identifier}"`);
     }
   }
 

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -103,7 +103,11 @@ export interface Composition {
   classList: string;
 }
 
-type IdentOption = 'short' | 'debug';
+type IdentOption =
+  | 'short'
+  | 'debug'
+  | ((scope: string, index: number, debugId: string | undefined) => string);
+
 export interface Adapter {
   appendCss: (css: CSS, fileScope: FileScope) => void;
   registerClassName: (className: string) => void;


### PR DESCRIPTION
Simple custom identifier hashing. Not quite the exact same feature request, but related: https://github.com/seek-oss/vanilla-extract/discussions/313

This may not be the best possible API for this, but it has the benefit of being a backwards-compatible drop-in for any adapter/plugin that already exposes `IdentifierOption` directly.

For example,  with the vite plugin, one can do:

```
plugins: [vanillaExtractPlugin({
      identifiers: (scope, index) => { return 'insert_logic_here'; }
    })],
```