### PR TITLE
Add RuntimeFn as an export to recipes index

### DIFF
--- a/.changeset/tasty-olives-tell.md
+++ b/.changeset/tasty-olives-tell.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/recipes': minor
+---
+
+Add RuntimeFn as an export to recipes index

--- a/packages/recipes/src/index.ts
+++ b/packages/recipes/src/index.ts
@@ -10,7 +10,7 @@ import type {
   VariantSelection,
 } from './types';
 
-export type { RecipeVariants } from './types';
+export type { RecipeVariants, RuntimeFn } from './types';
 
 function mapValues<Input extends Record<string, any>, OutputValue>(
   input: Input,


### PR DESCRIPTION
Closes #739

"Partial" builds (simple tsc builds, no bundling) will emit wrong declaration when using recipes. This allows it to use the correct import. 
