### PR TITLE
sprinkles: Add support for layers

### DIFF
--- a/.changeset/sprinkles-layers.md
+++ b/.changeset/sprinkles-layers.md
@@ -1,0 +1,20 @@
+---
+'@vanilla-extract/sprinkles': minor
+---
+
+Support assigning properties to layers via `@layer` option on `defineProperties`
+
+**Example usage:**
+
+```ts
+// sprinkles.css.ts
+import { defineProperties } from '@vanilla-extract/sprinkles';
+import { layer } from '@vanilla-extract/css';
+
+export const sprinklesLayer = layer();
+
+const properties = defineProperties({
+  '@layer': sprinklesLayer,
+  // etc.
+});
+```

--- a/fixtures/sprinkles/src/styles.css.ts
+++ b/fixtures/sprinkles/src/styles.css.ts
@@ -21,7 +21,7 @@ export const container = style({
   containerType: 'size',
 });
 
-const responsiveProperties = defineProperties({
+const responsiveConditions = {
   defaultCondition: 'mobile',
   conditions: {
     mobile: {},
@@ -40,12 +40,23 @@ const responsiveProperties = defineProperties({
     },
   },
   responsiveArray: ['mobile', 'tablet', 'desktop'],
+} as const;
+
+const responsiveProperties = defineProperties({
+  ...responsiveConditions,
   properties: {
     display: ['flex', 'none', 'block'],
     paddingTop: {
       small: '10px',
       medium: '20px',
     },
+  },
+});
+
+const responsiveLayerProperties = defineProperties({
+  '@layer': 'responsive-layer-name',
+  ...responsiveConditions,
+  properties: {
     background: {
       red: {
         vars: { [alpha]: '1' },
@@ -71,6 +82,12 @@ const unconditionalProperties = defineProperties({
         color: `rgba(255, 0, 0, ${textAlpha})`,
       },
     },
+  },
+});
+
+const unconditionalLayerProperties = defineProperties({
+  '@layer': 'unconditional-layer-name',
+  properties: {
     textOpacity: {
       1: { vars: { [textAlpha]: '1' } },
       0.8: { vars: { [textAlpha]: '0.8' } },
@@ -80,7 +97,9 @@ const unconditionalProperties = defineProperties({
 
 export const sprinkles = createSprinkles(
   responsiveProperties,
+  responsiveLayerProperties,
   unconditionalProperties,
+  unconditionalLayerProperties,
 );
 
 export const mapResponsiveValue = createMapValueFn(responsiveProperties);

--- a/packages/sprinkles/src/index.ts
+++ b/packages/sprinkles/src/index.ts
@@ -44,6 +44,7 @@ type ShorthandOptions<
 };
 
 type UnconditionalAtomicOptions<Properties extends AtomicProperties> = {
+  '@layer'?: string;
   properties: Properties;
 };
 
@@ -288,6 +289,14 @@ export function defineProperties(options: any): any {
             };
           }
 
+          if (options['@layer']) {
+            styleValue = {
+              '@layer': {
+                [options['@layer']]: styleValue,
+              },
+            };
+          }
+
           const className = style(
             styleValue,
             `${key}_${String(valueName)}_${conditionName}`,
@@ -304,8 +313,16 @@ export function defineProperties(options: any): any {
           styles[key].values[valueName].defaultClass = defaultClasses.join(' ');
         }
       } else {
-        const styleValue: StyleRule =
+        let styleValue: StyleRule =
           typeof value === 'object' ? value : { [key]: value };
+
+        if (options['@layer']) {
+          styleValue = {
+            '@layer': {
+              [options['@layer']]: styleValue,
+            },
+          };
+        }
 
         styles[key].values[valueName] = {
           defaultClass: style(styleValue, `${key}_${String(valueName)}`),

--- a/site/docs/packages/sprinkles.md
+++ b/site/docs/packages/sprinkles.md
@@ -532,6 +532,26 @@ const responsiveProperties = defineProperties({
 });
 ```
 
+### @layer
+
+Optionally defines a layer to assign styles to for a given set of properties.
+
+> 🚧&nbsp;&nbsp;Ensure your target browsers [support layers].
+> Vanilla Extract supports the [layers syntax][layer] but does not polyfill the feature in unsupported browsers.
+
+```ts
+// sprinkles.css.ts
+import { defineProperties } from '@vanilla-extract/sprinkles';
+import { layer } from '@vanilla-extract/css';
+
+export const sprinklesLayer = layer();
+
+const properties = defineProperties({
+  '@layer': sprinklesLayer
+  // etc.
+});
+```
+
 ## createSprinkles
 
 Creates a type-safe function for accessing your [defined properties](#defineProperties). You can provide as many collections of properties as you like.
@@ -775,3 +795,5 @@ const e: ResponsiveAlign = { desktop: 'center' };
 [styled system]: https://styled-system.com
 [support container queries]: https://caniuse.com/css-container-queries
 [container query syntax]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries
+[layer]: https://developer.mozilla.org/en-US/docs/Web/CSS/@layer
+[support layers]: https://caniuse.com/css-cascade-layers

--- a/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-esbuild--development.css
+++ b/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-esbuild--development.css
@@ -1,3 +1,5 @@
+@layer responsive-layer-name;
+@layer unconditional-layer-name;
 .styles_container__1j5zl923 {
   container-name: styles_containerName__1j5zl922;
   container-type: size;
@@ -17,31 +19,9 @@
 .styles_paddingTop_medium_mobile__1j5zl92k {
   padding-top: 20px;
 }
-.styles_background_red_mobile__1j5zl92o {
-  --alpha__1j5zl920: 1;
-  background: rgba(255, 0, 0, var(--alpha__1j5zl920));
-}
-.styles_backgroundOpacity_1_mobile__1j5zl92s {
-  --alpha__1j5zl920: 1;
-}
-.styles_backgroundOpacity_0\.1_mobile__1j5zl92w {
-  --alpha__1j5zl920: 0.1;
-}
-.styles_backgroundOpacity_0\.2_mobile__1j5zl9210 {
-  --alpha__1j5zl920: 0.2;
-}
-.styles_backgroundOpacity_0\.3_mobile__1j5zl9214 {
-  --alpha__1j5zl920: 0.3;
-}
 .styles_color_red__1j5zl9218 {
   --textAlpha__1j5zl921: 1;
   color: rgba(255, 0, 0, var(--textAlpha__1j5zl921));
-}
-.styles_textOpacity_1__1j5zl9219 {
-  --textAlpha__1j5zl921: 1;
-}
-.styles_textOpacity_0\.8__1j5zl921a {
-  --textAlpha__1j5zl921: 0.8;
 }
 body {
   margin: 0;
@@ -66,22 +46,6 @@ body .styles__1j5zl921c {
     .styles_paddingTop_medium_tablet__1j5zl92l {
       padding-top: 20px;
     }
-    .styles_background_red_tablet__1j5zl92p {
-      --alpha__1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--alpha__1j5zl920));
-    }
-    .styles_backgroundOpacity_1_tablet__1j5zl92t {
-      --alpha__1j5zl920: 1;
-    }
-    .styles_backgroundOpacity_0\.1_tablet__1j5zl92x {
-      --alpha__1j5zl920: 0.1;
-    }
-    .styles_backgroundOpacity_0\.2_tablet__1j5zl9211 {
-      --alpha__1j5zl920: 0.2;
-    }
-    .styles_backgroundOpacity_0\.3_tablet__1j5zl9215 {
-      --alpha__1j5zl920: 0.3;
-    }
   }
 }
 @media screen and (min-width: 1024px) {
@@ -101,22 +65,6 @@ body .styles__1j5zl921c {
     .styles_paddingTop_medium_desktop__1j5zl92m {
       padding-top: 20px;
     }
-    .styles_background_red_desktop__1j5zl92q {
-      --alpha__1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--alpha__1j5zl920));
-    }
-    .styles_backgroundOpacity_1_desktop__1j5zl92u {
-      --alpha__1j5zl920: 1;
-    }
-    .styles_backgroundOpacity_0\.1_desktop__1j5zl92y {
-      --alpha__1j5zl920: 0.1;
-    }
-    .styles_backgroundOpacity_0\.2_desktop__1j5zl9212 {
-      --alpha__1j5zl920: 0.2;
-    }
-    .styles_backgroundOpacity_0\.3_desktop__1j5zl9216 {
-      --alpha__1j5zl920: 0.3;
-    }
   }
   @supports not (display: grid) {
     [data-dark-mode] .styles_display_flex_darkDesktop__1j5zl927 {
@@ -134,21 +82,89 @@ body .styles__1j5zl921c {
     [data-dark-mode] .styles_paddingTop_medium_darkDesktop__1j5zl92n {
       padding-top: 20px;
     }
-    [data-dark-mode] .styles_background_red_darkDesktop__1j5zl92r {
-      --alpha__1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--alpha__1j5zl920));
+  }
+}
+@layer responsive-layer-name {
+  .styles_background_red_mobile__1j5zl92o {
+    --alpha__1j5zl920: 1;
+    background: rgba(255, 0, 0, var(--alpha__1j5zl920));
+  }
+  .styles_backgroundOpacity_1_mobile__1j5zl92s {
+    --alpha__1j5zl920: 1;
+  }
+  .styles_backgroundOpacity_0\.1_mobile__1j5zl92w {
+    --alpha__1j5zl920: 0.1;
+  }
+  .styles_backgroundOpacity_0\.2_mobile__1j5zl9210 {
+    --alpha__1j5zl920: 0.2;
+  }
+  .styles_backgroundOpacity_0\.3_mobile__1j5zl9214 {
+    --alpha__1j5zl920: 0.3;
+  }
+  @media screen and (min-width: 768px) {
+    @container styles_containerName__1j5zl922 (min-width: 768px) {
+      .styles_background_red_tablet__1j5zl92p {
+        --alpha__1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--alpha__1j5zl920));
+      }
+      .styles_backgroundOpacity_1_tablet__1j5zl92t {
+        --alpha__1j5zl920: 1;
+      }
+      .styles_backgroundOpacity_0\.1_tablet__1j5zl92x {
+        --alpha__1j5zl920: 0.1;
+      }
+      .styles_backgroundOpacity_0\.2_tablet__1j5zl9211 {
+        --alpha__1j5zl920: 0.2;
+      }
+      .styles_backgroundOpacity_0\.3_tablet__1j5zl9215 {
+        --alpha__1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] .styles_backgroundOpacity_1_darkDesktop__1j5zl92v {
-      --alpha__1j5zl920: 1;
+  }
+  @media screen and (min-width: 1024px) {
+    @container styles_containerName__1j5zl922 (min-width: 1024px) {
+      .styles_background_red_desktop__1j5zl92q {
+        --alpha__1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--alpha__1j5zl920));
+      }
+      .styles_backgroundOpacity_1_desktop__1j5zl92u {
+        --alpha__1j5zl920: 1;
+      }
+      .styles_backgroundOpacity_0\.1_desktop__1j5zl92y {
+        --alpha__1j5zl920: 0.1;
+      }
+      .styles_backgroundOpacity_0\.2_desktop__1j5zl9212 {
+        --alpha__1j5zl920: 0.2;
+      }
+      .styles_backgroundOpacity_0\.3_desktop__1j5zl9216 {
+        --alpha__1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] .styles_backgroundOpacity_0\.1_darkDesktop__1j5zl92z {
-      --alpha__1j5zl920: 0.1;
+    @supports not (display: grid) {
+      [data-dark-mode] .styles_background_red_darkDesktop__1j5zl92r {
+        --alpha__1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--alpha__1j5zl920));
+      }
+      [data-dark-mode] .styles_backgroundOpacity_1_darkDesktop__1j5zl92v {
+        --alpha__1j5zl920: 1;
+      }
+      [data-dark-mode] .styles_backgroundOpacity_0\.1_darkDesktop__1j5zl92z {
+        --alpha__1j5zl920: 0.1;
+      }
+      [data-dark-mode] .styles_backgroundOpacity_0\.2_darkDesktop__1j5zl9213 {
+        --alpha__1j5zl920: 0.2;
+      }
+      [data-dark-mode] .styles_backgroundOpacity_0\.3_darkDesktop__1j5zl9217 {
+        --alpha__1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] .styles_backgroundOpacity_0\.2_darkDesktop__1j5zl9213 {
-      --alpha__1j5zl920: 0.2;
-    }
-    [data-dark-mode] .styles_backgroundOpacity_0\.3_darkDesktop__1j5zl9217 {
-      --alpha__1j5zl920: 0.3;
-    }
+  }
+}
+@layer unconditional-layer-name {
+  .styles_textOpacity_1__1j5zl9219 {
+    --textAlpha__1j5zl921: 1;
+  }
+  .styles_textOpacity_0\.8__1j5zl921a {
+    --textAlpha__1j5zl921: 0.8;
   }
 }

--- a/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-esbuild--production.css
+++ b/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-esbuild--production.css
@@ -1,3 +1,5 @@
+@layer responsive-layer-name;
+@layer unconditional-layer-name;
 ._1j5zl923 {
   container-name: _1j5zl922;
   container-type: size;
@@ -17,31 +19,9 @@
 ._1j5zl92k {
   padding-top: 20px;
 }
-._1j5zl92o {
-  --_1j5zl920: 1;
-  background: rgba(255, 0, 0, var(--_1j5zl920));
-}
-._1j5zl92s {
-  --_1j5zl920: 1;
-}
-._1j5zl92w {
-  --_1j5zl920: 0.1;
-}
-._1j5zl9210 {
-  --_1j5zl920: 0.2;
-}
-._1j5zl9214 {
-  --_1j5zl920: 0.3;
-}
 ._1j5zl9218 {
   --_1j5zl921: 1;
   color: rgba(255, 0, 0, var(--_1j5zl921));
-}
-._1j5zl9219 {
-  --_1j5zl921: 1;
-}
-._1j5zl921a {
-  --_1j5zl921: 0.8;
 }
 body {
   margin: 0;
@@ -66,22 +46,6 @@ body ._1j5zl921c {
     ._1j5zl92l {
       padding-top: 20px;
     }
-    ._1j5zl92p {
-      --_1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--_1j5zl920));
-    }
-    ._1j5zl92t {
-      --_1j5zl920: 1;
-    }
-    ._1j5zl92x {
-      --_1j5zl920: 0.1;
-    }
-    ._1j5zl9211 {
-      --_1j5zl920: 0.2;
-    }
-    ._1j5zl9215 {
-      --_1j5zl920: 0.3;
-    }
   }
 }
 @media screen and (min-width: 1024px) {
@@ -101,22 +65,6 @@ body ._1j5zl921c {
     ._1j5zl92m {
       padding-top: 20px;
     }
-    ._1j5zl92q {
-      --_1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--_1j5zl920));
-    }
-    ._1j5zl92u {
-      --_1j5zl920: 1;
-    }
-    ._1j5zl92y {
-      --_1j5zl920: 0.1;
-    }
-    ._1j5zl9212 {
-      --_1j5zl920: 0.2;
-    }
-    ._1j5zl9216 {
-      --_1j5zl920: 0.3;
-    }
   }
   @supports not (display: grid) {
     [data-dark-mode] ._1j5zl927 {
@@ -134,21 +82,89 @@ body ._1j5zl921c {
     [data-dark-mode] ._1j5zl92n {
       padding-top: 20px;
     }
-    [data-dark-mode] ._1j5zl92r {
-      --_1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--_1j5zl920));
+  }
+}
+@layer responsive-layer-name {
+  ._1j5zl92o {
+    --_1j5zl920: 1;
+    background: rgba(255, 0, 0, var(--_1j5zl920));
+  }
+  ._1j5zl92s {
+    --_1j5zl920: 1;
+  }
+  ._1j5zl92w {
+    --_1j5zl920: 0.1;
+  }
+  ._1j5zl9210 {
+    --_1j5zl920: 0.2;
+  }
+  ._1j5zl9214 {
+    --_1j5zl920: 0.3;
+  }
+  @media screen and (min-width: 768px) {
+    @container _1j5zl922 (min-width: 768px) {
+      ._1j5zl92p {
+        --_1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--_1j5zl920));
+      }
+      ._1j5zl92t {
+        --_1j5zl920: 1;
+      }
+      ._1j5zl92x {
+        --_1j5zl920: 0.1;
+      }
+      ._1j5zl9211 {
+        --_1j5zl920: 0.2;
+      }
+      ._1j5zl9215 {
+        --_1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] ._1j5zl92v {
-      --_1j5zl920: 1;
+  }
+  @media screen and (min-width: 1024px) {
+    @container _1j5zl922 (min-width: 1024px) {
+      ._1j5zl92q {
+        --_1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--_1j5zl920));
+      }
+      ._1j5zl92u {
+        --_1j5zl920: 1;
+      }
+      ._1j5zl92y {
+        --_1j5zl920: 0.1;
+      }
+      ._1j5zl9212 {
+        --_1j5zl920: 0.2;
+      }
+      ._1j5zl9216 {
+        --_1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] ._1j5zl92z {
-      --_1j5zl920: 0.1;
+    @supports not (display: grid) {
+      [data-dark-mode] ._1j5zl92r {
+        --_1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--_1j5zl920));
+      }
+      [data-dark-mode] ._1j5zl92v {
+        --_1j5zl920: 1;
+      }
+      [data-dark-mode] ._1j5zl92z {
+        --_1j5zl920: 0.1;
+      }
+      [data-dark-mode] ._1j5zl9213 {
+        --_1j5zl920: 0.2;
+      }
+      [data-dark-mode] ._1j5zl9217 {
+        --_1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] ._1j5zl9213 {
-      --_1j5zl920: 0.2;
-    }
-    [data-dark-mode] ._1j5zl9217 {
-      --_1j5zl920: 0.3;
-    }
+  }
+}
+@layer unconditional-layer-name {
+  ._1j5zl9219 {
+    --_1j5zl921: 1;
+  }
+  ._1j5zl921a {
+    --_1j5zl921: 0.8;
   }
 }

--- a/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-esbuild-next--development.css
+++ b/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-esbuild-next--development.css
@@ -1,3 +1,5 @@
+@layer responsive-layer-name;
+@layer unconditional-layer-name;
 .styles_container__1j5zl923 {
   container-name: styles_containerName__1j5zl922;
   container-type: size;
@@ -17,31 +19,9 @@
 .styles_paddingTop_medium_mobile__1j5zl92k {
   padding-top: 20px;
 }
-.styles_background_red_mobile__1j5zl92o {
-  --alpha__1j5zl920: 1;
-  background: rgba(255, 0, 0, var(--alpha__1j5zl920));
-}
-.styles_backgroundOpacity_1_mobile__1j5zl92s {
-  --alpha__1j5zl920: 1;
-}
-.styles_backgroundOpacity_0\.1_mobile__1j5zl92w {
-  --alpha__1j5zl920: 0.1;
-}
-.styles_backgroundOpacity_0\.2_mobile__1j5zl9210 {
-  --alpha__1j5zl920: 0.2;
-}
-.styles_backgroundOpacity_0\.3_mobile__1j5zl9214 {
-  --alpha__1j5zl920: 0.3;
-}
 .styles_color_red__1j5zl9218 {
   --textAlpha__1j5zl921: 1;
   color: rgba(255, 0, 0, var(--textAlpha__1j5zl921));
-}
-.styles_textOpacity_1__1j5zl9219 {
-  --textAlpha__1j5zl921: 1;
-}
-.styles_textOpacity_0\.8__1j5zl921a {
-  --textAlpha__1j5zl921: 0.8;
 }
 body {
   margin: 0;
@@ -66,22 +46,6 @@ body .styles__1j5zl921c {
     .styles_paddingTop_medium_tablet__1j5zl92l {
       padding-top: 20px;
     }
-    .styles_background_red_tablet__1j5zl92p {
-      --alpha__1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--alpha__1j5zl920));
-    }
-    .styles_backgroundOpacity_1_tablet__1j5zl92t {
-      --alpha__1j5zl920: 1;
-    }
-    .styles_backgroundOpacity_0\.1_tablet__1j5zl92x {
-      --alpha__1j5zl920: 0.1;
-    }
-    .styles_backgroundOpacity_0\.2_tablet__1j5zl9211 {
-      --alpha__1j5zl920: 0.2;
-    }
-    .styles_backgroundOpacity_0\.3_tablet__1j5zl9215 {
-      --alpha__1j5zl920: 0.3;
-    }
   }
 }
 @media screen and (min-width: 1024px) {
@@ -101,22 +65,6 @@ body .styles__1j5zl921c {
     .styles_paddingTop_medium_desktop__1j5zl92m {
       padding-top: 20px;
     }
-    .styles_background_red_desktop__1j5zl92q {
-      --alpha__1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--alpha__1j5zl920));
-    }
-    .styles_backgroundOpacity_1_desktop__1j5zl92u {
-      --alpha__1j5zl920: 1;
-    }
-    .styles_backgroundOpacity_0\.1_desktop__1j5zl92y {
-      --alpha__1j5zl920: 0.1;
-    }
-    .styles_backgroundOpacity_0\.2_desktop__1j5zl9212 {
-      --alpha__1j5zl920: 0.2;
-    }
-    .styles_backgroundOpacity_0\.3_desktop__1j5zl9216 {
-      --alpha__1j5zl920: 0.3;
-    }
   }
   @supports not (display: grid) {
     [data-dark-mode] .styles_display_flex_darkDesktop__1j5zl927 {
@@ -134,21 +82,89 @@ body .styles__1j5zl921c {
     [data-dark-mode] .styles_paddingTop_medium_darkDesktop__1j5zl92n {
       padding-top: 20px;
     }
-    [data-dark-mode] .styles_background_red_darkDesktop__1j5zl92r {
-      --alpha__1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--alpha__1j5zl920));
+  }
+}
+@layer responsive-layer-name {
+  .styles_background_red_mobile__1j5zl92o {
+    --alpha__1j5zl920: 1;
+    background: rgba(255, 0, 0, var(--alpha__1j5zl920));
+  }
+  .styles_backgroundOpacity_1_mobile__1j5zl92s {
+    --alpha__1j5zl920: 1;
+  }
+  .styles_backgroundOpacity_0\.1_mobile__1j5zl92w {
+    --alpha__1j5zl920: 0.1;
+  }
+  .styles_backgroundOpacity_0\.2_mobile__1j5zl9210 {
+    --alpha__1j5zl920: 0.2;
+  }
+  .styles_backgroundOpacity_0\.3_mobile__1j5zl9214 {
+    --alpha__1j5zl920: 0.3;
+  }
+  @media screen and (min-width: 768px) {
+    @container styles_containerName__1j5zl922 (min-width: 768px) {
+      .styles_background_red_tablet__1j5zl92p {
+        --alpha__1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--alpha__1j5zl920));
+      }
+      .styles_backgroundOpacity_1_tablet__1j5zl92t {
+        --alpha__1j5zl920: 1;
+      }
+      .styles_backgroundOpacity_0\.1_tablet__1j5zl92x {
+        --alpha__1j5zl920: 0.1;
+      }
+      .styles_backgroundOpacity_0\.2_tablet__1j5zl9211 {
+        --alpha__1j5zl920: 0.2;
+      }
+      .styles_backgroundOpacity_0\.3_tablet__1j5zl9215 {
+        --alpha__1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] .styles_backgroundOpacity_1_darkDesktop__1j5zl92v {
-      --alpha__1j5zl920: 1;
+  }
+  @media screen and (min-width: 1024px) {
+    @container styles_containerName__1j5zl922 (min-width: 1024px) {
+      .styles_background_red_desktop__1j5zl92q {
+        --alpha__1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--alpha__1j5zl920));
+      }
+      .styles_backgroundOpacity_1_desktop__1j5zl92u {
+        --alpha__1j5zl920: 1;
+      }
+      .styles_backgroundOpacity_0\.1_desktop__1j5zl92y {
+        --alpha__1j5zl920: 0.1;
+      }
+      .styles_backgroundOpacity_0\.2_desktop__1j5zl9212 {
+        --alpha__1j5zl920: 0.2;
+      }
+      .styles_backgroundOpacity_0\.3_desktop__1j5zl9216 {
+        --alpha__1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] .styles_backgroundOpacity_0\.1_darkDesktop__1j5zl92z {
-      --alpha__1j5zl920: 0.1;
+    @supports not (display: grid) {
+      [data-dark-mode] .styles_background_red_darkDesktop__1j5zl92r {
+        --alpha__1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--alpha__1j5zl920));
+      }
+      [data-dark-mode] .styles_backgroundOpacity_1_darkDesktop__1j5zl92v {
+        --alpha__1j5zl920: 1;
+      }
+      [data-dark-mode] .styles_backgroundOpacity_0\.1_darkDesktop__1j5zl92z {
+        --alpha__1j5zl920: 0.1;
+      }
+      [data-dark-mode] .styles_backgroundOpacity_0\.2_darkDesktop__1j5zl9213 {
+        --alpha__1j5zl920: 0.2;
+      }
+      [data-dark-mode] .styles_backgroundOpacity_0\.3_darkDesktop__1j5zl9217 {
+        --alpha__1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] .styles_backgroundOpacity_0\.2_darkDesktop__1j5zl9213 {
-      --alpha__1j5zl920: 0.2;
-    }
-    [data-dark-mode] .styles_backgroundOpacity_0\.3_darkDesktop__1j5zl9217 {
-      --alpha__1j5zl920: 0.3;
-    }
+  }
+}
+@layer unconditional-layer-name {
+  .styles_textOpacity_1__1j5zl9219 {
+    --textAlpha__1j5zl921: 1;
+  }
+  .styles_textOpacity_0\.8__1j5zl921a {
+    --textAlpha__1j5zl921: 0.8;
   }
 }

--- a/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-esbuild-next--production.css
+++ b/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-esbuild-next--production.css
@@ -1,3 +1,5 @@
+@layer responsive-layer-name;
+@layer unconditional-layer-name;
 ._1j5zl923 {
   container-name: _1j5zl922;
   container-type: size;
@@ -17,31 +19,9 @@
 ._1j5zl92k {
   padding-top: 20px;
 }
-._1j5zl92o {
-  --_1j5zl920: 1;
-  background: rgba(255, 0, 0, var(--_1j5zl920));
-}
-._1j5zl92s {
-  --_1j5zl920: 1;
-}
-._1j5zl92w {
-  --_1j5zl920: 0.1;
-}
-._1j5zl9210 {
-  --_1j5zl920: 0.2;
-}
-._1j5zl9214 {
-  --_1j5zl920: 0.3;
-}
 ._1j5zl9218 {
   --_1j5zl921: 1;
   color: rgba(255, 0, 0, var(--_1j5zl921));
-}
-._1j5zl9219 {
-  --_1j5zl921: 1;
-}
-._1j5zl921a {
-  --_1j5zl921: 0.8;
 }
 body {
   margin: 0;
@@ -66,22 +46,6 @@ body ._1j5zl921c {
     ._1j5zl92l {
       padding-top: 20px;
     }
-    ._1j5zl92p {
-      --_1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--_1j5zl920));
-    }
-    ._1j5zl92t {
-      --_1j5zl920: 1;
-    }
-    ._1j5zl92x {
-      --_1j5zl920: 0.1;
-    }
-    ._1j5zl9211 {
-      --_1j5zl920: 0.2;
-    }
-    ._1j5zl9215 {
-      --_1j5zl920: 0.3;
-    }
   }
 }
 @media screen and (min-width: 1024px) {
@@ -101,22 +65,6 @@ body ._1j5zl921c {
     ._1j5zl92m {
       padding-top: 20px;
     }
-    ._1j5zl92q {
-      --_1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--_1j5zl920));
-    }
-    ._1j5zl92u {
-      --_1j5zl920: 1;
-    }
-    ._1j5zl92y {
-      --_1j5zl920: 0.1;
-    }
-    ._1j5zl9212 {
-      --_1j5zl920: 0.2;
-    }
-    ._1j5zl9216 {
-      --_1j5zl920: 0.3;
-    }
   }
   @supports not (display: grid) {
     [data-dark-mode] ._1j5zl927 {
@@ -134,21 +82,89 @@ body ._1j5zl921c {
     [data-dark-mode] ._1j5zl92n {
       padding-top: 20px;
     }
-    [data-dark-mode] ._1j5zl92r {
-      --_1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--_1j5zl920));
+  }
+}
+@layer responsive-layer-name {
+  ._1j5zl92o {
+    --_1j5zl920: 1;
+    background: rgba(255, 0, 0, var(--_1j5zl920));
+  }
+  ._1j5zl92s {
+    --_1j5zl920: 1;
+  }
+  ._1j5zl92w {
+    --_1j5zl920: 0.1;
+  }
+  ._1j5zl9210 {
+    --_1j5zl920: 0.2;
+  }
+  ._1j5zl9214 {
+    --_1j5zl920: 0.3;
+  }
+  @media screen and (min-width: 768px) {
+    @container _1j5zl922 (min-width: 768px) {
+      ._1j5zl92p {
+        --_1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--_1j5zl920));
+      }
+      ._1j5zl92t {
+        --_1j5zl920: 1;
+      }
+      ._1j5zl92x {
+        --_1j5zl920: 0.1;
+      }
+      ._1j5zl9211 {
+        --_1j5zl920: 0.2;
+      }
+      ._1j5zl9215 {
+        --_1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] ._1j5zl92v {
-      --_1j5zl920: 1;
+  }
+  @media screen and (min-width: 1024px) {
+    @container _1j5zl922 (min-width: 1024px) {
+      ._1j5zl92q {
+        --_1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--_1j5zl920));
+      }
+      ._1j5zl92u {
+        --_1j5zl920: 1;
+      }
+      ._1j5zl92y {
+        --_1j5zl920: 0.1;
+      }
+      ._1j5zl9212 {
+        --_1j5zl920: 0.2;
+      }
+      ._1j5zl9216 {
+        --_1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] ._1j5zl92z {
-      --_1j5zl920: 0.1;
+    @supports not (display: grid) {
+      [data-dark-mode] ._1j5zl92r {
+        --_1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--_1j5zl920));
+      }
+      [data-dark-mode] ._1j5zl92v {
+        --_1j5zl920: 1;
+      }
+      [data-dark-mode] ._1j5zl92z {
+        --_1j5zl920: 0.1;
+      }
+      [data-dark-mode] ._1j5zl9213 {
+        --_1j5zl920: 0.2;
+      }
+      [data-dark-mode] ._1j5zl9217 {
+        --_1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] ._1j5zl9213 {
-      --_1j5zl920: 0.2;
-    }
-    [data-dark-mode] ._1j5zl9217 {
-      --_1j5zl920: 0.3;
-    }
+  }
+}
+@layer unconditional-layer-name {
+  ._1j5zl9219 {
+    --_1j5zl921: 1;
+  }
+  ._1j5zl921a {
+    --_1j5zl921: 0.8;
   }
 }

--- a/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-mini-css-extract--development.css
+++ b/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-mini-css-extract--development.css
@@ -1,3 +1,5 @@
+@layer responsive-layer-name;
+@layer unconditional-layer-name;
 .styles_container__3nw5tz3 {
   container-name: styles_containerName__3nw5tz2;
   container-type: size;
@@ -17,31 +19,9 @@
 .styles_paddingTop_medium_mobile__3nw5tzk {
   padding-top: 20px;
 }
-.styles_background_red_mobile__3nw5tzo {
-  --alpha__3nw5tz0: 1;
-  background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
-}
-.styles_backgroundOpacity_1_mobile__3nw5tzs {
-  --alpha__3nw5tz0: 1;
-}
-.styles_backgroundOpacity_0\.1_mobile__3nw5tzw {
-  --alpha__3nw5tz0: 0.1;
-}
-.styles_backgroundOpacity_0\.2_mobile__3nw5tz10 {
-  --alpha__3nw5tz0: 0.2;
-}
-.styles_backgroundOpacity_0\.3_mobile__3nw5tz14 {
-  --alpha__3nw5tz0: 0.3;
-}
 .styles_color_red__3nw5tz18 {
   --textAlpha__3nw5tz1: 1;
   color: rgba(255, 0, 0, var(--textAlpha__3nw5tz1));
-}
-.styles_textOpacity_1__3nw5tz19 {
-  --textAlpha__3nw5tz1: 1;
-}
-.styles_textOpacity_0\.8__3nw5tz1a {
-  --textAlpha__3nw5tz1: 0.8;
 }
 body {
   margin: 0;
@@ -66,22 +46,6 @@ body .styles__3nw5tz1c {
     .styles_paddingTop_medium_tablet__3nw5tzl {
       padding-top: 20px;
     }
-    .styles_background_red_tablet__3nw5tzp {
-      --alpha__3nw5tz0: 1;
-      background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
-    }
-    .styles_backgroundOpacity_1_tablet__3nw5tzt {
-      --alpha__3nw5tz0: 1;
-    }
-    .styles_backgroundOpacity_0\.1_tablet__3nw5tzx {
-      --alpha__3nw5tz0: 0.1;
-    }
-    .styles_backgroundOpacity_0\.2_tablet__3nw5tz11 {
-      --alpha__3nw5tz0: 0.2;
-    }
-    .styles_backgroundOpacity_0\.3_tablet__3nw5tz15 {
-      --alpha__3nw5tz0: 0.3;
-    }
   }
 }
 @media screen and (min-width: 1024px) {
@@ -101,22 +65,6 @@ body .styles__3nw5tz1c {
     .styles_paddingTop_medium_desktop__3nw5tzm {
       padding-top: 20px;
     }
-    .styles_background_red_desktop__3nw5tzq {
-      --alpha__3nw5tz0: 1;
-      background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
-    }
-    .styles_backgroundOpacity_1_desktop__3nw5tzu {
-      --alpha__3nw5tz0: 1;
-    }
-    .styles_backgroundOpacity_0\.1_desktop__3nw5tzy {
-      --alpha__3nw5tz0: 0.1;
-    }
-    .styles_backgroundOpacity_0\.2_desktop__3nw5tz12 {
-      --alpha__3nw5tz0: 0.2;
-    }
-    .styles_backgroundOpacity_0\.3_desktop__3nw5tz16 {
-      --alpha__3nw5tz0: 0.3;
-    }
   }
   @supports not (display: grid) {
     [data-dark-mode] .styles_display_flex_darkDesktop__3nw5tz7 {
@@ -134,21 +82,89 @@ body .styles__3nw5tz1c {
     [data-dark-mode] .styles_paddingTop_medium_darkDesktop__3nw5tzn {
       padding-top: 20px;
     }
-    [data-dark-mode] .styles_background_red_darkDesktop__3nw5tzr {
-      --alpha__3nw5tz0: 1;
-      background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
+  }
+}
+@layer responsive-layer-name {
+  .styles_background_red_mobile__3nw5tzo {
+    --alpha__3nw5tz0: 1;
+    background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
+  }
+  .styles_backgroundOpacity_1_mobile__3nw5tzs {
+    --alpha__3nw5tz0: 1;
+  }
+  .styles_backgroundOpacity_0\.1_mobile__3nw5tzw {
+    --alpha__3nw5tz0: 0.1;
+  }
+  .styles_backgroundOpacity_0\.2_mobile__3nw5tz10 {
+    --alpha__3nw5tz0: 0.2;
+  }
+  .styles_backgroundOpacity_0\.3_mobile__3nw5tz14 {
+    --alpha__3nw5tz0: 0.3;
+  }
+  @media screen and (min-width: 768px) {
+    @container styles_containerName__3nw5tz2 (min-width: 768px) {
+      .styles_background_red_tablet__3nw5tzp {
+        --alpha__3nw5tz0: 1;
+        background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
+      }
+      .styles_backgroundOpacity_1_tablet__3nw5tzt {
+        --alpha__3nw5tz0: 1;
+      }
+      .styles_backgroundOpacity_0\.1_tablet__3nw5tzx {
+        --alpha__3nw5tz0: 0.1;
+      }
+      .styles_backgroundOpacity_0\.2_tablet__3nw5tz11 {
+        --alpha__3nw5tz0: 0.2;
+      }
+      .styles_backgroundOpacity_0\.3_tablet__3nw5tz15 {
+        --alpha__3nw5tz0: 0.3;
+      }
     }
-    [data-dark-mode] .styles_backgroundOpacity_1_darkDesktop__3nw5tzv {
-      --alpha__3nw5tz0: 1;
+  }
+  @media screen and (min-width: 1024px) {
+    @container styles_containerName__3nw5tz2 (min-width: 1024px) {
+      .styles_background_red_desktop__3nw5tzq {
+        --alpha__3nw5tz0: 1;
+        background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
+      }
+      .styles_backgroundOpacity_1_desktop__3nw5tzu {
+        --alpha__3nw5tz0: 1;
+      }
+      .styles_backgroundOpacity_0\.1_desktop__3nw5tzy {
+        --alpha__3nw5tz0: 0.1;
+      }
+      .styles_backgroundOpacity_0\.2_desktop__3nw5tz12 {
+        --alpha__3nw5tz0: 0.2;
+      }
+      .styles_backgroundOpacity_0\.3_desktop__3nw5tz16 {
+        --alpha__3nw5tz0: 0.3;
+      }
     }
-    [data-dark-mode] .styles_backgroundOpacity_0\.1_darkDesktop__3nw5tzz {
-      --alpha__3nw5tz0: 0.1;
+    @supports not (display: grid) {
+      [data-dark-mode] .styles_background_red_darkDesktop__3nw5tzr {
+        --alpha__3nw5tz0: 1;
+        background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
+      }
+      [data-dark-mode] .styles_backgroundOpacity_1_darkDesktop__3nw5tzv {
+        --alpha__3nw5tz0: 1;
+      }
+      [data-dark-mode] .styles_backgroundOpacity_0\.1_darkDesktop__3nw5tzz {
+        --alpha__3nw5tz0: 0.1;
+      }
+      [data-dark-mode] .styles_backgroundOpacity_0\.2_darkDesktop__3nw5tz13 {
+        --alpha__3nw5tz0: 0.2;
+      }
+      [data-dark-mode] .styles_backgroundOpacity_0\.3_darkDesktop__3nw5tz17 {
+        --alpha__3nw5tz0: 0.3;
+      }
     }
-    [data-dark-mode] .styles_backgroundOpacity_0\.2_darkDesktop__3nw5tz13 {
-      --alpha__3nw5tz0: 0.2;
-    }
-    [data-dark-mode] .styles_backgroundOpacity_0\.3_darkDesktop__3nw5tz17 {
-      --alpha__3nw5tz0: 0.3;
-    }
+  }
+}
+@layer unconditional-layer-name {
+  .styles_textOpacity_1__3nw5tz19 {
+    --textAlpha__3nw5tz1: 1;
+  }
+  .styles_textOpacity_0\.8__3nw5tz1a {
+    --textAlpha__3nw5tz1: 0.8;
   }
 }

--- a/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-mini-css-extract--production.css
+++ b/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-mini-css-extract--production.css
@@ -1,3 +1,5 @@
+@layer responsive-layer-name;
+@layer unconditional-layer-name;
 ._3nw5tz3 {
   container-name: _3nw5tz2;
   container-type: size;
@@ -17,31 +19,9 @@
 ._3nw5tzk {
   padding-top: 20px;
 }
-._3nw5tzo {
-  --_3nw5tz0: 1;
-  background: rgba(255, 0, 0, var(--_3nw5tz0));
-}
-._3nw5tzs {
-  --_3nw5tz0: 1;
-}
-._3nw5tzw {
-  --_3nw5tz0: 0.1;
-}
-._3nw5tz10 {
-  --_3nw5tz0: 0.2;
-}
-._3nw5tz14 {
-  --_3nw5tz0: 0.3;
-}
 ._3nw5tz18 {
   --_3nw5tz1: 1;
   color: rgba(255, 0, 0, var(--_3nw5tz1));
-}
-._3nw5tz19 {
-  --_3nw5tz1: 1;
-}
-._3nw5tz1a {
-  --_3nw5tz1: 0.8;
 }
 body {
   margin: 0;
@@ -66,22 +46,6 @@ body ._3nw5tz1c {
     ._3nw5tzl {
       padding-top: 20px;
     }
-    ._3nw5tzp {
-      --_3nw5tz0: 1;
-      background: rgba(255, 0, 0, var(--_3nw5tz0));
-    }
-    ._3nw5tzt {
-      --_3nw5tz0: 1;
-    }
-    ._3nw5tzx {
-      --_3nw5tz0: 0.1;
-    }
-    ._3nw5tz11 {
-      --_3nw5tz0: 0.2;
-    }
-    ._3nw5tz15 {
-      --_3nw5tz0: 0.3;
-    }
   }
 }
 @media screen and (min-width: 1024px) {
@@ -101,22 +65,6 @@ body ._3nw5tz1c {
     ._3nw5tzm {
       padding-top: 20px;
     }
-    ._3nw5tzq {
-      --_3nw5tz0: 1;
-      background: rgba(255, 0, 0, var(--_3nw5tz0));
-    }
-    ._3nw5tzu {
-      --_3nw5tz0: 1;
-    }
-    ._3nw5tzy {
-      --_3nw5tz0: 0.1;
-    }
-    ._3nw5tz12 {
-      --_3nw5tz0: 0.2;
-    }
-    ._3nw5tz16 {
-      --_3nw5tz0: 0.3;
-    }
   }
   @supports not (display: grid) {
     [data-dark-mode] ._3nw5tz7 {
@@ -134,21 +82,89 @@ body ._3nw5tz1c {
     [data-dark-mode] ._3nw5tzn {
       padding-top: 20px;
     }
-    [data-dark-mode] ._3nw5tzr {
-      --_3nw5tz0: 1;
-      background: rgba(255, 0, 0, var(--_3nw5tz0));
+  }
+}
+@layer responsive-layer-name {
+  ._3nw5tzo {
+    --_3nw5tz0: 1;
+    background: rgba(255, 0, 0, var(--_3nw5tz0));
+  }
+  ._3nw5tzs {
+    --_3nw5tz0: 1;
+  }
+  ._3nw5tzw {
+    --_3nw5tz0: 0.1;
+  }
+  ._3nw5tz10 {
+    --_3nw5tz0: 0.2;
+  }
+  ._3nw5tz14 {
+    --_3nw5tz0: 0.3;
+  }
+  @media screen and (min-width: 768px) {
+    @container _3nw5tz2 (min-width: 768px) {
+      ._3nw5tzp {
+        --_3nw5tz0: 1;
+        background: rgba(255, 0, 0, var(--_3nw5tz0));
+      }
+      ._3nw5tzt {
+        --_3nw5tz0: 1;
+      }
+      ._3nw5tzx {
+        --_3nw5tz0: 0.1;
+      }
+      ._3nw5tz11 {
+        --_3nw5tz0: 0.2;
+      }
+      ._3nw5tz15 {
+        --_3nw5tz0: 0.3;
+      }
     }
-    [data-dark-mode] ._3nw5tzv {
-      --_3nw5tz0: 1;
+  }
+  @media screen and (min-width: 1024px) {
+    @container _3nw5tz2 (min-width: 1024px) {
+      ._3nw5tzq {
+        --_3nw5tz0: 1;
+        background: rgba(255, 0, 0, var(--_3nw5tz0));
+      }
+      ._3nw5tzu {
+        --_3nw5tz0: 1;
+      }
+      ._3nw5tzy {
+        --_3nw5tz0: 0.1;
+      }
+      ._3nw5tz12 {
+        --_3nw5tz0: 0.2;
+      }
+      ._3nw5tz16 {
+        --_3nw5tz0: 0.3;
+      }
     }
-    [data-dark-mode] ._3nw5tzz {
-      --_3nw5tz0: 0.1;
+    @supports not (display: grid) {
+      [data-dark-mode] ._3nw5tzr {
+        --_3nw5tz0: 1;
+        background: rgba(255, 0, 0, var(--_3nw5tz0));
+      }
+      [data-dark-mode] ._3nw5tzv {
+        --_3nw5tz0: 1;
+      }
+      [data-dark-mode] ._3nw5tzz {
+        --_3nw5tz0: 0.1;
+      }
+      [data-dark-mode] ._3nw5tz13 {
+        --_3nw5tz0: 0.2;
+      }
+      [data-dark-mode] ._3nw5tz17 {
+        --_3nw5tz0: 0.3;
+      }
     }
-    [data-dark-mode] ._3nw5tz13 {
-      --_3nw5tz0: 0.2;
-    }
-    [data-dark-mode] ._3nw5tz17 {
-      --_3nw5tz0: 0.3;
-    }
+  }
+}
+@layer unconditional-layer-name {
+  ._3nw5tz19 {
+    --_3nw5tz1: 1;
+  }
+  ._3nw5tz1a {
+    --_3nw5tz1: 0.8;
   }
 }

--- a/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-parcel--development.css
+++ b/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-parcel--development.css
@@ -1,3 +1,5 @@
+@layer responsive-layer-name;
+@layer unconditional-layer-name;
 .styles_container__3nw5tz3 {
   container: styles_containerName__3nw5tz2/size;
 }
@@ -16,31 +18,9 @@
 .styles_paddingTop_medium_mobile__3nw5tzk {
   padding-top: 20px;
 }
-.styles_background_red_mobile__3nw5tzo {
-  --alpha__3nw5tz0: 1;
-  background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
-}
-.styles_backgroundOpacity_1_mobile__3nw5tzs {
-  --alpha__3nw5tz0: 1;
-}
-.styles_backgroundOpacity_0\.1_mobile__3nw5tzw {
-  --alpha__3nw5tz0: 0.1;
-}
-.styles_backgroundOpacity_0\.2_mobile__3nw5tz10 {
-  --alpha__3nw5tz0: 0.2;
-}
-.styles_backgroundOpacity_0\.3_mobile__3nw5tz14 {
-  --alpha__3nw5tz0: 0.3;
-}
 .styles_color_red__3nw5tz18 {
   --textAlpha__3nw5tz1: 1;
   color: rgba(255, 0, 0, var(--textAlpha__3nw5tz1));
-}
-.styles_textOpacity_1__3nw5tz19 {
-  --textAlpha__3nw5tz1: 1;
-}
-.styles_textOpacity_0\.8__3nw5tz1a {
-  --textAlpha__3nw5tz1: 0.8;
 }
 body {
   margin: 0;
@@ -65,22 +45,6 @@ body .styles__3nw5tz1c {
     .styles_paddingTop_medium_tablet__3nw5tzl {
       padding-top: 20px;
     }
-    .styles_background_red_tablet__3nw5tzp {
-      --alpha__3nw5tz0: 1;
-      background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
-    }
-    .styles_backgroundOpacity_1_tablet__3nw5tzt {
-      --alpha__3nw5tz0: 1;
-    }
-    .styles_backgroundOpacity_0\.1_tablet__3nw5tzx {
-      --alpha__3nw5tz0: 0.1;
-    }
-    .styles_backgroundOpacity_0\.2_tablet__3nw5tz11 {
-      --alpha__3nw5tz0: 0.2;
-    }
-    .styles_backgroundOpacity_0\.3_tablet__3nw5tz15 {
-      --alpha__3nw5tz0: 0.3;
-    }
   }
 }
 @media screen and (min-width: 1024px) {
@@ -100,22 +64,6 @@ body .styles__3nw5tz1c {
     .styles_paddingTop_medium_desktop__3nw5tzm {
       padding-top: 20px;
     }
-    .styles_background_red_desktop__3nw5tzq {
-      --alpha__3nw5tz0: 1;
-      background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
-    }
-    .styles_backgroundOpacity_1_desktop__3nw5tzu {
-      --alpha__3nw5tz0: 1;
-    }
-    .styles_backgroundOpacity_0\.1_desktop__3nw5tzy {
-      --alpha__3nw5tz0: 0.1;
-    }
-    .styles_backgroundOpacity_0\.2_desktop__3nw5tz12 {
-      --alpha__3nw5tz0: 0.2;
-    }
-    .styles_backgroundOpacity_0\.3_desktop__3nw5tz16 {
-      --alpha__3nw5tz0: 0.3;
-    }
   }
   @supports not (display: grid) {
     [data-dark-mode] .styles_display_flex_darkDesktop__3nw5tz7 {
@@ -133,21 +81,89 @@ body .styles__3nw5tz1c {
     [data-dark-mode] .styles_paddingTop_medium_darkDesktop__3nw5tzn {
       padding-top: 20px;
     }
-    [data-dark-mode] .styles_background_red_darkDesktop__3nw5tzr {
-      --alpha__3nw5tz0: 1;
-      background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
+  }
+}
+@layer responsive-layer-name {
+  .styles_background_red_mobile__3nw5tzo {
+    --alpha__3nw5tz0: 1;
+    background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
+  }
+  .styles_backgroundOpacity_1_mobile__3nw5tzs {
+    --alpha__3nw5tz0: 1;
+  }
+  .styles_backgroundOpacity_0\.1_mobile__3nw5tzw {
+    --alpha__3nw5tz0: 0.1;
+  }
+  .styles_backgroundOpacity_0\.2_mobile__3nw5tz10 {
+    --alpha__3nw5tz0: 0.2;
+  }
+  .styles_backgroundOpacity_0\.3_mobile__3nw5tz14 {
+    --alpha__3nw5tz0: 0.3;
+  }
+  @media screen and (min-width: 768px) {
+    @container styles_containerName__3nw5tz2 (min-width: 768px) {
+      .styles_background_red_tablet__3nw5tzp {
+        --alpha__3nw5tz0: 1;
+        background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
+      }
+      .styles_backgroundOpacity_1_tablet__3nw5tzt {
+        --alpha__3nw5tz0: 1;
+      }
+      .styles_backgroundOpacity_0\.1_tablet__3nw5tzx {
+        --alpha__3nw5tz0: 0.1;
+      }
+      .styles_backgroundOpacity_0\.2_tablet__3nw5tz11 {
+        --alpha__3nw5tz0: 0.2;
+      }
+      .styles_backgroundOpacity_0\.3_tablet__3nw5tz15 {
+        --alpha__3nw5tz0: 0.3;
+      }
     }
-    [data-dark-mode] .styles_backgroundOpacity_1_darkDesktop__3nw5tzv {
-      --alpha__3nw5tz0: 1;
+  }
+  @media screen and (min-width: 1024px) {
+    @container styles_containerName__3nw5tz2 (min-width: 1024px) {
+      .styles_background_red_desktop__3nw5tzq {
+        --alpha__3nw5tz0: 1;
+        background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
+      }
+      .styles_backgroundOpacity_1_desktop__3nw5tzu {
+        --alpha__3nw5tz0: 1;
+      }
+      .styles_backgroundOpacity_0\.1_desktop__3nw5tzy {
+        --alpha__3nw5tz0: 0.1;
+      }
+      .styles_backgroundOpacity_0\.2_desktop__3nw5tz12 {
+        --alpha__3nw5tz0: 0.2;
+      }
+      .styles_backgroundOpacity_0\.3_desktop__3nw5tz16 {
+        --alpha__3nw5tz0: 0.3;
+      }
     }
-    [data-dark-mode] .styles_backgroundOpacity_0\.1_darkDesktop__3nw5tzz {
-      --alpha__3nw5tz0: 0.1;
+    @supports not (display: grid) {
+      [data-dark-mode] .styles_background_red_darkDesktop__3nw5tzr {
+        --alpha__3nw5tz0: 1;
+        background: rgba(255, 0, 0, var(--alpha__3nw5tz0));
+      }
+      [data-dark-mode] .styles_backgroundOpacity_1_darkDesktop__3nw5tzv {
+        --alpha__3nw5tz0: 1;
+      }
+      [data-dark-mode] .styles_backgroundOpacity_0\.1_darkDesktop__3nw5tzz {
+        --alpha__3nw5tz0: 0.1;
+      }
+      [data-dark-mode] .styles_backgroundOpacity_0\.2_darkDesktop__3nw5tz13 {
+        --alpha__3nw5tz0: 0.2;
+      }
+      [data-dark-mode] .styles_backgroundOpacity_0\.3_darkDesktop__3nw5tz17 {
+        --alpha__3nw5tz0: 0.3;
+      }
     }
-    [data-dark-mode] .styles_backgroundOpacity_0\.2_darkDesktop__3nw5tz13 {
-      --alpha__3nw5tz0: 0.2;
-    }
-    [data-dark-mode] .styles_backgroundOpacity_0\.3_darkDesktop__3nw5tz17 {
-      --alpha__3nw5tz0: 0.3;
-    }
+  }
+}
+@layer unconditional-layer-name {
+  .styles_textOpacity_1__3nw5tz19 {
+    --textAlpha__3nw5tz1: 1;
+  }
+  .styles_textOpacity_0\.8__3nw5tz1a {
+    --textAlpha__3nw5tz1: 0.8;
   }
 }

--- a/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-parcel--production.css
+++ b/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-parcel--production.css
@@ -1,3 +1,5 @@
+@layer responsive-layer-name;
+@layer unconditional-layer-name;
 ._3nw5tz3 {
   container: _3nw5tz2/size;
 }
@@ -16,31 +18,9 @@
 ._3nw5tzk {
   padding-top: 20px;
 }
-._3nw5tzo {
-  --_3nw5tz0: 1;
-  background: rgba(255, 0, 0, var(--_3nw5tz0));
-}
-._3nw5tzs {
-  --_3nw5tz0: 1;
-}
-._3nw5tzw {
-  --_3nw5tz0: 0.1;
-}
-._3nw5tz10 {
-  --_3nw5tz0: 0.2;
-}
-._3nw5tz14 {
-  --_3nw5tz0: 0.3;
-}
 ._3nw5tz18 {
   --_3nw5tz1: 1;
   color: rgba(255, 0, 0, var(--_3nw5tz1));
-}
-._3nw5tz19 {
-  --_3nw5tz1: 1;
-}
-._3nw5tz1a {
-  --_3nw5tz1: 0.8;
 }
 body {
   margin: 0;
@@ -65,22 +45,6 @@ body ._3nw5tz1c {
     ._3nw5tzl {
       padding-top: 20px;
     }
-    ._3nw5tzp {
-      --_3nw5tz0: 1;
-      background: rgba(255, 0, 0, var(--_3nw5tz0));
-    }
-    ._3nw5tzt {
-      --_3nw5tz0: 1;
-    }
-    ._3nw5tzx {
-      --_3nw5tz0: 0.1;
-    }
-    ._3nw5tz11 {
-      --_3nw5tz0: 0.2;
-    }
-    ._3nw5tz15 {
-      --_3nw5tz0: 0.3;
-    }
   }
 }
 @media screen and (min-width: 1024px) {
@@ -100,22 +64,6 @@ body ._3nw5tz1c {
     ._3nw5tzm {
       padding-top: 20px;
     }
-    ._3nw5tzq {
-      --_3nw5tz0: 1;
-      background: rgba(255, 0, 0, var(--_3nw5tz0));
-    }
-    ._3nw5tzu {
-      --_3nw5tz0: 1;
-    }
-    ._3nw5tzy {
-      --_3nw5tz0: 0.1;
-    }
-    ._3nw5tz12 {
-      --_3nw5tz0: 0.2;
-    }
-    ._3nw5tz16 {
-      --_3nw5tz0: 0.3;
-    }
   }
   @supports not (display: grid) {
     [data-dark-mode] ._3nw5tz7 {
@@ -133,21 +81,89 @@ body ._3nw5tz1c {
     [data-dark-mode] ._3nw5tzn {
       padding-top: 20px;
     }
-    [data-dark-mode] ._3nw5tzr {
-      --_3nw5tz0: 1;
-      background: rgba(255, 0, 0, var(--_3nw5tz0));
+  }
+}
+@layer responsive-layer-name {
+  ._3nw5tzo {
+    --_3nw5tz0: 1;
+    background: rgba(255, 0, 0, var(--_3nw5tz0));
+  }
+  ._3nw5tzs {
+    --_3nw5tz0: 1;
+  }
+  ._3nw5tzw {
+    --_3nw5tz0: 0.1;
+  }
+  ._3nw5tz10 {
+    --_3nw5tz0: 0.2;
+  }
+  ._3nw5tz14 {
+    --_3nw5tz0: 0.3;
+  }
+  @media screen and (min-width: 768px) {
+    @container _3nw5tz2 (min-width:768px) {
+      ._3nw5tzp {
+        --_3nw5tz0: 1;
+        background: rgba(255, 0, 0, var(--_3nw5tz0));
+      }
+      ._3nw5tzt {
+        --_3nw5tz0: 1;
+      }
+      ._3nw5tzx {
+        --_3nw5tz0: 0.1;
+      }
+      ._3nw5tz11 {
+        --_3nw5tz0: 0.2;
+      }
+      ._3nw5tz15 {
+        --_3nw5tz0: 0.3;
+      }
     }
-    [data-dark-mode] ._3nw5tzv {
-      --_3nw5tz0: 1;
+  }
+  @media screen and (min-width: 1024px) {
+    @container _3nw5tz2 (min-width:1024px) {
+      ._3nw5tzq {
+        --_3nw5tz0: 1;
+        background: rgba(255, 0, 0, var(--_3nw5tz0));
+      }
+      ._3nw5tzu {
+        --_3nw5tz0: 1;
+      }
+      ._3nw5tzy {
+        --_3nw5tz0: 0.1;
+      }
+      ._3nw5tz12 {
+        --_3nw5tz0: 0.2;
+      }
+      ._3nw5tz16 {
+        --_3nw5tz0: 0.3;
+      }
     }
-    [data-dark-mode] ._3nw5tzz {
-      --_3nw5tz0: 0.1;
+    @supports not (display: grid) {
+      [data-dark-mode] ._3nw5tzr {
+        --_3nw5tz0: 1;
+        background: rgba(255, 0, 0, var(--_3nw5tz0));
+      }
+      [data-dark-mode] ._3nw5tzv {
+        --_3nw5tz0: 1;
+      }
+      [data-dark-mode] ._3nw5tzz {
+        --_3nw5tz0: 0.1;
+      }
+      [data-dark-mode] ._3nw5tz13 {
+        --_3nw5tz0: 0.2;
+      }
+      [data-dark-mode] ._3nw5tz17 {
+        --_3nw5tz0: 0.3;
+      }
     }
-    [data-dark-mode] ._3nw5tz13 {
-      --_3nw5tz0: 0.2;
-    }
-    [data-dark-mode] ._3nw5tz17 {
-      --_3nw5tz0: 0.3;
-    }
+  }
+}
+@layer unconditional-layer-name {
+  ._3nw5tz19 {
+    --_3nw5tz1: 1;
+  }
+  ._3nw5tz1a {
+    --_3nw5tz1: 0.8;
   }
 }

--- a/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-vite--production.css
+++ b/tests/e2e/sprinkles.playwright.ts-snapshots/sprinkles-vite--production.css
@@ -1,3 +1,5 @@
+@layer responsive-layer-name;
+@layer unconditional-layer-name;
 ._1j5zl923 {
   container-name: _1j5zl922;
   container-type: size;
@@ -17,31 +19,9 @@
 ._1j5zl92k {
   padding-top: 20px;
 }
-._1j5zl92o {
-  --_1j5zl920: 1;
-  background: rgba(255, 0, 0, var(--_1j5zl920));
-}
-._1j5zl92s {
-  --_1j5zl920: 1;
-}
-._1j5zl92w {
-  --_1j5zl920: 0.1;
-}
-._1j5zl9210 {
-  --_1j5zl920: 0.2;
-}
-._1j5zl9214 {
-  --_1j5zl920: 0.3;
-}
 ._1j5zl9218 {
   --_1j5zl921: 1;
   color: rgba(255, 0, 0, var(--_1j5zl921));
-}
-._1j5zl9219 {
-  --_1j5zl921: 1;
-}
-._1j5zl921a {
-  --_1j5zl921: 0.8;
 }
 body {
   margin: 0;
@@ -66,22 +46,6 @@ body ._1j5zl921c {
     ._1j5zl92l {
       padding-top: 20px;
     }
-    ._1j5zl92p {
-      --_1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--_1j5zl920));
-    }
-    ._1j5zl92t {
-      --_1j5zl920: 1;
-    }
-    ._1j5zl92x {
-      --_1j5zl920: 0.1;
-    }
-    ._1j5zl9211 {
-      --_1j5zl920: 0.2;
-    }
-    ._1j5zl9215 {
-      --_1j5zl920: 0.3;
-    }
   }
 }
 @media screen and (min-width: 1024px) {
@@ -101,22 +65,6 @@ body ._1j5zl921c {
     ._1j5zl92m {
       padding-top: 20px;
     }
-    ._1j5zl92q {
-      --_1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--_1j5zl920));
-    }
-    ._1j5zl92u {
-      --_1j5zl920: 1;
-    }
-    ._1j5zl92y {
-      --_1j5zl920: 0.1;
-    }
-    ._1j5zl9212 {
-      --_1j5zl920: 0.2;
-    }
-    ._1j5zl9216 {
-      --_1j5zl920: 0.3;
-    }
   }
   @supports not (display: grid) {
     [data-dark-mode] ._1j5zl927 {
@@ -134,21 +82,89 @@ body ._1j5zl921c {
     [data-dark-mode] ._1j5zl92n {
       padding-top: 20px;
     }
-    [data-dark-mode] ._1j5zl92r {
-      --_1j5zl920: 1;
-      background: rgba(255, 0, 0, var(--_1j5zl920));
+  }
+}
+@layer responsive-layer-name {
+  ._1j5zl92o {
+    --_1j5zl920: 1;
+    background: rgba(255, 0, 0, var(--_1j5zl920));
+  }
+  ._1j5zl92s {
+    --_1j5zl920: 1;
+  }
+  ._1j5zl92w {
+    --_1j5zl920: 0.1;
+  }
+  ._1j5zl9210 {
+    --_1j5zl920: 0.2;
+  }
+  ._1j5zl9214 {
+    --_1j5zl920: 0.3;
+  }
+  @media screen and (min-width: 768px) {
+    @container _1j5zl922 (min-width: 768px) {
+      ._1j5zl92p {
+        --_1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--_1j5zl920));
+      }
+      ._1j5zl92t {
+        --_1j5zl920: 1;
+      }
+      ._1j5zl92x {
+        --_1j5zl920: 0.1;
+      }
+      ._1j5zl9211 {
+        --_1j5zl920: 0.2;
+      }
+      ._1j5zl9215 {
+        --_1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] ._1j5zl92v {
-      --_1j5zl920: 1;
+  }
+  @media screen and (min-width: 1024px) {
+    @container _1j5zl922 (min-width: 1024px) {
+      ._1j5zl92q {
+        --_1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--_1j5zl920));
+      }
+      ._1j5zl92u {
+        --_1j5zl920: 1;
+      }
+      ._1j5zl92y {
+        --_1j5zl920: 0.1;
+      }
+      ._1j5zl9212 {
+        --_1j5zl920: 0.2;
+      }
+      ._1j5zl9216 {
+        --_1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] ._1j5zl92z {
-      --_1j5zl920: 0.1;
+    @supports not (display: grid) {
+      [data-dark-mode] ._1j5zl92r {
+        --_1j5zl920: 1;
+        background: rgba(255, 0, 0, var(--_1j5zl920));
+      }
+      [data-dark-mode] ._1j5zl92v {
+        --_1j5zl920: 1;
+      }
+      [data-dark-mode] ._1j5zl92z {
+        --_1j5zl920: 0.1;
+      }
+      [data-dark-mode] ._1j5zl9213 {
+        --_1j5zl920: 0.2;
+      }
+      [data-dark-mode] ._1j5zl9217 {
+        --_1j5zl920: 0.3;
+      }
     }
-    [data-dark-mode] ._1j5zl9213 {
-      --_1j5zl920: 0.2;
-    }
-    [data-dark-mode] ._1j5zl9217 {
-      --_1j5zl920: 0.3;
-    }
+  }
+}
+@layer unconditional-layer-name {
+  ._1j5zl9219 {
+    --_1j5zl921: 1;
+  }
+  ._1j5zl921a {
+    --_1j5zl921: 0.8;
   }
 }


### PR DESCRIPTION
This PR adds an optional `@layer` property to the options passed to `defineProperties`.

Example usage:

```ts
// sprinkles.css.ts
import { defineProperties } from '@vanilla-extract/sprinkles';
import { layer } from '@vanilla-extract/css';

export const sprinklesLayer = layer();

const properties = defineProperties({
  '@layer': sprinklesLayer,
  // etc.
});
```