### PR TITLE
Don't output CSS on Next server builds

### DIFF
--- a/.changeset/spicy-planes-approve.md
+++ b/.changeset/spicy-planes-approve.md
@@ -1,0 +1,7 @@
+---
+'@vanilla-extract/next-plugin': patch
+---
+
+Fix `Cannot find module *.css.ts.vanilla.css` issue
+
+Previously, CSS was being output on both the client and server builds. This fix ensure CSS is only output on the client build.

--- a/packages/next-plugin/src/index.js
+++ b/packages/next-plugin/src/index.js
@@ -50,7 +50,9 @@ export const createVanillaExtractPlugin =
           ),
         });
 
-        config.plugins.push(new VanillaExtractPlugin(pluginOptions));
+        config.plugins.push(
+          new VanillaExtractPlugin({ outputCss: !isServer, ...pluginOptions }),
+        );
 
         if (typeof nextConfig.webpack === 'function') {
           return nextConfig.webpack(config, options);


### PR DESCRIPTION
The actual issue this solves was because the Next server build was marking the virtual CSS files as external, which means a standard node require is used, obviously failing. While this is strange more of a Next issue, we shouldn't be generating CSS in the server build anyway. 

Resolves #569 