### PR TITLE
Add onFileCompiled callback

### DIFF
--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -22,11 +22,13 @@ interface VanillaExtractPluginOptions {
   externals?: Array<string>;
   runtime?: boolean;
   processCss?: (css: string) => Promise<string>;
+  onFileCompiled?: (path: string, identifiers: Record<string, string>) => void;
   identifiers?: IdentifierOption;
   esbuildOptions?: CompileOptions['esbuildOptions'];
 }
 export function vanillaExtractPlugin({
   outputCss,
+  onFileCompiled,
   externals = [],
   runtime = false,
   processCss,
@@ -93,6 +95,7 @@ export function vanillaExtractPlugin({
 
         const contents = await processVanillaFile({
           source,
+          onFileCompiled,
           filePath: path,
           outputCss,
           identOption,

--- a/packages/integration/src/processVanillaFile.ts
+++ b/packages/integration/src/processVanillaFile.ts
@@ -38,11 +38,13 @@ interface ProcessVanillaFileOptions {
     fileScope: FileScope;
     source: string;
   }) => string | Promise<string>;
+  onFileCompiled?: (path: string, identifiers: Record<string, string>) => void;
 }
 export async function processVanillaFile({
   source,
   filePath,
   outputCss = true,
+  onFileCompiled,
   identOption = process.env.NODE_ENV === 'production' ? 'short' : 'debug',
   serializeVirtualCssPath,
 }: ProcessVanillaFileOptions) {
@@ -96,6 +98,7 @@ export async function processVanillaFile({
     { console, process, __adapter__: cssAdapter },
     true,
   );
+  onFileCompiled?.(filePath, evalResult)
 
   process.env.NODE_ENV = currentNodeEnv;
 


### PR DESCRIPTION
Per https://github.com/vanilla-extract-css/vanilla-extract/discussions/864

This hook lets users supply the missing piece for integration with non-javascript backends - recording the class-name mapping used by vanilla-extract.