### PR TITLE
Add recipe variants to return value of `createRuntimeFn`

### DIFF
--- a/packages/recipes/src/createRuntimeFn.ts
+++ b/packages/recipes/src/createRuntimeFn.ts
@@ -19,11 +19,10 @@ const shouldApplyCompound = <Variants extends VariantGroups>(
   return true;
 };
 
-export const createRuntimeFn =
-  <Variants extends VariantGroups>(
-    config: PatternResult<Variants>,
-  ): RuntimeFn<Variants> =>
-  (options) => {
+export const createRuntimeFn = <Variants extends VariantGroups>(
+  config: PatternResult<Variants>,
+): RuntimeFn<Variants> => {
+  const runtimeFn: RuntimeFn<Variants> = (options) => {
     let className = config.defaultClassName;
 
     const selections: VariantSelection<Variants> = {
@@ -62,3 +61,8 @@ export const createRuntimeFn =
 
     return className;
   };
+
+  runtimeFn.variants = Object.keys(config.variantClassNames);
+
+  return runtimeFn;
+};

--- a/packages/recipes/src/types.ts
+++ b/packages/recipes/src/types.ts
@@ -32,9 +32,9 @@ export type PatternOptions<Variants extends VariantGroups> = {
   compoundVariants?: Array<CompoundVariant<Variants>>;
 };
 
-export type RuntimeFn<Variants extends VariantGroups> = (
+export type RuntimeFn<Variants extends VariantGroups> = ((
   options?: VariantSelection<Variants>,
-) => string;
+) => string) & { variants: (keyof Variants)[] };
 
 export type RecipeVariants<RecipeFn extends RuntimeFn<VariantGroups>> =
   Parameters<RecipeFn>[0];


### PR DESCRIPTION
This PR adds the keys of variants passed to `createRuntimeFn` as a property on its return value. This allows for runtime reflection of variants that are available, which is useful in a few cases, like deciding which props should be passed to the `runtimeFn` and which to passed to the component