### PR TITLE
export types needed for typescript inference with esm

### DIFF
--- a/.changeset/tasty-olives-tell.md
+++ b/.changeset/tasty-olives-tell.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/recipes': minor
+---
+
+Add RuntimeFn as an export to recipes index

--- a/packages/css/src/vars.ts
+++ b/packages/css/src/vars.ts
@@ -11,6 +11,8 @@ import { Tokens, NullableTokens, ThemeVars } from './types';
 import { validateContract } from './validateContract';
 import { generateIdentifier } from './identifier';
 
+export type { Contract, MapLeafNodes, CSSVarFunction } from '@vanilla-extract/private';
+
 export function createVar(debugId?: string): CSSVarFunction {
   const cssVarName = cssesc(
     generateIdentifier({

--- a/packages/recipes/src/index.ts
+++ b/packages/recipes/src/index.ts
@@ -10,7 +10,7 @@ import type {
   VariantSelection,
 } from './types';
 
-export type { RecipeVariants } from './types';
+export type { RecipeVariants, RuntimeFn } from './types';
 
 function mapValues<Input extends Record<string, any>, OutputValue>(
   input: Input,

--- a/packages/recipes/src/index.ts
+++ b/packages/recipes/src/index.ts
@@ -10,7 +10,7 @@ import type {
   VariantSelection,
 } from './types';
 
-export type { RecipeVariants, RuntimeFn } from './types';
+export type { RecipeVariants, RuntimeFn, PatternOptions, VariantGroups } from './types';
 
 function mapValues<Input extends Record<string, any>, OutputValue>(
   input: Input,

--- a/packages/sprinkles/src/index.ts
+++ b/packages/sprinkles/src/index.ts
@@ -14,6 +14,7 @@ import {
 import { SprinklesProperties, ResponsiveArrayConfig } from './types';
 
 export { createNormalizeValueFn, createMapValueFn } from './createUtils';
+export type { SprinklesFn } from './createSprinkles';
 export type { ConditionalValue, RequiredConditionalValue } from './createUtils';
 
 export type { ResponsiveArray } from './types';


### PR DESCRIPTION
additional fixes for https://github.com/vanilla-extract-css/vanilla-extract/issues/739 similar to https://github.com/vanilla-extract-css/vanilla-extract/pull/890 which was missing a few types necessary for export