### PR TITLE
Add esbuild as peer dependency of esbuild plugin

### DIFF
--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -19,5 +19,8 @@
   },
   "devDependencies": {
     "esbuild": "^0.16.3"
+  },
+  "peerDependencies": {
+    "esbuild": ">=0.16.0"
   }
 }


### PR DESCRIPTION
The plugin imports the `Plugin` type from the `esbuild` module, so I *think* it is better to declare it as a dependency of some sort. 

The issue I've seen without adding `esbuild` as a dependency is that the `Plugin` import is a moving target since it will resolve to an apparently random version of `esbuild` depending on the user's setup.

For example, I've started getting some errors in my build when I updated `tsup`, which uses `esbuild` internally and which recently upgraded to 0.17.0. The issue ultimately boils down to Vanilla Extract's plugin arbitrarily resolving the `Plugin` type from version 0.14.0 which was transitively present in the dependency tree and which has an incompatible type wrt 0.17.0.

My hope is that using a peer dependency will at least surface potential incompatibilities errors in a more predictable manner.

---

As an aside, I've randomly sampled esbuild plugins from https://github.com/esbuild/community-plugins to see what they do, and I don't think I've found one that does the same as the others 😅. Some use `"esbuild": "*"` as a peer dep, some don't specify anything, some add esbuild as a dependency, some use `^`, some use `>=`, and so on.

I've ultimately opted for a peer dependency, since it feels more natural for a plugin (it's fair to assume the consumer of this will have `esbuild` as a dependency on their end)