### PR TITLE
feat(recipes): export VariantDefinitions

### DIFF
--- a/packages/recipes/src/index.ts
+++ b/packages/recipes/src/index.ts
@@ -10,7 +10,7 @@ import type {
   VariantSelection,
 } from './types';
 
-export type { RecipeVariants, RuntimeFn } from './types';
+export type { RecipeVariants, RuntimeFn, VariantDefinitions } from './types';
 
 function mapValues<Input extends Record<string, any>, OutputValue>(
   input: Input,


### PR DESCRIPTION
Hi. I REALLY love vanilla-extract!
I wanted to use `VariantDefinitions` not being exported.
I can calculate it from the type of `recipe` but it's useful if exported.

Here's my use case.

```ts
// Button.css.ts
const size = {
  small: {
    height: "24px",
  },
  medium: {
    height: "32px",
  },
} as const satisfies VariantDefinitions;

export type Size = keyof typeof size;

export const button = recipe({
  base: {/* */},
  variants: {
    size
  }
})

// Button.tsx
import * as styles from './Button.css'

export const Button: React.FC<{ size: styles.Size }> = ({ size }) =>
  <button className={styles.button({ size })}>/* */</button>
```