### PR TITLE
[webpack-plugin] Allow `external` argument to accept both a string and array of strings

### DIFF
--- a/packages/webpack-plugin/src/compiler.ts
+++ b/packages/webpack-plugin/src/compiler.ts
@@ -114,7 +114,7 @@ function compileVanillaSource(
     new ExternalsPlugin('commonjs', [
       '@vanilla-extract/css',
       '@vanilla-extract/css/fileScope',
-      externals,
+      ...(Array.isArray(externals) ? externals : [externals]),
     ]).apply(childCompiler);
 
     let source: string;


### PR DESCRIPTION
To fix the issue described in #746, I need to specify externals of this form: 
```js
new VanillaExtractPlugin({externals: ["@name/pkg1/*", "@name/pkg1/**/*", "@name/pkg2/*", "@name/pkg2/**/*"]})
```
This PR allows `externals` to be either a single string or an array of strings.

I am aware that `externals` would also [accept](https://webpack.js.org/configuration/externals/) a regex or a function. But I haven't managed to make it work with either. I receive a `SyntaxError: Cannot use import statement outside a module` when using a regex, and the same error or
```
module.exports = @mono/ds/dsStyles.css;
                 ^
SyntaxError: Invalid or unexpected token
```
when using a function which returns different `type`s. So far only the array version of this PR worked reliably for me.