### PR TITLE
site: Add search

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,6 +393,7 @@ importers:
       mdx-loader: ^3.0.2
       mini-css-extract-plugin: ^1.5.1
       netlify-cli: ^11.8.3
+      null-loader: ^4.0.1
       outdent: ^0.8.0
       react: ^17.0.2
       react-dom: ^17.0.2
@@ -456,6 +457,7 @@ importers:
       mdx-loader: 3.0.2_react@17.0.2
       mini-css-extract-plugin: 1.6.2_webpack@5.64.2
       netlify-cli: 11.8.3
+      null-loader: 4.0.1_webpack@5.64.2
       remove-markdown: 0.3.0
       tailwindcss: 2.2.19
       webpack: 5.64.2_webpack-cli@4.9.1
@@ -5560,7 +5562,6 @@ packages:
 
   /@polka/url/1.0.0-next.21:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
-    dev: true
 
   /@preconstruct/cli/2.1.5:
     resolution: {integrity: sha512-bMnGTkaotxq+xoOkXoUOfTFvxBX/ZUxukcacf3mx3G7Iz5m/T4ZGzSOU12pxl64e+rVWGTKlUsgaDSgyFkup0A==}
@@ -6657,7 +6658,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       webpack: 5.64.2_webpack-cli@4.9.1
-      webpack-cli: 4.9.1_u5qztdvzsqoic44qnlo623kp4a
+      webpack-cli: 4.9.1_abnkovkv46tujkkuplf2x47yg4
 
   /@webpack-cli/info/1.4.0_webpack-cli@4.9.1:
     resolution: {integrity: sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==}
@@ -6665,7 +6666,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.9.1_u5qztdvzsqoic44qnlo623kp4a
+      webpack-cli: 4.9.1_abnkovkv46tujkkuplf2x47yg4
 
   /@webpack-cli/serve/1.6.0_4letf6knbpcm5x2zm2w2zfzpfy:
     resolution: {integrity: sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==}
@@ -6676,7 +6677,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.9.1_u5qztdvzsqoic44qnlo623kp4a
+      webpack-cli: 4.9.1_abnkovkv46tujkkuplf2x47yg4
       webpack-dev-server: 3.11.3_3gwf7nobdx7667zyja627dmgpi
 
   /@xtuc/ieee754/1.2.0:
@@ -9579,7 +9580,6 @@ packages:
 
   /duplexer/0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
-    dev: true
 
   /duplexer3/0.1.4:
     resolution: {integrity: sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==}
@@ -11245,7 +11245,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       duplexer: 0.1.2
-    dev: true
 
   /handle-thing/2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
@@ -15123,6 +15122,17 @@ packages:
       boolbase: 1.0.0
     dev: false
 
+  /null-loader/4.0.1_webpack@5.64.2:
+    resolution: {integrity: sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      webpack: ^4.0.0 || ^5.0.0
+    dependencies:
+      loader-utils: 2.0.2
+      schema-utils: 3.1.1
+      webpack: 5.64.2_webpack-cli@4.9.1
+    dev: true
+
   /nullthrows/1.1.1:
     resolution: {integrity: sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==}
     dev: false
@@ -15247,7 +15257,6 @@ packages:
   /opener/1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
-    dev: true
 
   /opn/5.5.0:
     resolution: {integrity: sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==}
@@ -17613,7 +17622,6 @@ packages:
       '@polka/url': 1.0.0-next.21
       mime: 2.6.0
       totalist: 1.1.0
-    dev: true
 
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -18484,6 +18492,31 @@ packages:
       webpack: 5.64.2_esbuild@0.16.17
     dev: false
 
+  /terser-webpack-plugin/5.2.5_acorn@8.8.1+webpack@5.64.2:
+    resolution: {integrity: sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      jest-worker: 27.3.1
+      schema-utils: 3.1.1
+      serialize-javascript: 6.0.0
+      source-map: 0.6.1
+      terser: 5.10.0_acorn@8.8.1
+      webpack: 5.64.2_webpack-cli@4.9.1
+    transitivePeerDependencies:
+      - acorn
+
   /terser-webpack-plugin/5.2.5_webpack@5.64.2:
     resolution: {integrity: sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==}
     engines: {node: '>= 10.13.0'}
@@ -18506,11 +18539,27 @@ packages:
       source-map: 0.6.1
       terser: 5.10.0
       webpack: 5.64.2_webpack-cli@4.9.1
+    dev: true
 
   /terser/5.10.0:
     resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
     engines: {node: '>=10'}
     hasBin: true
+    peerDependenciesMeta:
+      acorn:
+        optional: true
+    dependencies:
+      acorn: 8.8.1
+      commander: 2.20.3
+      source-map: 0.7.3
+      source-map-support: 0.5.21
+
+  /terser/5.10.0_acorn@8.8.1:
+    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    peerDependencies:
+      acorn: ^8.5.0
     peerDependenciesMeta:
       acorn:
         optional: true
@@ -18689,7 +18738,6 @@ packages:
   /totalist/1.1.0:
     resolution: {integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==}
     engines: {node: '>=6'}
-    dev: true
 
   /tough-cookie/4.1.2:
     resolution: {integrity: sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==}
@@ -19513,7 +19561,6 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
-    dev: true
 
   /webpack-cli/4.9.1_abnkovkv46tujkkuplf2x47yg4:
     resolution: {integrity: sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==}
@@ -19550,7 +19597,6 @@ packages:
       webpack-bundle-analyzer: 4.5.0
       webpack-dev-server: 3.11.3_3gwf7nobdx7667zyja627dmgpi
       webpack-merge: 5.8.0
-    dev: true
 
   /webpack-cli/4.9.1_u5qztdvzsqoic44qnlo623kp4a:
     resolution: {integrity: sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==}
@@ -19586,6 +19632,7 @@ packages:
       webpack: 5.64.2_webpack-cli@4.9.1
       webpack-dev-server: 3.11.3_3gwf7nobdx7667zyja627dmgpi
       webpack-merge: 5.8.0
+    dev: false
 
   /webpack-dev-middleware/3.7.3_webpack@5.64.2:
     resolution: {integrity: sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==}
@@ -19641,7 +19688,7 @@ packages:
       supports-color: 6.1.0
       url: 0.11.0
       webpack: 5.64.2_webpack-cli@4.9.1
-      webpack-cli: 4.9.1_u5qztdvzsqoic44qnlo623kp4a
+      webpack-cli: 4.9.1_abnkovkv46tujkkuplf2x47yg4
       webpack-dev-middleware: 3.7.3_webpack@5.64.2
       webpack-log: 2.0.0
       ws: 6.2.2
@@ -19839,9 +19886,9 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.2.5_webpack@5.64.2
+      terser-webpack-plugin: 5.2.5_acorn@8.8.1+webpack@5.64.2
       watchpack: 2.3.0
-      webpack-cli: 4.9.1_u5qztdvzsqoic44qnlo623kp4a
+      webpack-cli: 4.9.1_abnkovkv46tujkkuplf2x47yg4
       webpack-sources: 3.2.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -20086,7 +20133,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-    dev: true
 
   /ws/8.11.0:
     resolution: {integrity: sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,8 +360,8 @@ importers:
       '@babel/preset-react': ^7.18.6
       '@babel/preset-typescript': ^7.18.6
       '@capsizecss/vanilla-extract': ^1.0.0
-      '@docsearch/css': ^3.3.3
-      '@docsearch/react': ^3.3.3
+      '@docsearch/css': 3.3.3
+      '@docsearch/react': 3.3.3
       '@mdx-js/react': ^1.6.22
       '@types/classnames': ^2.2.11
       '@types/lodash': ^4.14.168
@@ -5562,6 +5562,7 @@ packages:
 
   /@polka/url/1.0.0-next.21:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
+    dev: true
 
   /@preconstruct/cli/2.1.5:
     resolution: {integrity: sha512-bMnGTkaotxq+xoOkXoUOfTFvxBX/ZUxukcacf3mx3G7Iz5m/T4ZGzSOU12pxl64e+rVWGTKlUsgaDSgyFkup0A==}
@@ -6658,7 +6659,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       webpack: 5.64.2_webpack-cli@4.9.1
-      webpack-cli: 4.9.1_abnkovkv46tujkkuplf2x47yg4
+      webpack-cli: 4.9.1_u5qztdvzsqoic44qnlo623kp4a
 
   /@webpack-cli/info/1.4.0_webpack-cli@4.9.1:
     resolution: {integrity: sha512-F6b+Man0rwE4n0409FyAJHStYA5OIZERxmnUfLVwv0mc0V1wLad3V7jqRlMkgKBeAq07jUvglacNaa6g9lOpuw==}
@@ -6666,7 +6667,7 @@ packages:
       webpack-cli: 4.x.x
     dependencies:
       envinfo: 7.8.1
-      webpack-cli: 4.9.1_abnkovkv46tujkkuplf2x47yg4
+      webpack-cli: 4.9.1_u5qztdvzsqoic44qnlo623kp4a
 
   /@webpack-cli/serve/1.6.0_4letf6knbpcm5x2zm2w2zfzpfy:
     resolution: {integrity: sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==}
@@ -6677,7 +6678,7 @@ packages:
       webpack-dev-server:
         optional: true
     dependencies:
-      webpack-cli: 4.9.1_abnkovkv46tujkkuplf2x47yg4
+      webpack-cli: 4.9.1_u5qztdvzsqoic44qnlo623kp4a
       webpack-dev-server: 3.11.3_3gwf7nobdx7667zyja627dmgpi
 
   /@xtuc/ieee754/1.2.0:
@@ -9580,6 +9581,7 @@ packages:
 
   /duplexer/0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
+    dev: true
 
   /duplexer3/0.1.4:
     resolution: {integrity: sha512-CEj8FwwNA4cVH2uFCoHUrmojhYh1vmCdOaneKJXwkeY1i9jnlslVo9dx+hQ5Hl9GnH/Bwy/IjxAyOePyPKYnzA==}
@@ -11245,6 +11247,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       duplexer: 0.1.2
+    dev: true
 
   /handle-thing/2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
@@ -15257,6 +15260,7 @@ packages:
   /opener/1.5.2:
     resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
+    dev: true
 
   /opn/5.5.0:
     resolution: {integrity: sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==}
@@ -17622,6 +17626,7 @@ packages:
       '@polka/url': 1.0.0-next.21
       mime: 2.6.0
       totalist: 1.1.0
+    dev: true
 
   /sisteransi/1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -18492,31 +18497,6 @@ packages:
       webpack: 5.64.2_esbuild@0.16.17
     dev: false
 
-  /terser-webpack-plugin/5.2.5_acorn@8.8.1+webpack@5.64.2:
-    resolution: {integrity: sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      jest-worker: 27.3.1
-      schema-utils: 3.1.1
-      serialize-javascript: 6.0.0
-      source-map: 0.6.1
-      terser: 5.10.0_acorn@8.8.1
-      webpack: 5.64.2_webpack-cli@4.9.1
-    transitivePeerDependencies:
-      - acorn
-
   /terser-webpack-plugin/5.2.5_webpack@5.64.2:
     resolution: {integrity: sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==}
     engines: {node: '>= 10.13.0'}
@@ -18539,27 +18519,11 @@ packages:
       source-map: 0.6.1
       terser: 5.10.0
       webpack: 5.64.2_webpack-cli@4.9.1
-    dev: true
 
   /terser/5.10.0:
     resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
     engines: {node: '>=10'}
     hasBin: true
-    peerDependenciesMeta:
-      acorn:
-        optional: true
-    dependencies:
-      acorn: 8.8.1
-      commander: 2.20.3
-      source-map: 0.7.3
-      source-map-support: 0.5.21
-
-  /terser/5.10.0_acorn@8.8.1:
-    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    peerDependencies:
-      acorn: ^8.5.0
     peerDependenciesMeta:
       acorn:
         optional: true
@@ -18738,6 +18702,7 @@ packages:
   /totalist/1.1.0:
     resolution: {integrity: sha512-gduQwd1rOdDMGxFG1gEvhV88Oirdo2p+KjoYFU7k2g+i7n6AFFbDQ5kMPUsW0pNbfQsB/cwXvT1i4Bue0s9g5g==}
     engines: {node: '>=6'}
+    dev: true
 
   /tough-cookie/4.1.2:
     resolution: {integrity: sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==}
@@ -19561,6 +19526,7 @@ packages:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    dev: true
 
   /webpack-cli/4.9.1_abnkovkv46tujkkuplf2x47yg4:
     resolution: {integrity: sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==}
@@ -19597,6 +19563,7 @@ packages:
       webpack-bundle-analyzer: 4.5.0
       webpack-dev-server: 3.11.3_3gwf7nobdx7667zyja627dmgpi
       webpack-merge: 5.8.0
+    dev: true
 
   /webpack-cli/4.9.1_u5qztdvzsqoic44qnlo623kp4a:
     resolution: {integrity: sha512-JYRFVuyFpzDxMDB+v/nanUdQYcZtqFPGzmlW4s+UkPMFhSpfRNmf1z4AwYcHJVdvEFAM7FFCQdNTpsBYhDLusQ==}
@@ -19632,7 +19599,6 @@ packages:
       webpack: 5.64.2_webpack-cli@4.9.1
       webpack-dev-server: 3.11.3_3gwf7nobdx7667zyja627dmgpi
       webpack-merge: 5.8.0
-    dev: false
 
   /webpack-dev-middleware/3.7.3_webpack@5.64.2:
     resolution: {integrity: sha512-djelc/zGiz9nZj/U7PTBi2ViorGJXEWo/3ltkPbDyxCXhhEXkW0ce99falaok4TPj+AsxLiXJR0EBOb0zh9fKQ==}
@@ -19688,7 +19654,7 @@ packages:
       supports-color: 6.1.0
       url: 0.11.0
       webpack: 5.64.2_webpack-cli@4.9.1
-      webpack-cli: 4.9.1_abnkovkv46tujkkuplf2x47yg4
+      webpack-cli: 4.9.1_u5qztdvzsqoic44qnlo623kp4a
       webpack-dev-middleware: 3.7.3_webpack@5.64.2
       webpack-log: 2.0.0
       ws: 6.2.2
@@ -19886,9 +19852,9 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.2.5_acorn@8.8.1+webpack@5.64.2
+      terser-webpack-plugin: 5.2.5_webpack@5.64.2
       watchpack: 2.3.0
-      webpack-cli: 4.9.1_abnkovkv46tujkkuplf2x47yg4
+      webpack-cli: 4.9.1_u5qztdvzsqoic44qnlo623kp4a
       webpack-sources: 3.2.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -20133,6 +20099,7 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+    dev: true
 
   /ws/8.11.0:
     resolution: {integrity: sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,8 @@ importers:
       '@babel/preset-react': ^7.18.6
       '@babel/preset-typescript': ^7.18.6
       '@capsizecss/vanilla-extract': ^1.0.0
+      '@docsearch/css': ^3.3.3
+      '@docsearch/react': ^3.3.3
       '@mdx-js/react': ^1.6.22
       '@types/classnames': ^2.2.11
       '@types/lodash': ^4.14.168
@@ -408,8 +410,10 @@ importers:
       webpack-node-externals: ^2.5.2
     dependencies:
       '@capsizecss/vanilla-extract': 1.0.0_z4nlwckr6vbkdmyzyua37pn2wu
+      '@docsearch/css': 3.3.3
+      '@docsearch/react': 3.3.3_lf6lsbfzzgwerpwle65mpjwjim
       '@mdx-js/react': 1.6.22_react@17.0.2
-      classnames: 2.3.1
+      classnames: 2.3.2
       lodash: 4.17.21
       outdent: 0.8.0
       react: 17.0.2
@@ -558,6 +562,116 @@ importers:
       '@vanilla-extract/sprinkles': link:../packages/sprinkles
 
 packages:
+
+  /@algolia/autocomplete-core/1.7.4:
+    resolution: {integrity: sha512-daoLpQ3ps/VTMRZDEBfU8ixXd+amZcNJ4QSP3IERGyzqnL5Ch8uSRFt/4G8pUvW9c3o6GA4vtVv4I4lmnkdXyg==}
+    dependencies:
+      '@algolia/autocomplete-shared': 1.7.4
+    dev: false
+
+  /@algolia/autocomplete-preset-algolia/1.7.4_algoliasearch@4.14.3:
+    resolution: {integrity: sha512-s37hrvLEIfcmKY8VU9LsAXgm2yfmkdHT3DnA3SgHaY93yjZ2qL57wzb5QweVkYuEBZkT2PIREvRoLXC2sxTbpQ==}
+    peerDependencies:
+      '@algolia/client-search': '>= 4.9.1 < 6'
+      algoliasearch: '>= 4.9.1 < 6'
+    dependencies:
+      '@algolia/autocomplete-shared': 1.7.4
+      algoliasearch: 4.14.3
+    dev: false
+
+  /@algolia/autocomplete-shared/1.7.4:
+    resolution: {integrity: sha512-2VGCk7I9tA9Ge73Km99+Qg87w0wzW4tgUruvWAn/gfey1ZXgmxZtyIRBebk35R1O8TbK77wujVtCnpsGpRy1kg==}
+    dev: false
+
+  /@algolia/cache-browser-local-storage/4.14.3:
+    resolution: {integrity: sha512-hWH1yCxgG3+R/xZIscmUrWAIBnmBFHH5j30fY/+aPkEZWt90wYILfAHIOZ1/Wxhho5SkPfwFmT7ooX2d9JeQBw==}
+    dependencies:
+      '@algolia/cache-common': 4.14.3
+    dev: false
+
+  /@algolia/cache-common/4.14.3:
+    resolution: {integrity: sha512-oZJofOoD9FQOwiGTzyRnmzvh3ZP8WVTNPBLH5xU5JNF7drDbRT0ocVT0h/xB2rPHYzOeXRrLaQQBwRT/CKom0Q==}
+    dev: false
+
+  /@algolia/cache-in-memory/4.14.3:
+    resolution: {integrity: sha512-ES0hHQnzWjeioLQf5Nq+x1AWdZJ50znNPSH3puB/Y4Xsg4Av1bvLmTJe7SY2uqONaeMTvL0OaVcoVtQgJVw0vg==}
+    dependencies:
+      '@algolia/cache-common': 4.14.3
+    dev: false
+
+  /@algolia/client-account/4.14.3:
+    resolution: {integrity: sha512-PBcPb0+f5Xbh5UfLZNx2Ow589OdP8WYjB4CnvupfYBrl9JyC1sdH4jcq/ri8osO/mCZYjZrQsKAPIqW/gQmizQ==}
+    dependencies:
+      '@algolia/client-common': 4.14.3
+      '@algolia/client-search': 4.14.3
+      '@algolia/transporter': 4.14.3
+    dev: false
+
+  /@algolia/client-analytics/4.14.3:
+    resolution: {integrity: sha512-eAwQq0Hb/aauv9NhCH5Dp3Nm29oFx28sayFN2fdOWemwSeJHIl7TmcsxVlRsO50fsD8CtPcDhtGeD3AIFLNvqw==}
+    dependencies:
+      '@algolia/client-common': 4.14.3
+      '@algolia/client-search': 4.14.3
+      '@algolia/requester-common': 4.14.3
+      '@algolia/transporter': 4.14.3
+    dev: false
+
+  /@algolia/client-common/4.14.3:
+    resolution: {integrity: sha512-jkPPDZdi63IK64Yg4WccdCsAP4pHxSkr4usplkUZM5C1l1oEpZXsy2c579LQ0rvwCs5JFmwfNG4ahOszidfWPw==}
+    dependencies:
+      '@algolia/requester-common': 4.14.3
+      '@algolia/transporter': 4.14.3
+    dev: false
+
+  /@algolia/client-personalization/4.14.3:
+    resolution: {integrity: sha512-UCX1MtkVNgaOL9f0e22x6tC9e2H3unZQlSUdnVaSKpZ+hdSChXGaRjp2UIT7pxmPqNCyv51F597KEX5WT60jNg==}
+    dependencies:
+      '@algolia/client-common': 4.14.3
+      '@algolia/requester-common': 4.14.3
+      '@algolia/transporter': 4.14.3
+    dev: false
+
+  /@algolia/client-search/4.14.3:
+    resolution: {integrity: sha512-I2U7xBx5OPFdPLA8AXKUPPxGY3HDxZ4r7+mlZ8ZpLbI8/ri6fnu6B4z3wcL7sgHhDYMwnAE8Xr0AB0h3Hnkp4A==}
+    dependencies:
+      '@algolia/client-common': 4.14.3
+      '@algolia/requester-common': 4.14.3
+      '@algolia/transporter': 4.14.3
+    dev: false
+
+  /@algolia/logger-common/4.14.3:
+    resolution: {integrity: sha512-kUEAZaBt/J3RjYi8MEBT2QEexJR2kAE2mtLmezsmqMQZTV502TkHCxYzTwY2dE7OKcUTxi4OFlMuS4GId9CWPw==}
+    dev: false
+
+  /@algolia/logger-console/4.14.3:
+    resolution: {integrity: sha512-ZWqAlUITktiMN2EiFpQIFCJS10N96A++yrexqC2Z+3hgF/JcKrOxOdT4nSCQoEPvU4Ki9QKbpzbebRDemZt/hw==}
+    dependencies:
+      '@algolia/logger-common': 4.14.3
+    dev: false
+
+  /@algolia/requester-browser-xhr/4.14.3:
+    resolution: {integrity: sha512-AZeg2T08WLUPvDncl2XLX2O67W5wIO8MNaT7z5ii5LgBTuk/rU4CikTjCe2xsUleIZeFl++QrPAi4Bdxws6r/Q==}
+    dependencies:
+      '@algolia/requester-common': 4.14.3
+    dev: false
+
+  /@algolia/requester-common/4.14.3:
+    resolution: {integrity: sha512-RrRzqNyKFDP7IkTuV3XvYGF9cDPn9h6qEDl595lXva3YUk9YSS8+MGZnnkOMHvjkrSCKfoLeLbm/T4tmoIeclw==}
+    dev: false
+
+  /@algolia/requester-node-http/4.14.3:
+    resolution: {integrity: sha512-O5wnPxtDRPuW2U0EaOz9rMMWdlhwP0J0eSL1Z7TtXF8xnUeeUyNJrdhV5uy2CAp6RbhM1VuC3sOJcIR6Av+vbA==}
+    dependencies:
+      '@algolia/requester-common': 4.14.3
+    dev: false
+
+  /@algolia/transporter/4.14.3:
+    resolution: {integrity: sha512-2qlKlKsnGJ008exFRb5RTeTOqhLZj0bkMCMVskxoqWejs2Q2QtWmsiH98hDfpw0fmnyhzHEt0Z7lqxBYp8bW2w==}
+    dependencies:
+      '@algolia/cache-common': 4.14.3
+      '@algolia/logger-common': 4.14.3
+      '@algolia/requester-common': 4.14.3
+    dev: false
 
   /@ampproject/remapping/2.2.0:
     resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
@@ -3012,6 +3126,35 @@ packages:
   /@discoveryjs/json-ext/0.5.5:
     resolution: {integrity: sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==}
     engines: {node: '>=10.0.0'}
+
+  /@docsearch/css/3.3.3:
+    resolution: {integrity: sha512-6SCwI7P8ao+se1TUsdZ7B4XzL+gqeQZnBc+2EONZlcVa0dVrk0NjETxozFKgMv0eEGH8QzP1fkN+A1rH61l4eg==}
+    dev: false
+
+  /@docsearch/react/3.3.3_lf6lsbfzzgwerpwle65mpjwjim:
+    resolution: {integrity: sha512-pLa0cxnl+G0FuIDuYlW+EBK6Rw2jwLw9B1RHIeS4N4s2VhsfJ/wzeCi3CWcs5yVfxLd5ZK50t//TMA5e79YT7Q==}
+    peerDependencies:
+      '@types/react': '>= 16.8.0 < 19.0.0'
+      react: '>= 16.8.0 < 19.0.0'
+      react-dom: '>= 16.8.0 < 19.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@algolia/autocomplete-core': 1.7.4
+      '@algolia/autocomplete-preset-algolia': 1.7.4_algoliasearch@4.14.3
+      '@docsearch/css': 3.3.3
+      '@types/react': 17.0.36
+      algoliasearch: 4.14.3
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+    transitivePeerDependencies:
+      - '@algolia/client-search'
+    dev: false
 
   /@emotion/hash/0.9.0:
     resolution: {integrity: sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==}
@@ -5913,7 +6056,7 @@ packages:
     resolution: {integrity: sha512-zeOWb0JGBoVmlQoznvqXbE0tEC/HONsnoUNH19Hc96NFsTAwTXbTqb8FMYkru1F/iqp7a18Ws3nWJvtA1sHD1A==}
     deprecated: This is a stub types definition. classnames provides its own type definitions, so you do not need this installed.
     dependencies:
-      classnames: 2.3.1
+      classnames: 2.3.2
     dev: true
 
   /@types/connect-history-api-fallback/1.3.5:
@@ -6141,7 +6284,6 @@ packages:
 
   /@types/prop-types/15.7.4:
     resolution: {integrity: sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==}
-    dev: true
 
   /@types/qs/6.9.7:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==}
@@ -6185,7 +6327,6 @@ packages:
       '@types/prop-types': 15.7.4
       '@types/scheduler': 0.16.2
       csstype: 3.0.10
-    dev: true
 
   /@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
@@ -6204,7 +6345,6 @@ packages:
 
   /@types/scheduler/0.16.2:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
-    dev: true
 
   /@types/semver/6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
@@ -6683,6 +6823,25 @@ packages:
       require-from-string: 2.0.2
       uri-js: 4.4.1
     dev: true
+
+  /algoliasearch/4.14.3:
+    resolution: {integrity: sha512-GZTEuxzfWbP/vr7ZJfGzIl8fOsoxN916Z6FY2Egc9q2TmZ6hvq5KfAxY89pPW01oW/2HDEKA8d30f9iAH9eXYg==}
+    dependencies:
+      '@algolia/cache-browser-local-storage': 4.14.3
+      '@algolia/cache-common': 4.14.3
+      '@algolia/cache-in-memory': 4.14.3
+      '@algolia/client-account': 4.14.3
+      '@algolia/client-analytics': 4.14.3
+      '@algolia/client-common': 4.14.3
+      '@algolia/client-personalization': 4.14.3
+      '@algolia/client-search': 4.14.3
+      '@algolia/logger-common': 4.14.3
+      '@algolia/logger-console': 4.14.3
+      '@algolia/requester-browser-xhr': 4.14.3
+      '@algolia/requester-common': 4.14.3
+      '@algolia/requester-node-http': 4.14.3
+      '@algolia/transporter': 4.14.3
+    dev: false
 
   /all-node-versions/8.0.0:
     resolution: {integrity: sha512-cF8ibgj23U7ai4qjSFzpeccwDXUlPFMzKe0Z6qf6gChR+9S0JMyzYz6oYz4n0nHi/FLH9BJIefsONsMH/WDM2w==}
@@ -7972,8 +8131,8 @@ packages:
   /classnames/2.2.6:
     resolution: {integrity: sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==}
 
-  /classnames/2.3.1:
-    resolution: {integrity: sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==}
+  /classnames/2.3.2:
+    resolution: {integrity: sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==}
 
   /clean-css/5.2.2:
     resolution: {integrity: sha512-/eR8ru5zyxKzpBLv9YZvMXgTSSQn7AdkMItMYynsFgGwTveCRVam9IUPFloE85B4vAIj05IuKmmEoV7/AQjT0w==}
@@ -14304,6 +14463,7 @@ packages:
 
   /nan/2.15.0:
     resolution: {integrity: sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==}
+    requiresBuild: true
     optional: true
 
   /nanoid/3.3.4:
@@ -16329,7 +16489,7 @@ packages:
       once: 1.4.0
 
   /punycode/1.3.2:
-    resolution: {integrity: sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=}
+    resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
 
   /punycode/1.4.1:
     resolution: {integrity: sha1-wNWmOycYgArY4esPpSachN1BhF4=}
@@ -18345,7 +18505,7 @@ packages:
       serialize-javascript: 6.0.0
       source-map: 0.6.1
       terser: 5.10.0
-      webpack: 5.64.2
+      webpack: 5.64.2_webpack-cli@4.9.1
 
   /terser/5.10.0:
     resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
@@ -19606,6 +19766,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /webpack/5.64.2_esbuild@0.16.17:
     resolution: {integrity: sha512-4KGc0+Ozi0aS3EaLNRvEppfZUer+CaORKqL6OBjDLZOPf9YfN8leagFzwe6/PoBdHFxc/utKArl8LMC0Ivtmdg==}

--- a/site/package.json
+++ b/site/package.json
@@ -10,6 +10,8 @@
   },
   "dependencies": {
     "@capsizecss/vanilla-extract": "^1.0.0",
+    "@docsearch/css": "^3.3.3",
+    "@docsearch/react": "^3.3.3",
     "@mdx-js/react": "^1.6.22",
     "classnames": "^2.2.6",
     "lodash": "^4.17.21",

--- a/site/package.json
+++ b/site/package.json
@@ -57,6 +57,7 @@
     "mdx-loader": "^3.0.2",
     "mini-css-extract-plugin": "^1.5.1",
     "netlify-cli": "^11.8.3",
+    "null-loader": "^4.0.1",
     "remove-markdown": "^0.3.0",
     "tailwindcss": "^2.1.2",
     "webpack": "^5.36.1",

--- a/site/package.json
+++ b/site/package.json
@@ -10,8 +10,8 @@
   },
   "dependencies": {
     "@capsizecss/vanilla-extract": "^1.0.0",
-    "@docsearch/css": "^3.3.3",
-    "@docsearch/react": "^3.3.3",
+    "@docsearch/css": "3.3.3",
+    "@docsearch/react": "3.3.3",
     "@mdx-js/react": "^1.6.22",
     "classnames": "^2.2.6",
     "lodash": "^4.17.21",

--- a/site/src/DocsPage/DocsPage.tsx
+++ b/site/src/DocsPage/DocsPage.tsx
@@ -20,6 +20,7 @@ import Link from '../Typography/Link';
 import Text from '../Typography/Text';
 
 import mapKeys from 'lodash/mapKeys';
+import { SearchInput } from '../SearchInput/SearchInput';
 
 interface DocsRouteProps {
   component: (props: any) => JSX.Element;
@@ -414,7 +415,10 @@ export const DocsPage = ({ location }: RouteChildrenProps) => {
 
       <Box zIndex={1} position="fixed" top={0} right={0} padding="large">
         <Box display={{ mobile: 'none', desktop: 'block' }}>
-          <ColorModeToggle />
+          <Box display="flex" alignItems="center">
+            <SearchInput />
+            <ColorModeToggle />
+          </Box>
         </Box>
         <Box display={{ desktop: 'none' }}>
           <Fab open={menuOpen} onClick={toggleMenu} />

--- a/site/src/DocsPage/DocsPage.tsx
+++ b/site/src/DocsPage/DocsPage.tsx
@@ -414,11 +414,9 @@ export const DocsPage = ({ location }: RouteChildrenProps) => {
       <SecondaryNav onClick={closeMenu} pathname={normalisedPath} />
 
       <Box zIndex={1} position="fixed" top={0} right={0} padding="large">
-        <Box display={{ mobile: 'none', desktop: 'block' }}>
-          <Box display="flex" alignItems="center">
-            <SearchInput />
-            <ColorModeToggle />
-          </Box>
+        <Box display={{ mobile: 'none', desktop: 'flex' }} alignItems="center">
+          <SearchInput />
+          <ColorModeToggle />
         </Box>
         <Box display={{ desktop: 'none' }}>
           <Fab open={menuOpen} onClick={toggleMenu} />

--- a/site/src/DocsPage/DocsPage.tsx
+++ b/site/src/DocsPage/DocsPage.tsx
@@ -415,7 +415,9 @@ export const DocsPage = ({ location }: RouteChildrenProps) => {
 
       <Box zIndex={1} position="fixed" top={0} right={0} padding="large">
         <Box display={{ mobile: 'none', desktop: 'flex' }} alignItems="center">
-          <SearchInput />
+          <Box paddingRight="medium">
+            <SearchInput />
+          </Box>
           <ColorModeToggle />
         </Box>
         <Box
@@ -423,7 +425,7 @@ export const DocsPage = ({ location }: RouteChildrenProps) => {
           alignItems="center"
           justifyContent="space-between"
         >
-          <Box display={menuOpen ? 'none' : undefined}>
+          <Box display={menuOpen ? 'none' : undefined} paddingRight="medium">
             <SearchInput />
           </Box>
           <Fab open={menuOpen} onClick={toggleMenu} />

--- a/site/src/DocsPage/DocsPage.tsx
+++ b/site/src/DocsPage/DocsPage.tsx
@@ -418,7 +418,14 @@ export const DocsPage = ({ location }: RouteChildrenProps) => {
           <SearchInput />
           <ColorModeToggle />
         </Box>
-        <Box display={{ desktop: 'none' }}>
+        <Box
+          display={{ mobile: 'flex', desktop: 'none' }}
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          <Box display={menuOpen ? 'none' : undefined}>
+            <SearchInput />
+          </Box>
           <Fab open={menuOpen} onClick={toggleMenu} />
         </Box>
       </Box>

--- a/site/src/Fab/Fab.css.ts
+++ b/site/src/Fab/Fab.css.ts
@@ -10,7 +10,7 @@ export const fab = style({
   height: fabSize,
   width: fabSize,
   zIndex: 3,
-  boxShadow: `0px 0px 0px 5px ${fallbackVar(focusColorVar, 'transparent')}`,
+  boxShadow: `0px 0px 0px 3px ${fallbackVar(focusColorVar, 'transparent')}`,
   WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
   ':focus-visible': {
     vars: {

--- a/site/src/HomePage/HomePage.css.ts
+++ b/site/src/HomePage/HomePage.css.ts
@@ -1,17 +1,11 @@
 import { createVar, style } from '@vanilla-extract/css';
-import { darkMode } from '../system/styles/sprinkles.css';
 import { vars } from '../themes.css';
 import { responsiveStyle } from '../themeUtils';
 
-export const shadowColorVar = createVar();
+// Used for overridding search box background
+export const homePage = style({});
 
-export const installBlock = style({
-  selectors: {
-    [`:not(.${darkMode}) &`]: {
-      filter: 'saturate(0.6)',
-    },
-  },
-});
+export const shadowColorVar = createVar();
 
 export const featureKeyLine = style({
   transform: 'skew(15deg)',

--- a/site/src/HomePage/HomePage.tsx
+++ b/site/src/HomePage/HomePage.tsx
@@ -13,6 +13,7 @@ import { GitHubStars } from '../GitHubStars/GitHubStars';
 import { CompiledCode } from '../Code/CompiledCode';
 import { ErrorHighlighter } from '../Code/ErrorHighlighter';
 import * as styles from './HomePage.css';
+import { SearchInput } from '../SearchInput/SearchInput';
 
 const InstallPrompt = () => {
   return (
@@ -98,12 +99,14 @@ export const HomePage = () => {
             <Box
               display="flex"
               justifyContent="flex-end"
+              alignItems="center"
               paddingBottom={{
                 mobile: 'large',
                 tablet: 'none',
                 desktop: 'xxlarge',
               }}
             >
+              <SearchInput />
               <ColorModeToggle />
             </Box>
             <Box>

--- a/site/src/HomePage/HomePage.tsx
+++ b/site/src/HomePage/HomePage.tsx
@@ -25,10 +25,9 @@ const InstallPrompt = () => {
       borderRadius="small"
       padding="large"
       background={{
-        lightMode: 'teal200',
+        lightMode: 'teal200muted',
         darkMode: 'gray800',
       }}
-      className={styles.installBlock}
     >
       <Box display={{ mobile: 'none', tablet: 'block' }}>
         <Text type="code" size="small" color="secondary">
@@ -47,7 +46,7 @@ const InstallPrompt = () => {
 
 export const HomePage = () => {
   return (
-    <>
+    <Box className={styles.homePage}>
       {/* <Box
         margin="large"
         paddingY="xxxlarge"
@@ -106,7 +105,9 @@ export const HomePage = () => {
                 desktop: 'xxlarge',
               }}
             >
-              <SearchInput />
+              <Box paddingRight="xsmall">
+                <SearchInput />
+              </Box>
               <ColorModeToggle />
             </Box>
             <Box>
@@ -725,7 +726,7 @@ export const HomePage = () => {
           </Box>
         </ContentBlock>
       </Stack>
-    </>
+    </Box>
   );
 };
 

--- a/site/src/SearchInput/SearchInput.css.ts
+++ b/site/src/SearchInput/SearchInput.css.ts
@@ -1,22 +1,23 @@
 import { globalStyle } from '@vanilla-extract/css';
+import { darkMode } from '../system/styles/sprinkles.css';
 import { vars } from '../themes.css';
 
 globalStyle('.DocSearch', {
+  fontFamily: vars.fonts.body,
+});
+
+globalStyle(`.${darkMode} .DocSearch`, {
   vars: {
-    '--docsearch-primary-color': vars.palette.pink500,
-    '--docsearch-highlight-color': vars.palette.pink500,
     '--docsearch-text-color': vars.palette.white,
     '--docsearch-searchbox-focus-background': vars.palette.gray800,
     '--docsearch-searchbox-background': vars.palette.gray800,
     '--docsearch-modal-background': vars.palette.gray800,
-    '--docsearch-modal-shadow': `inset 1px 1px 0 0 hsla(0, 0%, 0%, 0.5), 0 3px 8px 0 ${vars.palette.blueGray800}`,
+    '--docsearch-modal-shadow': `inset 1px 1px 0 0 hsla(0, 0%, 0%, 0.5), 0 3px 8px 0 ${vars.palette.gray800}`,
     '--docsearch-footer-background': vars.palette.gray800,
-    '--docsearch-muted-color': vars.palette.gray400,
+    '--docsearch-footer-shadow': `0 -1px 0 0 ${vars.palette.gray800}, 0 -3px 6px 0 ${vars.palette.gray700}`,
+    '--docsearch-muted-color': vars.palette.gray500,
     '--docsearch-hit-color': vars.palette.white,
     '--docsearch-hit-background': vars.palette.gray900,
-    '--docsearch-key-gradient': `linear-gradient(-225deg, ${vars.palette.gray500}, ${vars.palette.gray900})`,
-    '--docsearch-key-shadow': `inset 0 -2px 0 0 ${vars.palette.gray700}, inset 0 0 1px 1px ${vars.palette.black}, 0 1px 2px 1px ${vars.palette.gray700}`,
-    '--foo-bar': '#f00',
+    '--docsearch-hit-shadow': 'none',
   },
-  fontFamily: vars.fonts.body,
 });

--- a/site/src/SearchInput/SearchInput.css.ts
+++ b/site/src/SearchInput/SearchInput.css.ts
@@ -1,9 +1,13 @@
-import { globalStyle } from '@vanilla-extract/css';
+import { createVar, fallbackVar, globalStyle } from '@vanilla-extract/css';
 import { darkMode } from '../system/styles/sprinkles.css';
 import { vars } from '../themes.css';
 
+const searchInputMinSize = 44;
+
 globalStyle('.DocSearch', {
   fontFamily: vars.fonts.body,
+  minHeight: searchInputMinSize,
+  minWidth: searchInputMinSize,
 });
 
 globalStyle(`.${darkMode} .DocSearch`, {
@@ -20,4 +24,59 @@ globalStyle(`.${darkMode} .DocSearch`, {
     '--docsearch-hit-background': vars.palette.gray900,
     '--docsearch-hit-shadow': 'none',
   },
+});
+
+const docsearchButton = `.DocSearch.DocSearch-Button`;
+const focusColorVar = createVar();
+
+globalStyle(docsearchButton, {
+  boxShadow: `0 4px 8px rgba(14, 14, 33, 0.2), 0px 0px 0px 3px ${fallbackVar(
+    focusColorVar,
+    'transparent',
+  )}`,
+  WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
+  justifyContent: 'space-around',
+});
+
+globalStyle(`${docsearchButton}:focus-visible`, {
+  vars: {
+    [focusColorVar]: vars.palette.pink300,
+  },
+});
+
+globalStyle(`.${darkMode} ${docsearchButton}:focus-visible`, {
+  vars: {
+    [focusColorVar]: vars.palette.pink600,
+  },
+});
+
+const pseudos = [':hover', ':active'];
+const docsearchButtonAndPseudos = [
+  docsearchButton,
+  ...pseudos.map((pseudo) => `${docsearchButton}${pseudo}`),
+];
+
+globalStyle(docsearchButtonAndPseudos.join(','), {
+  vars: {
+    '--docsearch-searchbox-background': vars.palette.white,
+    '--docsearch-searchbox-focus-background': vars.palette.white,
+    '--docsearch-text-color': vars.palette.coolGray900,
+  },
+});
+
+globalStyle(
+  docsearchButtonAndPseudos
+    .map((className) => `.${darkMode} ${className}`)
+    .join(','),
+  {
+    vars: {
+      '--docsearch-searchbox-background': vars.palette.gray300,
+      '--docsearch-searchbox-focus-background': vars.palette.gray300,
+      '--docsearch-text-color': vars.palette.gray800,
+    },
+  },
+);
+
+globalStyle('.DocSearch .DocSearch-Search-Icon', {
+  strokeWidth: 3.0,
 });

--- a/site/src/SearchInput/SearchInput.css.ts
+++ b/site/src/SearchInput/SearchInput.css.ts
@@ -1,82 +1,332 @@
-import { createVar, fallbackVar, globalStyle } from '@vanilla-extract/css';
-import { darkMode } from '../system/styles/sprinkles.css';
+import { createVar, globalStyle } from '@vanilla-extract/css';
+import { homePage } from '../HomePage/HomePage.css';
+import { darkMode as darkModeClass } from '../system/styles/sprinkles.css';
 import { vars } from '../themes.css';
+import { responsiveStyle } from '../themeUtils';
 
 const searchInputMinSize = 44;
+const darkMode = `html.${darkModeClass}`;
+const lightMode = `html:not(.${darkModeClass})`;
+const focusRingColor = createVar();
+const formBackgroundColor = createVar();
+const iconSize = createVar();
+const hitSourceColor = createVar();
+const hitIndicatorColor = createVar();
+const hitIndicatorAngle = createVar();
 
 globalStyle('.DocSearch', {
   fontFamily: vars.fonts.body,
   minHeight: searchInputMinSize,
   minWidth: searchInputMinSize,
+  ...responsiveStyle({
+    mobile: {
+      vars: {
+        '--docsearch-spacing': vars.spacing.large,
+      },
+    },
+    tablet: {
+      vars: {
+        '--docsearch-spacing': vars.spacing.xlarge,
+      },
+    },
+  }),
 });
 
-globalStyle(`.${darkMode} .DocSearch`, {
+/**
+ * DocSearch Vars
+ */
+globalStyle(`${lightMode} .DocSearch`, {
   vars: {
-    '--docsearch-text-color': vars.palette.white,
+    '--docsearch-text-color': vars.palette.coolGray900,
+    '--docsearch-searchbox-focus-background': vars.palette.blue50,
+    '--docsearch-searchbox-background': vars.palette.blue50,
+    '--docsearch-searchbox-shadow': `none`,
+    '--docsearch-key-gradient': vars.palette.teal100,
+    '--docsearch-key-shadow': 'none',
+    '--docsearch-muted-color': vars.palette.coolGray700,
+    '--docsearch-container-background': vars.palette.teal100,
+    '--docsearch-modal-background': vars.palette.white,
+    '--docsearch-modal-shadow': `none`,
+    '--docsearch-footer-background': 'none',
+    '--docsearch-footer-shadow': `none`,
+    '--docsearch-highlight-color': vars.palette.pink500,
+    '--docsearch-hit-shadow': 'none',
+    '--docsearch-logo-color': vars.palette.black,
+    '--docsearch-hit-active-color': vars.palette.black,
+    '--docsearch-hit-color': vars.palette.coolGray500,
+    [hitSourceColor]: vars.palette.green500,
+    [focusRingColor]: vars.palette.pink400,
+    [formBackgroundColor]: vars.palette.blue50,
+    [hitIndicatorColor]: vars.palette.blue300,
+  },
+});
+
+globalStyle(`${lightMode} ${homePage} .DocSearch`, {
+  vars: {
+    '--docsearch-searchbox-focus-background': vars.palette.teal200muted,
+    '--docsearch-searchbox-background': vars.palette.teal200muted,
+  },
+});
+
+globalStyle(`${darkMode} .DocSearch`, {
+  vars: {
+    '--docsearch-text-color': vars.palette.gray50,
     '--docsearch-searchbox-focus-background': vars.palette.gray800,
     '--docsearch-searchbox-background': vars.palette.gray800,
-    '--docsearch-modal-background': vars.palette.gray800,
-    '--docsearch-modal-shadow': `inset 1px 1px 0 0 hsla(0, 0%, 0%, 0.5), 0 3px 8px 0 ${vars.palette.gray800}`,
-    '--docsearch-footer-background': vars.palette.gray800,
-    '--docsearch-footer-shadow': `0 -1px 0 0 ${vars.palette.gray800}, 0 -3px 6px 0 ${vars.palette.gray700}`,
-    '--docsearch-muted-color': vars.palette.gray500,
-    '--docsearch-hit-color': vars.palette.white,
-    '--docsearch-hit-background': vars.palette.gray900,
+    '--docsearch-searchbox-shadow': `none`,
+    '--docsearch-key-gradient': vars.palette.gray900,
+    '--docsearch-key-shadow': 'none',
+    '--docsearch-muted-color': vars.palette.gray400,
+    '--docsearch-container-background': vars.palette.black,
+    '--docsearch-modal-background': vars.palette.gray900,
+    '--docsearch-modal-shadow': `none`,
+    '--docsearch-footer-background': 'none',
+    '--docsearch-footer-shadow': `none`,
+    '--docsearch-highlight-color': vars.palette.pink400,
+    '--docsearch-hit-background': 'none',
     '--docsearch-hit-shadow': 'none',
+    '--docsearch-logo-color': vars.palette.white,
+    '--docsearch-hit-active-color': vars.palette.white,
+    '--docsearch-hit-color': vars.palette.gray400,
+    [hitSourceColor]: vars.palette.green300,
+    [focusRingColor]: vars.palette.pink500,
+    [formBackgroundColor]: vars.palette.gray800,
+    [hitIndicatorColor]: vars.palette.blue400,
   },
 });
 
-const docsearchButton = `.DocSearch.DocSearch-Button`;
-const focusColorVar = createVar();
+/**
+ * DocSearch Button
+ */
+globalStyle(
+  `.DocSearch-Button`,
+  responsiveStyle({
+    mobile: {
+      margin: 0,
+      padding: 0,
+      display: 'flex',
+      justifyContent: 'center',
+      background: 'none',
+    },
+    tablet: {
+      paddingLeft: vars.spacing.large,
+      paddingRight: vars.spacing.medium,
+      borderRadius: vars.border.radius.small,
+      background: 'var(--docsearch-searchbox-background)',
+    },
+  }),
+);
 
-globalStyle(docsearchButton, {
-  boxShadow: `0 4px 8px rgba(14, 14, 33, 0.2), 0px 0px 0px 3px ${fallbackVar(
-    focusColorVar,
-    'transparent',
-  )}`,
-  WebkitTapHighlightColor: 'rgba(0, 0, 0, 0)',
-  justifyContent: 'space-around',
+globalStyle(
+  '.DocSearch-Button:hover, .DocSearch-Button:focus',
+  responsiveStyle({
+    mobile: {
+      background: 'none',
+    },
+    tablet: {
+      background: 'var(--docsearch-searchbox-background)',
+    },
+  }),
+);
+
+globalStyle('.DocSearch-Button:focus-visible', {
+  boxShadow: `0px 0px 0px 3px ${focusRingColor}`,
 });
 
-globalStyle(`${docsearchButton}:focus-visible`, {
+globalStyle('.DocSearch-Button .DocSearch-Button-Keys', {
+  justifyContent: 'flex-end',
+});
+
+globalStyle('.DocSearch-Button .DocSearch-Button-Key', {
   vars: {
-    [focusColorVar]: vars.palette.pink300,
+    '--docsearch-key-gradient': 'none',
   },
+  padding: 0,
+  margin: 0,
+  width: 'auto',
+  fontFamily: vars.fonts.body,
 });
 
-globalStyle(`.${darkMode} ${docsearchButton}:focus-visible`, {
-  vars: {
-    [focusColorVar]: vars.palette.pink600,
-  },
+globalStyle(`.DocSearch-Button-Placeholder`, {
+  paddingLeft: vars.spacing.medium,
+  paddingRight: vars.spacing.medium,
 });
 
-const pseudos = [':hover', ':active'];
-const docsearchButtonAndPseudos = [
-  docsearchButton,
-  ...pseudos.map((pseudo) => `${docsearchButton}${pseudo}`),
-];
+/**
+ * DocSearch Search Icon
+ */
+globalStyle('.DocSearch-Search-Icon', {
+  strokeWidth: 2,
+  color: 'var(--docsearch-text-color)',
+  height: iconSize,
+  width: iconSize,
+  ...responsiveStyle({
+    mobile: {
+      vars: {
+        [iconSize]: '24px',
+      },
+    },
+    tablet: {
+      vars: {
+        [iconSize]: '18px',
+      },
+    },
+  }),
+});
 
-globalStyle(docsearchButtonAndPseudos.join(','), {
+/**
+ * DocSearch Container (holds the modal)
+ */
+globalStyle(`.DocSearch-Container`, {
+  background: 'none',
+});
+
+globalStyle(`.DocSearch-Container::before`, {
+  content: '',
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  zIndex: -1,
+  pointerEvents: 'none',
+  background: 'var(--docsearch-container-background)',
+  backdropFilter: 'blur(4px)',
+  opacity: 0.9,
+});
+
+/**
+ * DocSearch Modal
+ */
+globalStyle(`.DocSearch-Modal`, {
+  background: 'none',
+});
+
+globalStyle(`.DocSearch-Modal::before`, {
+  content: '',
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  zIndex: -1,
+  pointerEvents: 'none',
+  background: 'var(--docsearch-modal-background)',
+  ...responsiveStyle({
+    tablet: {
+      clipPath: 'polygon(1% 1%, 98% 0, 100% 100%, 0 98%)',
+      bottom: 'var(--docsearch-footer-height)',
+    },
+  }),
+});
+
+/**
+ * DocSearch Form (input field container)
+ */
+globalStyle('.DocSearch-Form', {
   vars: {
-    '--docsearch-searchbox-background': vars.palette.white,
-    '--docsearch-searchbox-focus-background': vars.palette.white,
-    '--docsearch-text-color': vars.palette.coolGray900,
+    '--docsearch-searchbox-focus-background': formBackgroundColor,
   },
+  ...responsiveStyle({
+    mobile: {
+      paddingLeft: vars.spacing.medium,
+      paddingRight: vars.spacing.medium,
+    },
+    tablet: {
+      paddingLeft: vars.spacing.large,
+      paddingRight: vars.spacing.large,
+    },
+  }),
+});
+
+/**
+ * DocSearch Input
+ */
+globalStyle(`.DocSearch-Input`, {
+  paddingLeft: vars.spacing.large,
+});
+
+/**
+ * DocSearch Cancel (close button on mobile)
+ */
+globalStyle(`.DocSearch-Cancel`, {
+  color: 'var(--docsearch-text-color)',
+});
+
+/**
+ * DocSearch Hit Source (section heading)
+ */
+globalStyle(`.DocSearch-Hit-source`, {
+  color: hitSourceColor,
+});
+
+/**
+ * DocSearch Hit Item
+ */
+globalStyle(`.DocSearch-Hit > a`, {
+  padding: `${vars.spacing.medium} ${vars.spacing.medium}`,
+});
+
+globalStyle(`.DocSearch-Hit[aria-selected=true] > a`, {
+  background: 'none',
+});
+
+/**
+ * DocSearch Hit Item Indicator
+ */
+globalStyle(`.DocSearch-Hit a::before`, {
+  backgroundColor: hitIndicatorColor,
+  content: '""',
+  width: vars.spacing.xsmall,
+  position: 'absolute',
+  left: '-8px',
+  top: '24px',
+  bottom: '24px',
+  borderRadius: vars.border.radius.small,
+  transform: `skew(${hitIndicatorAngle})`,
+  transition: 'transform .15s ease',
+});
+
+globalStyle(`.DocSearch-Hit[aria-selected=false] a::before`, {
+  opacity: 0,
 });
 
 globalStyle(
-  docsearchButtonAndPseudos
-    .map((className) => `.${darkMode} ${className}`)
-    .join(','),
+  [
+    `.DocSearch-Hit[aria-selected=true] a::before`,
+    `.DocSearch-Hit:nth-child(2n) a::before`,
+  ].join(', '),
   {
     vars: {
-      '--docsearch-searchbox-background': vars.palette.gray300,
-      '--docsearch-searchbox-focus-background': vars.palette.gray300,
-      '--docsearch-text-color': vars.palette.gray800,
+      [hitIndicatorAngle]: '-8deg',
     },
   },
 );
 
-globalStyle('.DocSearch .DocSearch-Search-Icon', {
-  strokeWidth: 3.0,
+globalStyle(
+  [
+    `.DocSearch-Hit a::before`,
+    `.DocSearch-Hit[aria-selected=true]:nth-child(2n) a::before`,
+  ].join(', '),
+  {
+    vars: {
+      [hitIndicatorAngle]: '8deg',
+    },
+  },
+);
+
+/**
+ * DocSearch Hit Mark (Match highlight color)
+ */
+globalStyle(`.DocSearch-Hit[aria-selected=true] mark`, {
+  vars: {
+    '--docsearch-hit-active-color': 'var(--docsearch-highlight-color)',
+  },
+});
+
+/**
+ * DocSearch Hit Mark (Match highlight color)
+ */
+globalStyle(`.DocSearch-Logo svg *`, {
+  fill: 'var(--docsearch-muted-color)',
 });

--- a/site/src/SearchInput/SearchInput.css.ts
+++ b/site/src/SearchInput/SearchInput.css.ts
@@ -1,0 +1,22 @@
+import { globalStyle } from '@vanilla-extract/css';
+import { vars } from '../themes.css';
+
+globalStyle('.DocSearch', {
+  vars: {
+    '--docsearch-primary-color': vars.palette.pink500,
+    '--docsearch-highlight-color': vars.palette.pink500,
+    '--docsearch-text-color': vars.palette.white,
+    '--docsearch-searchbox-focus-background': vars.palette.gray800,
+    '--docsearch-searchbox-background': vars.palette.gray800,
+    '--docsearch-modal-background': vars.palette.gray800,
+    '--docsearch-modal-shadow': `inset 1px 1px 0 0 hsla(0, 0%, 0%, 0.5), 0 3px 8px 0 ${vars.palette.blueGray800}`,
+    '--docsearch-footer-background': vars.palette.gray800,
+    '--docsearch-muted-color': vars.palette.gray400,
+    '--docsearch-hit-color': vars.palette.white,
+    '--docsearch-hit-background': vars.palette.gray900,
+    '--docsearch-key-gradient': `linear-gradient(-225deg, ${vars.palette.gray500}, ${vars.palette.gray900})`,
+    '--docsearch-key-shadow': `inset 0 -2px 0 0 ${vars.palette.gray700}, inset 0 0 1px 1px ${vars.palette.black}, 0 1px 2px 1px ${vars.palette.gray700}`,
+    '--foo-bar': '#f00',
+  },
+  fontFamily: vars.fonts.body,
+});

--- a/site/src/SearchInput/SearchInput.tsx
+++ b/site/src/SearchInput/SearchInput.tsx
@@ -3,7 +3,6 @@ import '@docsearch/css';
 import { ComponentProps } from 'react';
 
 import './SearchInput.css';
-import { Box } from '../system';
 
 type DocSearchProps = ComponentProps<typeof DocSearch>;
 
@@ -26,13 +25,12 @@ const getMissingResultsUrl: DocSearchProps['getMissingResultsUrl'] = ({
   )}\` should return search results.`;
 
 export const SearchInput = () => (
-  <Box paddingRight="medium">
-    <DocSearch
-      appId="ABPL1AJSFN"
-      apiKey="d0d2252fbd30f7cb523a50c5a7780078"
-      indexName="vanilla-extract"
-      transformItems={transformSearchResultItems}
-      getMissingResultsUrl={getMissingResultsUrl}
-    />
-  </Box>
+  <DocSearch
+    appId="ABPL1AJSFN"
+    apiKey="d0d2252fbd30f7cb523a50c5a7780078"
+    indexName="vanilla-extract"
+    transformItems={transformSearchResultItems}
+    getMissingResultsUrl={getMissingResultsUrl}
+    placeholder="Search"
+  />
 );

--- a/site/src/SearchInput/SearchInput.tsx
+++ b/site/src/SearchInput/SearchInput.tsx
@@ -3,6 +3,7 @@ import '@docsearch/css';
 import { ComponentProps } from 'react';
 
 import './SearchInput.css';
+import { Box } from '../system';
 
 type DocSearchProps = ComponentProps<typeof DocSearch>;
 
@@ -25,11 +26,13 @@ const getMissingResultsUrl: DocSearchProps['getMissingResultsUrl'] = ({
   )}\` should return search results.`;
 
 export const SearchInput = () => (
-  <DocSearch
-    appId="ABPL1AJSFN"
-    apiKey="d0d2252fbd30f7cb523a50c5a7780078"
-    indexName="vanilla-extract"
-    transformItems={transformSearchResultItems}
-    getMissingResultsUrl={getMissingResultsUrl}
-  />
+  <Box paddingRight="medium">
+    <DocSearch
+      appId="ABPL1AJSFN"
+      apiKey="d0d2252fbd30f7cb523a50c5a7780078"
+      indexName="vanilla-extract"
+      transformItems={transformSearchResultItems}
+      getMissingResultsUrl={getMissingResultsUrl}
+    />
+  </Box>
 );

--- a/site/src/SearchInput/SearchInput.tsx
+++ b/site/src/SearchInput/SearchInput.tsx
@@ -1,0 +1,35 @@
+import { DocSearch } from '@docsearch/react';
+import '@docsearch/css';
+import { ComponentProps } from 'react';
+
+import './SearchInput.css';
+
+type DocSearchProps = ComponentProps<typeof DocSearch>;
+
+// Make search item URLs relative so the local site doesn't take you back to prod
+const transformSearchResultItems: DocSearchProps['transformItems'] = (items) =>
+  items.map((item) => {
+    const url = new URL(item.url);
+
+    return {
+      ...item,
+      url: url.pathname,
+    };
+  });
+
+const getMissingResultsUrl: DocSearchProps['getMissingResultsUrl'] = ({
+  query,
+}) =>
+  `https://github.com/vanilla-extract-css/vanilla-extract/issues/new?assignees=&labels=pending+triage&template=bug_report.yml&bug-description=Search query \`${encodeURIComponent(
+    query,
+  )}\` should return search results.`;
+
+export const SearchInput = () => (
+  <DocSearch
+    appId="ABPL1AJSFN"
+    apiKey="d0d2252fbd30f7cb523a50c5a7780078"
+    indexName="vanilla-extract"
+    transformItems={transformSearchResultItems}
+    getMissingResultsUrl={getMissingResultsUrl}
+  />
+);

--- a/site/src/SearchInput/SearchInput.tsx
+++ b/site/src/SearchInput/SearchInput.tsx
@@ -13,7 +13,7 @@ const transformSearchResultItems: DocSearchProps['transformItems'] = (items) =>
 
     return {
       ...item,
-      url: url.pathname,
+      url: `${url.pathname}${url.hash}`,
     };
   });
 

--- a/site/src/mdx-components.tsx
+++ b/site/src/mdx-components.tsx
@@ -148,12 +148,12 @@ export default {
     </Block>
   ),
   h1: ({ component, ...props }: HeadingProps) => (
-    <Block component="h1">
+    <Block component="h1" name={props.id}>
       <Heading component="span" {...props} level="1" />
     </Block>
   ),
   h2: ({ component, ...props }: HeadingProps) => (
-    <Block component="h2" paddingTop="xxlarge">
+    <Block component="h2" paddingTop="xxlarge" name={props.id}>
       <Box
         position="relative"
         component="span"
@@ -180,7 +180,7 @@ export default {
     </Block>
   ),
   h3: ({ component, ...props }: HeadingProps) => (
-    <Block component="h3" paddingTop="xlarge">
+    <Block component="h3" paddingTop="xlarge" name={props.id}>
       <Box
         position="relative"
         component="span"

--- a/site/src/themeUtils.ts
+++ b/site/src/themeUtils.ts
@@ -6,7 +6,7 @@ import mapValues from 'lodash/mapValues';
 
 export const breakpoints = {
   mobile: 0,
-  tablet: 769,
+  tablet: 769, // aligning breakpoint with the SearchInput, which uses a `max-width: 768px`. Ref: https://github.com/algolia/docsearch/blob/d81016b110aa0818231b6e4b7b96d2007d345b05/packages/docsearch-css/src/button.css#L66
   desktop: 1200,
 };
 

--- a/site/src/themeUtils.ts
+++ b/site/src/themeUtils.ts
@@ -1,16 +1,17 @@
 import omit from 'lodash/omit';
 import isEqual from 'lodash/isEqual';
 import { StyleRule } from '@vanilla-extract/css';
-import { Properties, SimplePseudos } from 'csstype';
+import { Properties } from 'csstype';
 import mapValues from 'lodash/mapValues';
 
 export const breakpoints = {
   mobile: 0,
-  tablet: 768,
+  tablet: 769,
   desktop: 1200,
 };
 
 export type Breakpoint = keyof typeof breakpoints;
+type CSSProps = Omit<StyleRule, '@media' | '@supports'>;
 
 export const queries = mapValues(
   omit(breakpoints, 'mobile'),
@@ -18,7 +19,7 @@ export const queries = mapValues(
 );
 
 const makeMediaQuery =
-  (breakpoint: keyof typeof queries) => (styles: Properties<string | number>) =>
+  (breakpoint: keyof typeof queries) => (styles: CSSProps) =>
     !styles || Object.keys(styles).length === 0
       ? {}
       : {
@@ -28,10 +29,6 @@ const makeMediaQuery =
 const mediaQuery = {
   tablet: makeMediaQuery('tablet'),
   desktop: makeMediaQuery('desktop'),
-};
-
-type CSSProps = Properties<string | number> & {
-  [P in SimplePseudos]?: Properties<string | number>;
 };
 
 interface ResponsiveStyle {

--- a/site/src/themes.css.ts
+++ b/site/src/themes.css.ts
@@ -79,6 +79,7 @@ const tailwindPalette = {
   teal50: colors.teal['50'],
   teal100: colors.teal['100'],
   teal200: colors.teal['200'],
+  teal200muted: '#b6eee3',
   teal300: colors.teal['300'],
   teal400: colors.teal['400'],
   teal500: colors.teal['500'],

--- a/site/webpack.config.js
+++ b/site/webpack.config.js
@@ -73,6 +73,11 @@ module.exports = [
           use: [MiniCssExtractPlugin.loader, 'css-loader'],
         },
         {
+          test: /\.css$/i,
+          use: [MiniCssExtractPlugin.loader, 'css-loader'],
+          exclude: /\.vanilla\.css$/i,
+        },
+        {
           test: /\.mdx?$/,
           use: ['mdx-loader', './code-block-loader'],
         },

--- a/site/webpack.config.js
+++ b/site/webpack.config.js
@@ -69,13 +69,8 @@ module.exports = [
           ],
         },
         {
-          test: /\.vanilla\.css$/i,
-          use: [MiniCssExtractPlugin.loader, 'css-loader'],
-        },
-        {
           test: /\.css$/i,
           use: [MiniCssExtractPlugin.loader, 'css-loader'],
-          exclude: /\.vanilla\.css$/i,
         },
         {
           test: /\.mdx?$/,
@@ -113,7 +108,7 @@ module.exports = [
     target: 'node',
     externals: [
       nodeExternals({
-        allowlist: [/^react-syntax-highlighter\/dist\/esm/],
+        allowlist: [/^react-syntax-highlighter\/dist\/esm/, /^@docsearch\/css/],
       }),
     ],
     output: {
@@ -151,8 +146,8 @@ module.exports = [
           ],
         },
         {
-          test: /\.vanilla\.css$/i,
-          use: ['css-loader'],
+          test: /\.css$/i,
+          use: ['null-loader'],
         },
         {
           test: /\.mdx?$/,


### PR DESCRIPTION
[**Preview site**](https://63fc30f6771c470d7338fad6--vanilla-extract-css.netlify.app)


Created a `SearchInput` component that wraps algolia's `DocSearch` component.

Not customizing too much for now, the two notable customizations are:
- Making search result URLs relative rather than absolute so clicking a search result when running the site locally/on a preview site doesn't take you to production
- Customizing the missing result URL to point to a github issue template

[DocSearch component API Reference](https://docsearch.algolia.com/docs/api)

I've also taken a crack at the styling and general positioning on site. I've put it next to the color mode icon/fab, and attempted to style it in the same manor as the fab, mainly for consistency. Feel free to clean up or change the styles completely, I don't have any strong opinions about them. The docesarch styles can be found [here](https://github.com/algolia/docsearch/tree/main/packages/docsearch-css/src), and I've overwritten some of the CSS vars and styles with global styles.

**NOTE**: There are a handful of CSS vars you can customize, but some of them are used for _both_ the modal and the search input, which is a bit of a pain.