### PR TITLE
docs: fix rollup configuration

### DIFF
--- a/site/docs/integrations/rollup.md
+++ b/site/docs/integrations/rollup.md
@@ -45,8 +45,10 @@ import { vanillaExtractPlugin } from '@vanilla-extract/rollup-plugin';
 export default {
   plugins: [vanillaExtractPlugin()],
   preserveModules: true,
-  assetFileNames({ name }) {
-    return name?.replace(/^src\//, '') ?? '';
+  output: {
+    assetFileNames({ name }) {
+      return name?.replace(/^src\//, '') ?? '';
+    }
   }
 };
 ```

--- a/site/docs/integrations/rollup.md
+++ b/site/docs/integrations/rollup.md
@@ -44,8 +44,8 @@ import { vanillaExtractPlugin } from '@vanilla-extract/rollup-plugin';
 
 export default {
   plugins: [vanillaExtractPlugin()],
-  preserveModules: true,
   output: {
+    preserveModules: true,
     assetFileNames({ name }) {
       return name?.replace(/^src\//, '') ?? '';
     }


### PR DESCRIPTION
- `assetFileNames` only exists inside `output`: https://rollupjs.org/configuration-options/#output-assetfilenames
- `preserveModules` exists in both top-level and in `output`, but the top-level one is deprecated: https://rollupjs.org/configuration-options/#output-preservemodules