### PR TITLE
vite: Fix RSC integration

### DIFF
--- a/.changeset/stupid-keys-notice.md
+++ b/.changeset/stupid-keys-notice.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Fix React Server Components integration at build time.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -33,7 +33,7 @@ export function vanillaExtractPlugin({
   let postCssConfig: PostCSSConfigResult | null;
   const cssMap = new Map<string, string>();
 
-  let forceEmitCssInSsrBuild: boolean = !!process.env.VITE_RSC_BUILD;
+  let forceEmitCssInSsrBuild: boolean;
   let packageName: string;
 
   const getAbsoluteVirtualFileId = (source: string) =>
@@ -74,6 +74,8 @@ export function vanillaExtractPlugin({
         )
       ) {
         forceEmitCssInSsrBuild = true;
+      } else {
+        forceEmitCssInSsrBuild = !process.env.VITE_RSC_BUILD;
       }
     },
     resolveId(source) {


### PR DESCRIPTION
It looks like the RSC integration broke in https://github.com/vanilla-extract-css/vanilla-extract/pull/796 (release 3.4.0). The reason is that the code changed from `!process.env.VITE_RSC_BUILD` to `!!process.env.VITE_RSC_BUILD`.

This change fixes it. I've added it to the `else` part of the Astro/Solid integration to make sure we don't break those frameworks. It would be good to check that everything works there regardless -- cc @mechairoi @markdalgleish