### PR TITLE
vite: Fix stale CSS emit by invalidating all modules

### DIFF
--- a/.changeset/fluffy-knives-dress.md
+++ b/.changeset/fluffy-knives-dress.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Fix stale emitted CSS in SSR mode by invalidating all modules related to a file

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -216,16 +216,18 @@ export function vanillaExtractPlugin({
             cssMap.get(absoluteId) !== source
           ) {
             const { moduleGraph } = server;
-            const [module] = Array.from(
+            const modules = Array.from(
               moduleGraph.getModulesByFile(absoluteId) || [],
             );
 
-            if (module) {
-              moduleGraph.invalidateModule(module);
+            for (const module of modules) {
+              if (module) {
+                moduleGraph.invalidateModule(module);
 
-              // Vite uses this timestamp to add `?t=` query string automatically for HMR.
-              module.lastHMRTimestamp =
-                (module as any).lastInvalidationTimestamp || Date.now();
+                // Vite uses this timestamp to add `?t=` query string automatically for HMR.
+                module.lastHMRTimestamp =
+                  (module as any).lastInvalidationTimestamp || Date.now();
+              }
             }
 
             server.ws.send({


### PR DESCRIPTION
Sort of addresses #925. [As mentioned in the issue](https://github.com/vanilla-extract-css/vanilla-extract/pull/925#issuecomment-1494243530), sometimes a single file ID is associated with more than 1 module, but we were only only invalidating the first module when a change in CSS was detected. This resulted in stale CSS that would only update with a server restart.

In the case of qwik, 2 modules are returned during the CSS invalidation step, one that matches the file ID, and a 2nd one that has the `?direct` param on it, which I think has something to do with vite's SSR mode, though I'm not particularly knowledgeable on that front, and I can't find any explicit documentation about it. I do however believe that this new behaviour of invalidating all modules is more correct than before.

This fix results in a page reload and up-to-date CSS, but doesn't go as far as to implement CSS HMR, nor do I think it is the responsibility of the VE plugin to do so.