### PR TITLE
rollup-plugin: fix caching in watch mode

### DIFF
--- a/.changeset/healthy-turtles-help.md
+++ b/.changeset/healthy-turtles-help.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/rollup-plugin': patch
+---
+
+Fix emitting assets when in watch mode (#1076)

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -69,12 +69,12 @@ export function vanillaExtractPlugin({
         external: true,
         meta: {
           css: source,
-        }
+        },
       };
     },
     // Emit .css assets
     moduleParsed(moduleInfo) {
-      moduleInfo.importedIdResolutions.forEach(resolution => {
+      moduleInfo.importedIdResolutions.forEach((resolution) => {
         if (resolution.meta.css) {
           resolution.meta.assetId = this.emitFile({
             type: 'asset',
@@ -93,7 +93,9 @@ export function vanillaExtractPlugin({
           return codeResult;
         }
         const assetPath = this.getFileName(moduleInfo?.meta.assetId);
-        const relativeAssetPath = `./${normalize(relative(chunkPath, assetPath))}`;
+        const relativeAssetPath = `./${normalize(
+          relative(chunkPath, assetPath),
+        )}`;
         return codeResult.replace(importPath, relativeAssetPath);
       }, code);
 


### PR DESCRIPTION
I have changed the asset emitting logic significantly.

Before, we emitted css assets in the `resolveId` stage and kept track of emitted assets in a plugin-local variable (`emittedFiles`), clearing them all on a rebuild. However, emitted css assets are external and not part of the module graph and thus not cached by rollup. Previously emitted assets are cleared on rebuilds and we didn't re-emit them (because on rebuild only the changed files get transformed/resolved).

I changed this to use the rollup caching mechanism by attaching the css output to the module's `meta` during `resolveId` and only emitting the actual css assets in the `moduleParsed` stage. Module info is cached between rebuilds, so this way we can access previous build outputs.

Fixes: #1076
(Also a better fix for #691. What I did in #693 only works in some cases.)