### PR TITLE
fix(vite-plugin): Fix HMR in Windows

### DIFF
--- a/.changeset/pink-students-grab.md
+++ b/.changeset/pink-students-grab.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Fix HMR in Windows by normalizing paths from `watchFiles`

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -179,7 +179,7 @@ export function vanillaExtractPlugin({
       for (const file of watchFiles) {
         // In start mode, we need to prevent the file from rewatching itself.
         // If it's a `build --watch`, it needs to watch everything.
-        if (config.command === 'build' || file !== validId) {
+        if (config.command === 'build' || normalizePath(file) !== validId) {
           this.addWatchFile(file);
         }
       }


### PR DESCRIPTION
According [to Vite docs](https://vitejs.dev/guide/api-plugin.html#path-normalization), resolved ids will have `/` as directory separators.
But `watchFiles`, returned by the `compile` function, have platform-specific directory separators (`\` in Windows), so comparing file and module id (`file === validId`) will always be false in Windows and module itself will be added to watched files (which breaks HMR and leads to page reload).

So, by normalizing paths from `watchFiles` (using POSIX directory separators instead of platform-specific), module will be correctly ignored from adding to watched files and HMR will work.