### PR TITLE
Add transform wrapper method, use it for `@keyframes` rules

### DIFF
--- a/.changeset/empty-snakes-deny.md
+++ b/.changeset/empty-snakes-deny.md
@@ -2,4 +2,6 @@
 '@vanilla-extract/css': patch
 ---
 
-Fix generation of invalid CSS inside `@keyframes` rules by transforming `content` property values
+Align transformation of `@keyframes` rules with other rules
+
+This fixes a bug where invalid CSS could be generated inside `@keyframes` rules.

--- a/packages/css/src/transformCss.test.ts
+++ b/packages/css/src/transformCss.test.ts
@@ -1375,10 +1375,12 @@ describe('transformCss', () => {
               from: {
                 opacity: 0,
                 content: 'none',
+                padding: 0,
               },
               to: {
                 opacity: 1,
                 content: 'foo',
+                padding: 10,
               },
             },
           },
@@ -1389,10 +1391,12 @@ describe('transformCss', () => {
         from {
           content: none;
           opacity: 0;
+          padding: 0;
         }
         to {
           content: "foo";
           opacity: 1;
+          padding: 10px;
         }
       }"
     `);

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -148,7 +148,7 @@ class Stylesheet {
     if (root.type === 'keyframes') {
       root.rule = Object.fromEntries(
         Object.entries(root.rule).map(([keyframe, rule]) => {
-          return [keyframe, this.transformContent(rule)];
+          return [keyframe, this.transformProperties(rule)];
         }),
       );
       this.keyframesRules.push(root);
@@ -184,10 +184,8 @@ class Stylesheet {
   }
 
   addConditionalRule(cssRule: CSSRule, conditions: Array<string>) {
-    // Run `pixelifyProperties` before `transformVars` as we don't want to pixelify CSS Vars
-    const rule = this.transformVars(
-      this.transformContent(this.pixelifyProperties(cssRule.rule)),
-    );
+    // Run `normalizeProperties` before `transformVars` as we don't want to pixelify CSS Vars
+    const rule = this.transformVars(this.transformProperties(cssRule.rule));
     const selector = this.transformSelector(cssRule.selector);
 
     if (!this.currConditionalRuleset) {
@@ -208,16 +206,18 @@ class Stylesheet {
   }
 
   addRule(cssRule: CSSRule) {
-    // Run `pixelifyProperties` before `transformVars` as we don't want to pixelify CSS Vars
-    const rule = this.transformVars(
-      this.transformContent(this.pixelifyProperties(cssRule.rule)),
-    );
+    // Run `normalizeProperties` before `transformVars` as we don't want to pixelify CSS Vars
+    const rule = this.transformVars(this.transformProperties(cssRule.rule));
     const selector = this.transformSelector(cssRule.selector);
 
     this.rules.push({
       selector,
       rule,
     });
+  }
+
+  transformProperties(cssRule: CSSPropertiesWithVars) {
+    return this.transformContent(this.pixelifyProperties(cssRule));
   }
 
   pixelifyProperties(cssRule: CSSPropertiesWithVars) {

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -184,7 +184,7 @@ class Stylesheet {
   }
 
   addConditionalRule(cssRule: CSSRule, conditions: Array<string>) {
-    // Run `normalizeProperties` before `transformVars` as we don't want to pixelify CSS Vars
+    // Run `transformProperties` before `transformVars` as we don't want to pixelify CSS Vars
     const rule = this.transformVars(this.transformProperties(cssRule.rule));
     const selector = this.transformSelector(cssRule.selector);
 
@@ -206,7 +206,7 @@ class Stylesheet {
   }
 
   addRule(cssRule: CSSRule) {
-    // Run `normalizeProperties` before `transformVars` as we don't want to pixelify CSS Vars
+    // Run `transformProperties` before `transformVars` as we don't want to pixelify CSS Vars
     const rule = this.transformVars(this.transformProperties(cssRule.rule));
     const selector = this.transformSelector(cssRule.selector);
 


### PR DESCRIPTION
Adding a `transformProperties` method that wraps `transformContent` and `pixelifyProperties`. Applying this to `@keyframes` rules as well to make it consistent with the other rules (missed this in #990).