### PR TITLE
Allow `fontFace` to accept array of font face rules

### DIFF
--- a/.changeset/fontFace-array.md
+++ b/.changeset/fontFace-array.md
@@ -1,0 +1,26 @@
+---
+'@vanilla-extract/css': minor
+---
+
+Supports passing multiple font face rules to `fontFace`
+
+**Example usage**
+
+```ts
+import { fontFace, style } from '@vanilla-extract/css';
+
+const gentium = fontFace([
+  {
+    src: 'local("Gentium")',
+    fontWeight: 'normal',
+  },
+  {
+    src: 'local("Gentium Bold")',
+    fontWeight: 'bold',
+  },
+]);
+
+export const font = style({
+  fontFamily: gentium,
+});
+```

--- a/packages/css/src/style.ts
+++ b/packages/css/src/style.ts
@@ -101,35 +101,22 @@ export function fontFace(
     quotes: 'double',
   })}"`;
 
-  const fontFamilyError = outdent`
-  This function creates and returns a hashed font-family name, so the "fontFamily" property should not be provided.
+  const rules = Array.isArray(rule) ? rule : [rule];
 
-  If you'd like to define a globally scoped custom font, you can use the "globalFontFace" function instead.
-`;
-
-  if (Array.isArray(rule)) {
-    for (const singleRule of rule) {
-      if ('fontFamily' in singleRule) {
-        throw new Error(fontFamilyError);
-      }
-
-      appendCss(
-        { type: 'fontFace', rule: { ...singleRule, fontFamily } },
-        getFileScope(),
-      );
+  for (const singleRule of rules) {
+    if ('fontFamily' in singleRule) {
+      throw new Error(outdent`
+      This function creates and returns a hashed font-family name, so the "fontFamily" property should not be provided.
+    
+      If you'd like to define a globally scoped custom font, you can use the "globalFontFace" function instead.
+    `);
     }
 
-    return fontFamily;
+    appendCss(
+      { type: 'fontFace', rule: { ...singleRule, fontFamily } },
+      getFileScope(),
+    );
   }
-
-  if ('fontFamily' in rule) {
-    throw new Error(fontFamilyError);
-  }
-
-  appendCss(
-    { type: 'fontFace', rule: { ...rule, fontFamily } },
-    getFileScope(),
-  );
 
   return fontFamily;
 }

--- a/packages/css/src/style.ts
+++ b/packages/css/src/style.ts
@@ -93,19 +93,37 @@ export function globalStyle(selector: string, rule: GlobalStyleRule) {
   appendCss({ type: 'global', selector, rule }, getFileScope());
 }
 
-export function fontFace(rule: FontFaceRule, debugId?: string) {
+export function fontFace(
+  rule: FontFaceRule | FontFaceRule[],
+  debugId?: string,
+) {
   const fontFamily = `"${cssesc(generateIdentifier(debugId), {
     quotes: 'double',
   })}"`;
 
+  const fontFamilyError = outdent`
+  This function creates and returns a hashed font-family name, so the "fontFamily" property should not be provided.
+
+  If you'd like to define a globally scoped custom font, you can use the "globalFontFace" function instead.
+`;
+
+  if (Array.isArray(rule)) {
+    for (const singleRule of rule) {
+      if ('fontFamily' in singleRule) {
+        throw new Error(fontFamilyError);
+      }
+
+      appendCss(
+        { type: 'fontFace', rule: { ...singleRule, fontFamily } },
+        getFileScope(),
+      );
+    }
+
+    return fontFamily;
+  }
+
   if ('fontFamily' in rule) {
-    throw new Error(
-      outdent`
-          This function creates and returns a hashed font-family name, so the "fontFamily" property should not be provided.
-  
-          If you'd like to define a globally scoped custom font, you can use the "globalFontFace" function instead.
-        `,
-    );
+    throw new Error(fontFamilyError);
   }
 
   appendCss(

--- a/packages/css/src/transformCss.test.ts
+++ b/packages/css/src/transformCss.test.ts
@@ -1825,6 +1825,40 @@ describe('transformCss', () => {
     `);
   });
 
+  it('should handle multiple font faces of the same family', () => {
+    expect(
+      transformCss({
+        composedClassLists: [],
+        localClassNames: [],
+        cssObjs: [
+          {
+            type: 'fontFace',
+            rule: {
+              fontFamily: 'MyFont',
+              src: 'local("Helvetica")',
+            },
+          },
+          {
+            type: 'fontFace',
+            rule: {
+              fontFamily: 'MyFont',
+              src: 'local("Helvetica-Bold")',
+            },
+          },
+        ],
+      }).join('\n'),
+    ).toMatchInlineSnapshot(`
+      @font-face {
+        font-family: MyFont;
+        src: local("Helvetica");
+      }
+      @font-face {
+        font-family: MyFont;
+        src: local("Helvetica-Bold");
+      }
+    `);
+  });
+
   it('should handle multiple font faces', () => {
     expect(
       transformCss({

--- a/site/docs/api/font-face.md
+++ b/site/docs/api/font-face.md
@@ -20,3 +20,27 @@ export const font = style({
   fontFamily: comicSans
 });
 ```
+
+## Multiple Fonts with Single Family
+
+The `fontFace` function allows you to pass an array of font-face rules that may contain different rules but treat them as if they are from one font family.
+
+```ts compiled
+// text.css.ts
+import { fontFace, style } from '@vanilla-extract/css';
+
+const gentium = fontFace([
+  {
+    src: 'local("Gentium")',
+    fontWeight: 'normal',
+  },
+  {
+    src: 'local("Gentium Bold")',
+    fontWeight: 'bold',
+  },
+]);
+
+export const font = style({
+  fontFamily: gentium,
+});
+```

--- a/site/docs/api/font-face.md
+++ b/site/docs/api/font-face.md
@@ -32,15 +32,15 @@ import { fontFace, style } from '@vanilla-extract/css';
 const gentium = fontFace([
   {
     src: 'local("Gentium")',
-    fontWeight: 'normal',
+    fontWeight: 'normal'
   },
   {
     src: 'local("Gentium Bold")',
-    fontWeight: 'bold',
-  },
+    fontWeight: 'bold'
+  }
 ]);
 
 export const font = style({
-  fontFamily: gentium,
+  fontFamily: gentium
 });
 ```


### PR DESCRIPTION
This PR adds support to the `fontFace` function to accept an array of font face rules that share the same font family name.

Example usage:
```
// text.css.ts
import { fontFace, style } from '@vanilla-extract/css';

const gentium = fontFace([
  {
    src: 'local("Gentium")',
    fontWeight: 'normal',
  },
  {
    src: 'local("Gentium Bold")',
    fontWeight: 'bold',
  },
]);

export const font = style({
  fontFamily: gentium,
});

// CSS
@font-face {
  src: local("Gentium");
  font-weight: normal;
  font-family: "text_gentium__fih47p0";
}
@font-face {
  src: local("Gentium Bold");
  font-weight: bold;
  font-family: "text_gentium__fih47p0";
}
.text_font__fih47p1 {
  font-family: "text_gentium__fih47p0";
}
```