### PR TITLE
integration: Sort serialized module exports

### DIFF
--- a/.changeset/shiny-socks-lick.md
+++ b/.changeset/shiny-socks-lick.md
@@ -1,0 +1,7 @@
+---
+'@vanilla-extract/integration': patch
+---
+
+Sort serialized module exports
+
+Fixes a Vanilla module serialization bug that sometimes resulted in variables being used before they were declared

--- a/packages/integration/src/processVanillaFile.test.ts
+++ b/packages/integration/src/processVanillaFile.test.ts
@@ -180,4 +180,59 @@ describe('serializeVanillaModule', () => {
       export var sprinkles = _86bce(__default__,otherComplexExport);"
     `);
   });
+
+  test('should order exports correctly', () => {
+    const simpleObjectExport = { hello: 'world' };
+
+    const complexExport = {
+      my: {
+        very: {
+          complex: {
+            arg: simpleObjectExport,
+          },
+        },
+      },
+    };
+
+    const otherComplexExport = {
+      other: {
+        complex: [1, 2, 3],
+      },
+    };
+
+    const someOtherExport = [4, 5, 6];
+
+    const reExport = otherComplexExport;
+    const reReExport = reExport;
+
+    const sprinkles = () => {};
+    sprinkles.__function_serializer__ = {
+      importPath: 'my-package',
+      importName: 'myFunction',
+      args: [complexExport, otherComplexExport, someOtherExport, reReExport],
+    };
+    const exports = {
+      sprinkles,
+      complexExport,
+      simpleObjectExport,
+      reReExport,
+      otherComplexExport,
+      default: someOtherExport,
+      reExport,
+    };
+
+    expect(serializeVanillaModule(['import "./styles.css"'], exports, null))
+      .toMatchInlineSnapshot(`
+      "import "./styles.css"
+      import { myFunction as _86bce } from 'my-package';
+      export var simpleObjectExport = {hello:'world'};
+      export var complexExport = {my:{very:{complex:{arg:simpleObjectExport}}}};
+      var __default__ = [4,5,6];
+      export default __default__;
+      export var reExport = {other:{complex:[1,2,3]}};
+      export var sprinkles = _86bce(complexExport,reExport,__default__,reExport);
+      export var reReExport = reExport;
+      export var otherComplexExport = reExport;"
+    `);
+  });
 });


### PR DESCRIPTION
The `eval` result we use to serialize modules is an object containing the module's exports, so its order can't be reliably depended on. This was resulting in module exports sometimes being serialized in the wrong order. In [my reproduction](https://github.com/askoufis/vanilla-extract-issue-1027-repro), the effect of this was `createSprinkles` being called on a variable that was declared on the line below, causing a runtime error.

```js
import "/src/App.css.ts.vanilla.js";
import { createSprinkles as _ad221 } from "/node_modules/.vite/deps/@vanilla-extract_sprinkles_createRuntimeSprinkles.js?v=0be76525";

// Referencing `textProperties` before it's defined
export var textAtoms = _ad221(textProperties);
export var textProperties = { /* */ };
```

We can take advantage of [the new exports variable sharing](https://github.com/vanilla-extract-css/vanilla-extract/releases/tag/%40vanilla-extract%2Fintegration%406.1.1) to build a dependency graph, which we can then use to sort the exports in a valid order.

Fixes #1027.