### PR TITLE
feat: export SprinklesProperties type

### DIFF
--- a/.changeset/twenty-tables-report.md
+++ b/.changeset/twenty-tables-report.md
@@ -1,0 +1,5 @@
+---
+"@vanilla-extract/sprinkles": patch
+---
+
+Export `SprinklesProperties` type

--- a/packages/sprinkles/src/index.ts
+++ b/packages/sprinkles/src/index.ts
@@ -16,7 +16,7 @@ import { SprinklesProperties, ResponsiveArrayConfig } from './types';
 export { createNormalizeValueFn, createMapValueFn } from './createUtils';
 export type { ConditionalValue, RequiredConditionalValue } from './createUtils';
 
-export type { ResponsiveArray } from './types';
+export type { ResponsiveArray, SprinklesProperties } from './types';
 
 type ConditionKey = '@media' | '@supports' | '@container' | 'selector';
 type Condition = Partial<Record<ConditionKey, string>>;


### PR DESCRIPTION
As discussed on Discord, exposing the `SprinklesProperties` type allows wrapping `createSprinkles` with custom utilities without resorting to awkward workarounds like:

```ts
type VarargParameters<T> = T extends (args: infer P) => any ? P : never;
type SprinklesProperties = VarargParameters<typeof createSprinkles>;
```

which it turns out are also very expensive for tsc to compute (I personally had compile times to skyrocket in a library I maintain).