### PR TITLE
Add fallbackVar to @vanilla-extract/dynamic

### DIFF
--- a/packages/dynamic/src/fallbackVar.test.ts
+++ b/packages/dynamic/src/fallbackVar.test.ts
@@ -1,0 +1,69 @@
+import { fallbackVar } from './fallbackVar';
+
+describe('fallbackVar', () => {
+  it('supports a single string fallback', () => {
+    expect(fallbackVar('var(--foo-bar)', 'blue')).toMatchInlineSnapshot(
+      `"var(--foo-bar, blue)"`,
+    );
+  });
+
+  it('supports a single numeric fallback', () => {
+    expect(fallbackVar('var(--foo-bar)', '10px')).toMatchInlineSnapshot(
+      `"var(--foo-bar, 10px)"`,
+    );
+  });
+
+  it('supports a single var fallback', () => {
+    expect(fallbackVar('var(--foo-bar)', 'var(--baz)')).toMatchInlineSnapshot(
+      `"var(--foo-bar, var(--baz))"`,
+    );
+  });
+
+  it('supports multiple fallbacks resolving to a string', () => {
+    expect(
+      fallbackVar('var(--foo)', 'var(--bar)', 'var(--baz)', 'blue'),
+    ).toMatchInlineSnapshot(`"var(--foo, var(--bar, var(--baz, blue)))"`);
+  });
+
+  it('supports multiple fallbacks resolving to a number', () => {
+    expect(
+      fallbackVar('var(--foo)', 'var(--bar)', 'var(--baz)', '10px'),
+    ).toMatchInlineSnapshot(`"var(--foo, var(--bar, var(--baz, 10px)))"`);
+  });
+
+  it('supports multiple fallbacks resolving to a var', () => {
+    expect(
+      fallbackVar(
+        'var(--foo)',
+        'var(--bar)',
+        'var(--baz)',
+        'var(--final-fallback)',
+      ),
+    ).toMatchInlineSnapshot(
+      `"var(--foo, var(--bar, var(--baz, var(--final-fallback))))"`,
+    );
+  });
+
+  it('should throw with invalid vars', () => {
+    expect(() => {
+      fallbackVar('INVALID', '10px');
+    }).toThrowErrorMatchingInlineSnapshot(`"Invalid variable name: INVALID"`);
+
+    expect(() => {
+      fallbackVar('INVALID1', 'INVALID2', '10px');
+    }).toThrowErrorMatchingInlineSnapshot(`"Invalid variable name: INVALID2"`);
+
+    expect(() => {
+      // @ts-expect-error
+      fallbackVar('INVALID', 10, 10);
+    }).toThrowErrorMatchingInlineSnapshot(`"Invalid variable name: 10"`);
+
+    expect(() => {
+      fallbackVar('var(--foo-bar)', 'INVALID', '10px');
+    }).toThrowErrorMatchingInlineSnapshot(`"Invalid variable name: INVALID"`);
+
+    expect(() => {
+      fallbackVar('INVALID', 'var(--foo-bar)', '10px');
+    }).toThrowErrorMatchingInlineSnapshot(`"Invalid variable name: INVALID"`);
+  });
+});

--- a/packages/dynamic/src/fallbackVar.ts
+++ b/packages/dynamic/src/fallbackVar.ts
@@ -1,0 +1,21 @@
+import { CSSVarFunction } from '@vanilla-extract/private';
+
+export function fallbackVar(
+  ...values: [string, ...Array<string>]
+): CSSVarFunction {
+  let finalValue = '';
+
+  values.reverse().forEach((value) => {
+    if (finalValue === '') {
+      finalValue = String(value);
+    } else {
+      if (typeof value !== 'string' || !/^var\(--.*\)$/.test(value)) {
+        throw new Error(`Invalid variable name: ${value}`);
+      }
+
+      finalValue = value.replace(/\)$/, `, ${finalValue})`);
+    }
+  });
+
+  return finalValue as CSSVarFunction;
+}

--- a/packages/dynamic/src/index.ts
+++ b/packages/dynamic/src/index.ts
@@ -1,2 +1,3 @@
 export { assignInlineVars } from './assignInlineVars';
 export { setElementVars } from './setElementVars';
+export { fallbackVar } from './fallbackVar';

--- a/site/docs/dynamic-api.md
+++ b/site/docs/dynamic-api.md
@@ -103,3 +103,48 @@ setElementVars(el, vars.colors, {
   accent: 'green'
 });
 ```
+
+## fallbackVar
+
+Provides fallback values when consuming variables.
+
+```tsx
+// app.ts
+
+import {
+  fallbackVar,
+  setElementVars
+} from '@vanilla-extract/dynamic';
+import { vars } from './styles.css.ts';
+
+const el = document.getElementById('myElement');
+
+setElementVars(el, {
+  [vars.colors.accent]: fallbackVar(
+    vars.colors.brand,
+    'pink'
+  )
+});
+```
+
+Multiple fallbacks are also supported.
+
+```tsx
+// app.ts
+
+import {
+  fallbackVar,
+  setElementVars
+} from '@vanilla-extract/dynamic';
+import { vars } from './styles.css.ts';
+
+const el = document.getElementById('myElement');
+
+setElementVars(el, {
+  [vars.colors.accent]: fallbackVar(
+    vars.colors.brand,
+    vars.colors.primary,
+    'pink'
+  )
+});
+```


### PR DESCRIPTION
I ran into a case where I needed to use `fallbackVar` during runtime. It involved a pretty complex CSS calculation with other dynamic values, and I needed to use a CSS variable with a fallback value. Currently `fallbackVar` is exported from `@vanilla-extract/css`, and using it during runtime would require makinging it a peer dependency of the library. Considering this function is just string manipulation, I thought it made sense to add it to the dynamic library as well.

If this sounds good to the maintainers, would it make sense to move this function to a shared location that can be used by both `/css` and `/dynamic`? Would that be `@vanilla-extract/private`?
