### PR TITLE
Use the resolved Next.js config in `next-plugin`

### DIFF
--- a/.changeset/shiny-crews-rescue.md
+++ b/.changeset/shiny-crews-rescue.md
@@ -1,0 +1,5 @@
+---
+"@vanilla-extract/next-plugin": patch
+---
+
+Use the resolved Next.js config in `next-plugin`

--- a/packages/next-plugin/src/index.ts
+++ b/packages/next-plugin/src/index.ts
@@ -23,7 +23,7 @@ export const createVanillaExtractPlugin =
   (nextConfig: NextConfig = {}): NextConfig =>
     Object.assign({}, nextConfig, {
       webpack(config: any, options: any) {
-        const { dir, dev, isServer } = options;
+        const { dir, dev, isServer, config: resolvedNextConfig } = options;
 
         const cssRules = config.module.rules.find(
           (rule: any) =>
@@ -45,10 +45,10 @@ export const createVanillaExtractPlugin =
               isClient: !isServer,
               isServer,
               isDevelopment: dev,
-              future: nextConfig.future || {},
-              experimental: nextConfig.experimental || {},
+              future: resolvedNextConfig.future || {},
+              experimental: resolvedNextConfig.experimental || {},
               // @ts-ignore -- 'appDir' config is in beta
-              hasAppDir: nextConfig.experimental?.appDir,
+              hasAppDir: resolvedNextConfig.experimental?.appDir,
             } as any,
             () => lazyPostCSS(dir, getSupportedBrowsers(dir, dev), undefined),
             [],


### PR DESCRIPTION
Currently we're getting experimental flags (such as `appDir`) from the user config, `nextConfig`. This PR changes it to use the `options.config` argument of the `webpack` function instead. It's similar to `nextConfig` but it has all fallback values resolved as `appDir` now defaults to `true`.

Fixes #1087.