### PR TITLE
site: Add `name` attributes to Headings

### DIFF
--- a/site/src/mdx-components.tsx
+++ b/site/src/mdx-components.tsx
@@ -148,12 +148,12 @@ export default {
     </Block>
   ),
   h1: ({ component, ...props }: HeadingProps) => (
-    <Block component="h1">
+    <Block component="h1" name={props.id}>
       <Heading component="span" {...props} level="1" />
     </Block>
   ),
   h2: ({ component, ...props }: HeadingProps) => (
-    <Block component="h2" paddingTop="xxlarge">
+    <Block component="h2" paddingTop="xxlarge" name={props.id}>
       <Box
         position="relative"
         component="span"
@@ -180,7 +180,7 @@ export default {
     </Block>
   ),
   h3: ({ component, ...props }: HeadingProps) => (
-    <Block component="h3" paddingTop="xlarge">
+    <Block component="h3" paddingTop="xlarge" name={props.id}>
       <Box
         position="relative"
         component="span"


### PR DESCRIPTION
Adding the `name` attribute to headings on the site in the hope that the elements can be picked up by the search indexer and support linking to hashes.

See [docs](https://docsearch.algolia.com/docs/tips/#add-anchors-to-headings).