### PR TITLE
feat: provide a static set of conditions on the sprinkles function

### DIFF
--- a/.changeset/cuddly-hounds-notice.md
+++ b/.changeset/cuddly-hounds-notice.md
@@ -2,4 +2,5 @@
 '@vanilla-extract/sprinkles': minor
 ---
 
-expose sprinkles conditions names
+Add conditions property to result of `createSprinkles`
+A `Set` of all the condition names assigned to the sprinkles function is now available via `sprinkles.conditions`.

--- a/.changeset/cuddly-hounds-notice.md
+++ b/.changeset/cuddly-hounds-notice.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/sprinkles': minor
+---
+
+expose sprinkles conditions names

--- a/packages/sprinkles/src/createSprinkles.ts
+++ b/packages/sprinkles/src/createSprinkles.ts
@@ -62,7 +62,10 @@ type SprinkleProps<Args extends ReadonlyArray<any>> = Args extends [
 
 export type SprinklesFn<Args extends ReadonlyArray<SprinklesProperties>> = ((
   props: SprinkleProps<Args>,
-) => string) & { properties: Set<keyof SprinkleProps<Args>> };
+) => string) & {
+  properties: Set<keyof SprinkleProps<Args>>;
+  conditions: Set<string>;
+};
 
 export const createSprinkles =
   <Args extends ReadonlyArray<SprinklesProperties>>(
@@ -70,6 +73,9 @@ export const createSprinkles =
   ) =>
   (...args: Args): SprinklesFn<Args> => {
     const sprinklesStyles = Object.assign({}, ...args.map((a) => a.styles));
+    const sprinklesConditions = new Set<any>(
+      args.flatMap((a) => a.conditions?.conditionNames).filter(Boolean),
+    );
     const sprinklesKeys = Object.keys(sprinklesStyles) as Array<
       keyof SprinkleProps<Args>
     >;
@@ -272,5 +278,6 @@ export const createSprinkles =
 
     return Object.assign(sprinklesFn, {
       properties: new Set(sprinklesKeys),
+      conditions: sprinklesConditions,
     });
   };

--- a/packages/sprinkles/src/createSprinkles.ts
+++ b/packages/sprinkles/src/createSprinkles.ts
@@ -82,8 +82,10 @@ export const createSprinkles =
   ) =>
   (...args: Args): SprinklesFn<Args> => {
     const sprinklesStyles = Object.assign({}, ...args.map((a) => a.styles));
-    const sprinklesConditions = new Set<any>(
-      args.flatMap((a) => a.conditions?.conditionNames).filter(Boolean),
+    const sprinklesConditions = new Set(
+      args.flatMap((a) => a.conditions?.conditionNames).filter(Boolean) as [
+        SprinkleConditions<Args>,
+      ],
     );
     const sprinklesKeys = Object.keys(sprinklesStyles) as Array<
       keyof SprinkleProps<Args>

--- a/packages/sprinkles/src/createSprinkles.ts
+++ b/packages/sprinkles/src/createSprinkles.ts
@@ -65,13 +65,9 @@ type SprinkleConditions<Args extends ReadonlyArray<any>> = Args extends [
   ...infer R
 ]
   ? L extends SprinklesProperties
-    ? [
-        keyof L['conditions'],
-        ...SprinkleConditions<[ChildSprinkleProps<L['styles']>]>,
-        ...SprinkleConditions<R>
-      ]
-    : []
-  : [];
+    ? keyof L['conditions'] | SprinkleConditions<R>
+    : never
+  : never;
 
 export type SprinklesFn<Args extends ReadonlyArray<SprinklesProperties>> = ((
   props: SprinkleProps<Args>,

--- a/packages/sprinkles/src/createSprinkles.ts
+++ b/packages/sprinkles/src/createSprinkles.ts
@@ -65,7 +65,7 @@ type SprinkleConditions<Args extends ReadonlyArray<any>> = Args extends [
   ...infer R
 ]
   ? L extends SprinklesProperties
-    ? keyof L['conditions'] | SprinkleConditions<R>
+    ? L['conditions']['conditionNames'][number] | SprinkleConditions<R>
     : never
   : never;
 

--- a/packages/sprinkles/src/createSprinkles.ts
+++ b/packages/sprinkles/src/createSprinkles.ts
@@ -60,11 +60,24 @@ type SprinkleProps<Args extends ReadonlyArray<any>> = Args extends [
       SprinkleProps<R>
   : {};
 
+type SprinkleConditions<Args extends ReadonlyArray<any>> = Args extends [
+  infer L,
+  ...infer R
+]
+  ? L extends SprinklesProperties
+    ? [
+        keyof L['conditions'],
+        ...SprinkleConditions<[ChildSprinkleProps<L['styles']>]>,
+        ...SprinkleConditions<R>
+      ]
+    : []
+  : [];
+
 export type SprinklesFn<Args extends ReadonlyArray<SprinklesProperties>> = ((
   props: SprinkleProps<Args>,
 ) => string) & {
   properties: Set<keyof SprinkleProps<Args>>;
-  conditions: Set<string>;
+  conditions: Set<SprinkleConditions<Args>>;
 };
 
 export const createSprinkles =

--- a/packages/sprinkles/src/createUtils.ts
+++ b/packages/sprinkles/src/createUtils.ts
@@ -2,6 +2,7 @@ import { addRecipe } from '@vanilla-extract/css/recipe';
 import {
   ResponsiveArrayByMaxLength,
   RequiredResponsiveArrayByMaxLength,
+  Conditions,
 } from './types';
 
 type ExtractValue<
@@ -19,14 +20,6 @@ type ExtractValue<
   : Value extends Partial<Record<string, string | number | boolean>>
   ? NonNullable<Value[keyof Value]>
   : Value;
-
-type Conditions<ConditionName extends string> = {
-  conditions: {
-    defaultCondition: ConditionName | false;
-    conditionNames: Array<ConditionName>;
-    responsiveArray?: Array<ConditionName>;
-  };
-};
 
 type ExtractDefaultCondition<SprinklesProperties extends Conditions<string>> =
   SprinklesProperties['conditions']['defaultCondition'];

--- a/packages/sprinkles/src/index.ts
+++ b/packages/sprinkles/src/index.ts
@@ -11,15 +11,17 @@ import {
   SprinklesFn,
   createSprinkles as internalCreateSprinkles,
 } from './createSprinkles';
-import { SprinklesProperties, ResponsiveArrayConfig } from './types';
+import {
+  SprinklesProperties,
+  ResponsiveArrayConfig,
+  Condition,
+  ConditionKey,
+} from './types';
 
 export { createNormalizeValueFn, createMapValueFn } from './createUtils';
 export type { ConditionalValue, RequiredConditionalValue } from './createUtils';
 
 export type { ResponsiveArray } from './types';
-
-type ConditionKey = '@media' | '@supports' | '@container' | 'selector';
-export type Condition = Partial<Record<ConditionKey, string>>;
 
 type BaseConditions = { [conditionName: string]: Condition };
 

--- a/packages/sprinkles/src/index.ts
+++ b/packages/sprinkles/src/index.ts
@@ -11,17 +11,15 @@ import {
   SprinklesFn,
   createSprinkles as internalCreateSprinkles,
 } from './createSprinkles';
-import {
-  SprinklesProperties,
-  ResponsiveArrayConfig,
-  Condition,
-  ConditionKey,
-} from './types';
+import { SprinklesProperties, ResponsiveArrayConfig } from './types';
 
 export { createNormalizeValueFn, createMapValueFn } from './createUtils';
 export type { ConditionalValue, RequiredConditionalValue } from './createUtils';
 
 export type { ResponsiveArray } from './types';
+
+type ConditionKey = '@media' | '@supports' | '@container' | 'selector';
+type Condition = Partial<Record<ConditionKey, string>>;
 
 type BaseConditions = { [conditionName: string]: Condition };
 

--- a/packages/sprinkles/src/index.ts
+++ b/packages/sprinkles/src/index.ts
@@ -19,7 +19,7 @@ export type { ConditionalValue, RequiredConditionalValue } from './createUtils';
 export type { ResponsiveArray } from './types';
 
 type ConditionKey = '@media' | '@supports' | '@container' | 'selector';
-type Condition = Partial<Record<ConditionKey, string>>;
+export type Condition = Partial<Record<ConditionKey, string>>;
 
 type BaseConditions = { [conditionName: string]: Condition };
 

--- a/packages/sprinkles/src/types.ts
+++ b/packages/sprinkles/src/types.ts
@@ -1,3 +1,5 @@
+import type { Condition } from './';
+
 export interface ResponsiveArray<Length extends number, Value>
   extends ReadonlyArray<Value> {
   0: Value;
@@ -75,6 +77,7 @@ export type ShorthandProperty = {
 };
 
 export type SprinklesProperties = {
+  conditions?: { [conditionName: string]: Condition };
   styles: {
     [property: string]:
       | ConditionalWithResponsiveArrayProperty

--- a/packages/sprinkles/src/types.ts
+++ b/packages/sprinkles/src/types.ts
@@ -74,11 +74,16 @@ export type ShorthandProperty = {
   mappings: Array<string>;
 };
 
-export type ConditionKey = '@media' | '@supports' | '@container' | 'selector';
-export type Condition = Partial<Record<ConditionKey, string>>;
+export type Conditions<ConditionName extends string> = {
+  conditions: {
+    defaultCondition: ConditionName | false;
+    conditionNames: Array<ConditionName>;
+    responsiveArray?: Array<ConditionName>;
+  };
+};
 
 export type SprinklesProperties = {
-  conditions?: { [conditionName: string]: Condition };
+  conditions: Conditions<string>['conditions'];
   styles: {
     [property: string]:
       | ConditionalWithResponsiveArrayProperty

--- a/packages/sprinkles/src/types.ts
+++ b/packages/sprinkles/src/types.ts
@@ -1,5 +1,3 @@
-import type { Condition } from './';
-
 export interface ResponsiveArray<Length extends number, Value>
   extends ReadonlyArray<Value> {
   0: Value;
@@ -75,6 +73,9 @@ export type UnconditionalProperty = {
 export type ShorthandProperty = {
   mappings: Array<string>;
 };
+
+export type ConditionKey = '@media' | '@supports' | '@container' | 'selector';
+export type Condition = Partial<Record<ConditionKey, string>>;
 
 export type SprinklesProperties = {
   conditions?: { [conditionName: string]: Condition };

--- a/tests/sprinkles/sprinkles-type-tests.ts
+++ b/tests/sprinkles/sprinkles-type-tests.ts
@@ -284,9 +284,9 @@ const noop = (...args: Array<any>) => {};
 
   noop(invalidRequiredValue);
 
-  conditionalProperties.conditions.conditionNames.includes('mobile');
-  conditionalProperties.conditions.conditionNames.includes('tablet');
-  conditionalProperties.conditions.conditionNames.includes('desktop');
+  sprinkles.conditions.has('mobile');
+  sprinkles.conditions.has('tablet');
+  sprinkles.conditions.has('desktop');
   // @ts-expect-error
-  conditionalProperties.conditions.conditionNames.includes('missingCondition');
+  sprinkles.conditions.has('missingCondition');
 };

--- a/tests/sprinkles/sprinkles-type-tests.ts
+++ b/tests/sprinkles/sprinkles-type-tests.ts
@@ -284,17 +284,9 @@ const noop = (...args: Array<any>) => {};
 
   noop(invalidRequiredValue);
 
-  const conditionalSprinkle = createSprinkles({
-    styles: {},
-    conditions: {
-      mobile: { selector: 'xxx mobile' },
-      tablet: { selector: 'xxx tablet' },
-      desktop: { selector: 'xxx desktop' },
-    },
-  });
-  conditionalSprinkle.conditions.has('mobile');
-  conditionalSprinkle.conditions.has('tablet');
-  conditionalSprinkle.conditions.has('desktop');
+  conditionalProperties.conditions.conditionNames.includes('mobile');
+  conditionalProperties.conditions.conditionNames.includes('tablet');
+  conditionalProperties.conditions.conditionNames.includes('desktop');
   // @ts-expect-error
-  conditionalSprinkle.conditions.has('missingCondition');
+  conditionalProperties.conditions.conditionNames.includes('missingCondition');
 };

--- a/tests/sprinkles/sprinkles-type-tests.ts
+++ b/tests/sprinkles/sprinkles-type-tests.ts
@@ -283,4 +283,18 @@ const noop = (...args: Array<any>) => {};
   > = ['row'];
 
   noop(invalidRequiredValue);
+
+  const conditionalSprinkle = createSprinkles({
+    styles: {},
+    conditions: {
+      mobile: { selector: 'xxx mobile' },
+      tablet: { selector: 'xxx tablet' },
+      desktop: { selector: 'xxx desktop' },
+    },
+  });
+  conditionalSprinkle.conditions.has('mobile');
+  conditionalSprinkle.conditions.has('tablet');
+  conditionalSprinkle.conditions.has('desktop');
+  // @ts-expect-error
+  conditionalSprinkle.conditions.has('missingCondition');
 };

--- a/tests/sprinkles/sprinkles.test.ts
+++ b/tests/sprinkles/sprinkles.test.ts
@@ -309,6 +309,20 @@ describe('sprinkles', () => {
         }
       `);
     });
+    it('should provide a static set of conditions on the sprinkles function', () => {
+      const sprinkles = createSprinkles(
+        propertiesWithShorthands,
+        conditionalProperties,
+      );
+
+      expect(sprinkles.conditions).toMatchInlineSnapshot(`
+        Set {
+          "mobile",
+          "tablet",
+          "desktop",
+        }
+      `);
+    });
   });
 
   describe('errors', () => {


### PR DESCRIPTION
Hey, first I want to thank you for this library and your work on it, it's great !

### Context:
This is both a feature request and a MVP as a PR.

Currently the sprinkles function only expose the `properties`, I'd like to be able to see (type-wise) / check (using as guards) the validity of the conditions. 
I was trying to implement [this feature request](https://github.com/TheMightyPenguin/dessert-box/issues/18) and realized I couldn't do it properly (no (easy?) way to infer all the conditions / I could check the validity of each props passed but couldn't check if the condition exist)

### Use-case
My use-case would be to implement properties grouped by conditions like:
`mobile: { color: "red", fontSize: "small" }`
rather than the opposite, having to specify conditions by property which is the current way of specifying conditions: 
`color: { mobile: "red" }, fontSize: { mobile: "red" }`

### Solution
For that I think a `conditions` property on the `createSprinkles` return is needed, just like the `properties` static attribute.
When I say "MVP", I mean that I guess my PR in the current state might not fit the repository, maybe you want some more tests or better typings, since I'm not really familiar with the repository I went for the quickest implementation 

Would love to hear your thought on this !