### PR TITLE
Fix babel plugin in node14, run ci on supported node versions

### DIFF
--- a/.changeset/old-avocados-play.md
+++ b/.changeset/old-avocados-play.md
@@ -1,0 +1,7 @@
+---
+'@vanilla-extract/babel-plugin-debug-ids': patch
+---
+
+Fix `args.at is not a function` error
+
+Refactor argument traversal to ensure compatibility with node 14.

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,7 +4,12 @@ on: [push, pull_request]
 
 jobs:
   test:
-    name: Lint & Test
+    strategy:
+      matrix:
+        # Blank string allows us to test against version in nvmrc file
+        # configured in 'Set up Node.js' down below.
+        node: [14, ''] # Add 'lts/*' to this list when ready
+    name: Lint & Test (${{ (matrix.node && matrix.node != 'lts/*') && format('node {0}', matrix.node) || matrix.node || 'nvmrc' }})
     runs-on: ubuntu-latest
     env:
       CI: true
@@ -12,12 +17,13 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@main
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2
 
       - name: Set up Node.js
         uses: actions/setup-node@main
         with:
-          node-version-file: '.nvmrc'
+          node-version: ${{ matrix.node }}
+          node-version-file: ${{ matrix.node == '' && '.nvmrc' || '' }}
           cache: 'pnpm'
 
       - name: Install Dependencies
@@ -40,7 +46,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@main
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2
 
       - name: Set up Node.js
         uses: actions/setup-node@main

--- a/packages/babel-plugin-debug-ids/src/index.ts
+++ b/packages/babel-plugin-debug-ids/src/index.ts
@@ -19,8 +19,10 @@ const debuggableFunctionConfig = {
   },
   styleVariants: {
     maxParams: 3,
-    hasDebugId: ({ arguments: args }) =>
-      t.isStringLiteral(args.at(-1)) || t.isTemplateLiteral(args.at(-1)),
+    hasDebugId: ({ arguments: args }) => {
+      const previousArg = args[args.length - 1];
+      return t.isStringLiteral(previousArg) || t.isTemplateLiteral(previousArg);
+    },
   },
   fontFace: {
     maxParams: 2,


### PR DESCRIPTION
Fixes `args.at is not a function` error when using the `babel-plugin-debug-ids` package in node 14. Refactored the argument traversal to ensure backwards compatibility.

Also setup CI to run on minimum supported version of node to catch this category of problem going forwards.