### PR TITLE
vite: Add `emitCssInSsr` option

### DIFF
--- a/.changeset/shy-beers-pull.md
+++ b/.changeset/shy-beers-pull.md
@@ -1,0 +1,21 @@
+---
+'@vanilla-extract/vite-plugin': minor
+---
+
+Add `forceEmitCss` option
+
+Provides the ability to force the plugin to emit CSS for a particular build.
+
+```js
+// vite.config.js
+
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+
+export default {
+  plugins: [
+    vanillaExtractPlugin({
+      forceEmitCss: true
+    })
+  ]
+};
+```

--- a/.changeset/shy-beers-pull.md
+++ b/.changeset/shy-beers-pull.md
@@ -2,9 +2,9 @@
 '@vanilla-extract/vite-plugin': minor
 ---
 
-Add `forceEmitCss` option
+Add `emitCssInSsr` option
 
-Provides the ability to force the plugin to emit CSS for a particular build.
+Provides the ability to opt in to emitting CSS during SSR.
 
 ```js
 // vite.config.js
@@ -14,7 +14,7 @@ import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 export default {
   plugins: [
     vanillaExtractPlugin({
-      forceEmitCss: true
+      emitCssInSsr: true
     })
   ]
 };

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -22,12 +22,12 @@ const virtualExtJs = '.vanilla.js';
 
 interface Options {
   identifiers?: IdentifierOption;
-  forceEmitCss?: boolean;
+  emitCssInSsr?: boolean;
   esbuildOptions?: CompileOptions['esbuildOptions'];
 }
 export function vanillaExtractPlugin({
   identifiers,
-  forceEmitCss,
+  emitCssInSsr,
   esbuildOptions,
 }: Options = {}): Plugin {
   let config: ResolvedConfig;
@@ -35,9 +35,9 @@ export function vanillaExtractPlugin({
   let postCssConfig: PostCSSConfigResult | null;
   const cssMap = new Map<string, string>();
 
-  const hasEmitCssOverride = typeof forceEmitCss === 'boolean';
-  let resolvedEmitCss: boolean = hasEmitCssOverride
-    ? forceEmitCss
+  const hasEmitCssOverride = typeof emitCssInSsr === 'boolean';
+  let resolvedEmitCssInSsr: boolean = hasEmitCssOverride
+    ? emitCssInSsr
     : !!process.env.VITE_RSC_BUILD;
   let packageName: string;
 
@@ -84,7 +84,7 @@ export function vanillaExtractPlugin({
           ].includes(plugin.name),
         )
       ) {
-        resolvedEmitCss = true;
+        resolvedEmitCssInSsr = true;
       }
     },
     resolveId(source) {
@@ -159,7 +159,7 @@ export function vanillaExtractPlugin({
         ssr = ssrParam?.ssr;
       }
 
-      if (ssr && !resolvedEmitCss) {
+      if (ssr && !resolvedEmitCssInSsr) {
         return transform({
           source: code,
           filePath: normalizePath(validId),
@@ -190,7 +190,7 @@ export function vanillaExtractPlugin({
         identOption,
         serializeVirtualCssPath: async ({ fileScope, source }) => {
           const rootRelativeId = `${fileScope.filePath}${
-            config.command === 'build' || (ssr && resolvedEmitCss)
+            config.command === 'build' || (ssr && resolvedEmitCssInSsr)
               ? virtualExtCss
               : virtualExtJs
           }`;

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -22,10 +22,12 @@ const virtualExtJs = '.vanilla.js';
 
 interface Options {
   identifiers?: IdentifierOption;
+  forceEmitCss?: boolean;
   esbuildOptions?: CompileOptions['esbuildOptions'];
 }
 export function vanillaExtractPlugin({
   identifiers,
+  forceEmitCss,
   esbuildOptions,
 }: Options = {}): Plugin {
   let config: ResolvedConfig;
@@ -33,7 +35,10 @@ export function vanillaExtractPlugin({
   let postCssConfig: PostCSSConfigResult | null;
   const cssMap = new Map<string, string>();
 
-  let forceEmitCssInSsrBuild: boolean = !!process.env.VITE_RSC_BUILD;
+  const hasEmitCssOverride = typeof forceEmitCss === 'boolean';
+  let resolvedEmitCss: boolean = hasEmitCssOverride
+    ? forceEmitCss
+    : !!process.env.VITE_RSC_BUILD;
   let packageName: string;
 
   const getAbsoluteVirtualFileId = (source: string) =>
@@ -69,6 +74,7 @@ export function vanillaExtractPlugin({
       }
 
       if (
+        !hasEmitCssOverride &&
         config.plugins.some((plugin) =>
           [
             'astro:build',
@@ -78,7 +84,7 @@ export function vanillaExtractPlugin({
           ].includes(plugin.name),
         )
       ) {
-        forceEmitCssInSsrBuild = true;
+        resolvedEmitCss = true;
       }
     },
     resolveId(source) {
@@ -153,7 +159,7 @@ export function vanillaExtractPlugin({
         ssr = ssrParam?.ssr;
       }
 
-      if (ssr && !forceEmitCssInSsrBuild) {
+      if (ssr && !resolvedEmitCss) {
         return transform({
           source: code,
           filePath: normalizePath(validId),
@@ -184,7 +190,7 @@ export function vanillaExtractPlugin({
         identOption,
         serializeVirtualCssPath: async ({ fileScope, source }) => {
           const rootRelativeId = `${fileScope.filePath}${
-            config.command === 'build' || (ssr && forceEmitCssInSsrBuild)
+            config.command === 'build' || (ssr && resolvedEmitCss)
               ? virtualExtCss
               : virtualExtJs
           }`;

--- a/site/docs/integrations/vite.md
+++ b/site/docs/integrations/vite.md
@@ -53,3 +53,26 @@ Different formatting of identifiers (e.g. class names, keyframes, CSS Vars, etc)
 - `debug` identifiers contain human readable prefixes representing the owning filename and a potential rule level debug name. e.g. `myfile_mystyle_hnw5tz3`
 
 Each integration will set a default value based on the configuration options passed to the bundler.
+
+### forceEmitCss
+
+Historically, extracting CSS was a side effect of building the browser bundle, with the server or static build process only needing the JavaScript references. However, many frameworks are now moving the evaluation of CSS to be a server-side or compile-time responsibility.
+
+For the most common frameworks, Vanilla Extract will set this flag internally based on the plugins it discovers in the Vite configuration.
+This makes the plugin essentially zero config for the majority of consumers.
+
+For other cases, such as newer frameworks, it may be necessary to manually opt in to emitting CSS:
+
+```js
+// vite.config.js
+
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+
+export default {
+  plugins: [
+    vanillaExtractPlugin({
+      forceEmitCss: true
+    })
+  ]
+};
+```

--- a/site/docs/integrations/vite.md
+++ b/site/docs/integrations/vite.md
@@ -54,14 +54,14 @@ Different formatting of identifiers (e.g. class names, keyframes, CSS Vars, etc)
 
 Each integration will set a default value based on the configuration options passed to the bundler.
 
-### forceEmitCss
+### emitCssInSsr
 
 Historically, extracting CSS was a side effect of building the browser bundle, with the server or static build process only needing the JavaScript references. However, many frameworks are now moving the evaluation of CSS to be a server-side or compile-time responsibility.
 
-For the most common frameworks, Vanilla Extract will set this flag internally based on the plugins it discovers in the Vite configuration.
-This makes the plugin essentially zero config for the majority of consumers.
+For the most common frameworks, Vanilla Extract will set this flag internally based on the plugins it discovers in the consumers Vite configuration.
+This makes the plugin essentially zero config for the majority of cases.
 
-For other cases, such as newer frameworks, it may be necessary to manually opt in to emitting CSS:
+For other cases, such as newer frameworks, it may be necessary to manually opt in to emitting CSS during server side rendering:
 
 ```js
 // vite.config.js
@@ -71,7 +71,7 @@ import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 export default {
   plugins: [
     vanillaExtractPlugin({
-      forceEmitCss: true
+      emitCssInSsr: true
     })
   ]
 };


### PR DESCRIPTION
Provides the ability to opt in to emitting CSS during SSR.

```js
// vite.config.js
import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
export default {
  plugins: [
    vanillaExtractPlugin({
      emitCssInSsr: true
    })
  ]
};
```