### PR TITLE
Use async Babel transform in `integration/transform.ts`

### DIFF
--- a/.changeset/lovely-lies-hide.md
+++ b/.changeset/lovely-lies-hide.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/babel-plugin-debug-ids': patch
+---
+
+Use correct async Babel transform method in integration transform

--- a/.changeset/lovely-lies-hide.md
+++ b/.changeset/lovely-lies-hide.md
@@ -1,5 +1,5 @@
 ---
-'@vanilla-extract/babel-plugin-debug-ids': patch
+'@vanilla-extract/integration': patch
 ---
 
 Use correct async Babel transform method in integration transform

--- a/packages/integration/src/transform.ts
+++ b/packages/integration/src/transform.ts
@@ -55,7 +55,7 @@ export const transform = async ({
   let code = source;
 
   if (identOption === 'debug') {
-    const result = await babel.transform(source, {
+    const result = await babel.transformAsync(source, {
       filename: filePath,
       cwd: rootPath,
       plugins: [vanillaBabelPlugin, typescriptSyntax],


### PR DESCRIPTION
Currently both transforms are synchronous because the Babel `transform` method used is just an alias for `transformSync` — see [here][1] and [here][2].

[2]: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/babel__core/index.d.ts#L398-L401
[1]: https://github.com/babel/babel/blob/main/packages/babel-core/src/transform.ts#L63-L72