### PR TITLE
chore(deps): esbuild 0.17.19

### DIFF
--- a/packages/esbuild-plugin-next/package.json
+++ b/packages/esbuild-plugin-next/package.json
@@ -19,6 +19,6 @@
     "@vanilla-extract/integration": "^6.0.2"
   },
   "devDependencies": {
-    "esbuild": "0.17.6"
+    "esbuild": "0.17.18"
   }
 }

--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -18,6 +18,6 @@
     "@vanilla-extract/integration": "^6.2.0"
   },
   "devDependencies": {
-    "esbuild": "0.17.6"
+    "esbuild": "0.17.18"
   }
 }

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -18,7 +18,7 @@
     "@babel/plugin-syntax-typescript": "^7.20.0",
     "@vanilla-extract/babel-plugin-debug-ids": "^1.0.2",
     "@vanilla-extract/css": "^1.10.0",
-    "esbuild": "0.17.6",
+    "esbuild": "0.17.18",
     "eval": "0.1.6",
     "find-up": "^5.0.0",
     "javascript-stringify": "^2.0.1",

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "@vanilla-extract/integration": "^6.2.0",
-    "esbuild": "0.17.6"
+    "esbuild": "0.17.18"
   },
   "devDependencies": {
     "@jest/transform": "^29.0.3"

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -21,7 +21,7 @@
     "@fixtures/themed": "*",
     "@rollup/plugin-json": "^4.1.0",
     "@vanilla-extract/css": "^1.12.0",
-    "esbuild": "0.17.6",
+    "esbuild": "0.17.18",
     "rollup": "^2.7.0",
     "rollup-plugin-esbuild": "^4.9.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,20 +225,20 @@ importers:
   packages/esbuild-plugin:
     specifiers:
       '@vanilla-extract/integration': ^6.2.0
-      esbuild: 0.17.6
+      esbuild: 0.17.18
     dependencies:
       '@vanilla-extract/integration': link:../integration
     devDependencies:
-      esbuild: 0.17.6
+      esbuild: 0.17.18
 
   packages/esbuild-plugin-next:
     specifiers:
       '@vanilla-extract/integration': ^6.0.2
-      esbuild: 0.17.6
+      esbuild: 0.17.18
     dependencies:
       '@vanilla-extract/integration': link:../integration
     devDependencies:
-      esbuild: 0.17.6
+      esbuild: 0.17.18
 
   packages/integration:
     specifiers:
@@ -248,7 +248,7 @@ importers:
       '@types/lodash': ^4.14.168
       '@vanilla-extract/babel-plugin-debug-ids': ^1.0.2
       '@vanilla-extract/css': ^1.10.0
-      esbuild: 0.17.6
+      esbuild: 0.17.18
       eval: 0.1.6
       find-up: ^5.0.0
       javascript-stringify: ^2.0.1
@@ -262,7 +262,7 @@ importers:
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.7
       '@vanilla-extract/babel-plugin-debug-ids': link:../babel-plugin-debug-ids
       '@vanilla-extract/css': link:../css
-      esbuild: 0.17.6
+      esbuild: 0.17.18
       eval: 0.1.6
       find-up: 5.0.0
       javascript-stringify: 2.1.0
@@ -279,10 +279,10 @@ importers:
     specifiers:
       '@jest/transform': ^29.0.3
       '@vanilla-extract/integration': ^6.2.0
-      esbuild: 0.17.6
+      esbuild: 0.17.18
     dependencies:
       '@vanilla-extract/integration': link:../integration
-      esbuild: 0.17.6
+      esbuild: 0.17.18
     devDependencies:
       '@jest/transform': 29.3.1
 
@@ -320,7 +320,7 @@ importers:
       '@rollup/plugin-json': ^4.1.0
       '@vanilla-extract/css': ^1.12.0
       '@vanilla-extract/integration': ^6.2.0
-      esbuild: 0.17.6
+      esbuild: 0.17.18
       rollup: ^2.7.0
       rollup-plugin-esbuild: ^4.9.1
     dependencies:
@@ -329,9 +329,9 @@ importers:
       '@fixtures/themed': link:../../fixtures/themed
       '@rollup/plugin-json': 4.1.0_rollup@2.79.1
       '@vanilla-extract/css': link:../css
-      esbuild: 0.17.6
+      esbuild: 0.17.18
       rollup: 2.79.1
-      rollup-plugin-esbuild: 4.9.1_72vqmc7tx7ptj43i3kyzp2skqu
+      rollup-plugin-esbuild: 4.9.1_yzudisgzitceydsqnwfe45ef5i
 
   packages/sprinkles:
     specifiers:
@@ -513,7 +513,7 @@ importers:
       css-loader: ^5.2.4
       cssnano: ^5.1.15
       cssnano-preset-lite: ^2.1.3
-      esbuild: 0.17.6
+      esbuild: 0.17.18
       got: ^11.8.2
       html-webpack-plugin: ^5.3.1
       mini-css-extract-plugin: ^1.5.1
@@ -539,7 +539,7 @@ importers:
       '@fixtures/unused-modules': link:../fixtures/unused-modules
       '@parcel/config-default': 2.8.3_vmmibovol2f5ijcpy47wzln4ni
       '@parcel/core': 2.8.3
-      '@types/mini-css-extract-plugin': 1.4.3_esbuild@0.17.6
+      '@types/mini-css-extract-plugin': 1.4.3_esbuild@0.17.18
       '@types/webpack-dev-server': 3.11.6
       '@vanilla-extract/esbuild-plugin': link:../packages/esbuild-plugin
       '@vanilla-extract/esbuild-plugin-next': link:../packages/esbuild-plugin-next
@@ -550,7 +550,7 @@ importers:
       css-loader: 5.2.7_webpack@5.64.2
       cssnano: 5.1.15_postcss@8.4.21
       cssnano-preset-lite: 2.1.3_postcss@8.4.21
-      esbuild: 0.17.6
+      esbuild: 0.17.18
       got: 11.8.3
       html-webpack-plugin: 5.5.0_webpack@5.64.2
       mini-css-extract-plugin: 1.6.2_webpack@5.64.2
@@ -562,7 +562,7 @@ importers:
       serve-handler: 6.1.3
       style-loader: 2.0.0_webpack@5.64.2
       vite: 2.7.2
-      webpack: 5.64.2_esbuild@0.17.6
+      webpack: 5.64.2_esbuild@0.17.18
       webpack-dev-server: 3.11.3_webpack@5.64.2
       webpack-merge: 5.8.0
     devDependencies:
@@ -3200,8 +3200,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/android-arm/0.17.6:
-    resolution: {integrity: sha512-bSC9YVUjADDy1gae8RrioINU6e1lCkg3VGVwm0QQ2E1CWcC4gnMce9+B6RpxuSsrsXsk1yojn7sp1fnG8erE2g==}
+  /@esbuild/android-arm/0.17.18:
+    resolution: {integrity: sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -3217,8 +3217,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/android-arm64/0.17.6:
-    resolution: {integrity: sha512-YnYSCceN/dUzUr5kdtUzB+wZprCafuD89Hs0Aqv9QSdwhYQybhXTaSTcrl6X/aWThn1a/j0eEpUBGOE7269REg==}
+  /@esbuild/android-arm64/0.17.18:
+    resolution: {integrity: sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -3234,8 +3234,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/android-x64/0.17.6:
-    resolution: {integrity: sha512-MVcYcgSO7pfu/x34uX9u2QIZHmXAB7dEiLQC5bBl5Ryqtpj9lT2sg3gNDEsrPEmimSJW2FXIaxqSQ501YLDsZQ==}
+  /@esbuild/android-x64/0.17.18:
+    resolution: {integrity: sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -3251,8 +3251,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/darwin-arm64/0.17.6:
-    resolution: {integrity: sha512-bsDRvlbKMQMt6Wl08nHtFz++yoZHsyTOxnjfB2Q95gato+Yi4WnRl13oC2/PJJA9yLCoRv9gqT/EYX0/zDsyMA==}
+  /@esbuild/darwin-arm64/0.17.18:
+    resolution: {integrity: sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -3268,8 +3268,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/darwin-x64/0.17.6:
-    resolution: {integrity: sha512-xh2A5oPrYRfMFz74QXIQTQo8uA+hYzGWJFoeTE8EvoZGHb+idyV4ATaukaUvnnxJiauhs/fPx3vYhU4wiGfosg==}
+  /@esbuild/darwin-x64/0.17.18:
+    resolution: {integrity: sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -3285,8 +3285,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/freebsd-arm64/0.17.6:
-    resolution: {integrity: sha512-EnUwjRc1inT4ccZh4pB3v1cIhohE2S4YXlt1OvI7sw/+pD+dIE4smwekZlEPIwY6PhU6oDWwITrQQm5S2/iZgg==}
+  /@esbuild/freebsd-arm64/0.17.18:
+    resolution: {integrity: sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -3302,8 +3302,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/freebsd-x64/0.17.6:
-    resolution: {integrity: sha512-Uh3HLWGzH6FwpviUcLMKPCbZUAFzv67Wj5MTwK6jn89b576SR2IbEp+tqUHTr8DIl0iDmBAf51MVaP7pw6PY5Q==}
+  /@esbuild/freebsd-x64/0.17.18:
+    resolution: {integrity: sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -3319,8 +3319,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/linux-arm/0.17.6:
-    resolution: {integrity: sha512-7YdGiurNt7lqO0Bf/U9/arrPWPqdPqcV6JCZda4LZgEn+PTQ5SMEI4MGR52Bfn3+d6bNEGcWFzlIxiQdS48YUw==}
+  /@esbuild/linux-arm/0.17.18:
+    resolution: {integrity: sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -3336,8 +3336,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/linux-arm64/0.17.6:
-    resolution: {integrity: sha512-bUR58IFOMJX523aDVozswnlp5yry7+0cRLCXDsxnUeQYJik1DukMY+apBsLOZJblpH+K7ox7YrKrHmJoWqVR9w==}
+  /@esbuild/linux-arm64/0.17.18:
+    resolution: {integrity: sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -3353,8 +3353,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/linux-ia32/0.17.6:
-    resolution: {integrity: sha512-ujp8uoQCM9FRcbDfkqECoARsLnLfCUhKARTP56TFPog8ie9JG83D5GVKjQ6yVrEVdMie1djH86fm98eY3quQkQ==}
+  /@esbuild/linux-ia32/0.17.18:
+    resolution: {integrity: sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -3370,8 +3370,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/linux-loong64/0.17.6:
-    resolution: {integrity: sha512-y2NX1+X/Nt+izj9bLoiaYB9YXT/LoaQFYvCkVD77G/4F+/yuVXYCWz4SE9yr5CBMbOxOfBcy/xFL4LlOeNlzYQ==}
+  /@esbuild/linux-loong64/0.17.18:
+    resolution: {integrity: sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -3387,8 +3387,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/linux-mips64el/0.17.6:
-    resolution: {integrity: sha512-09AXKB1HDOzXD+j3FdXCiL/MWmZP0Ex9eR8DLMBVcHorrWJxWmY8Nms2Nm41iRM64WVx7bA/JVHMv081iP2kUA==}
+  /@esbuild/linux-mips64el/0.17.18:
+    resolution: {integrity: sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -3404,8 +3404,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/linux-ppc64/0.17.6:
-    resolution: {integrity: sha512-AmLhMzkM8JuqTIOhxnX4ubh0XWJIznEynRnZAVdA2mMKE6FAfwT2TWKTwdqMG+qEaeyDPtfNoZRpJbD4ZBv0Tg==}
+  /@esbuild/linux-ppc64/0.17.18:
+    resolution: {integrity: sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -3421,8 +3421,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/linux-riscv64/0.17.6:
-    resolution: {integrity: sha512-Y4Ri62PfavhLQhFbqucysHOmRamlTVK10zPWlqjNbj2XMea+BOs4w6ASKwQwAiqf9ZqcY9Ab7NOU4wIgpxwoSQ==}
+  /@esbuild/linux-riscv64/0.17.18:
+    resolution: {integrity: sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -3438,8 +3438,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/linux-s390x/0.17.6:
-    resolution: {integrity: sha512-SPUiz4fDbnNEm3JSdUW8pBJ/vkop3M1YwZAVwvdwlFLoJwKEZ9L98l3tzeyMzq27CyepDQ3Qgoba44StgbiN5Q==}
+  /@esbuild/linux-s390x/0.17.18:
+    resolution: {integrity: sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -3455,8 +3455,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/linux-x64/0.17.6:
-    resolution: {integrity: sha512-a3yHLmOodHrzuNgdpB7peFGPx1iJ2x6m+uDvhP2CKdr2CwOaqEFMeSqYAHU7hG+RjCq8r2NFujcd/YsEsFgTGw==}
+  /@esbuild/linux-x64/0.17.18:
+    resolution: {integrity: sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -3472,8 +3472,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/netbsd-x64/0.17.6:
-    resolution: {integrity: sha512-EanJqcU/4uZIBreTrnbnre2DXgXSa+Gjap7ifRfllpmyAU7YMvaXmljdArptTHmjrkkKm9BK6GH5D5Yo+p6y5A==}
+  /@esbuild/netbsd-x64/0.17.18:
+    resolution: {integrity: sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -3489,8 +3489,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/openbsd-x64/0.17.6:
-    resolution: {integrity: sha512-xaxeSunhQRsTNGFanoOkkLtnmMn5QbA0qBhNet/XLVsc+OVkpIWPHcr3zTW2gxVU5YOHFbIHR9ODuaUdNza2Vw==}
+  /@esbuild/openbsd-x64/0.17.18:
+    resolution: {integrity: sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -3506,8 +3506,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/sunos-x64/0.17.6:
-    resolution: {integrity: sha512-gnMnMPg5pfMkZvhHee21KbKdc6W3GR8/JuE0Da1kjwpK6oiFU3nqfHuVPgUX2rsOx9N2SadSQTIYV1CIjYG+xw==}
+  /@esbuild/sunos-x64/0.17.18:
+    resolution: {integrity: sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -3523,8 +3523,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/win32-arm64/0.17.6:
-    resolution: {integrity: sha512-G95n7vP1UnGJPsVdKXllAJPtqjMvFYbN20e8RK8LVLhlTiSOH1sd7+Gt7rm70xiG+I5tM58nYgwWrLs6I1jHqg==}
+  /@esbuild/win32-arm64/0.17.18:
+    resolution: {integrity: sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -3540,8 +3540,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/win32-ia32/0.17.6:
-    resolution: {integrity: sha512-96yEFzLhq5bv9jJo5JhTs1gI+1cKQ83cUpyxHuGqXVwQtY5Eq54ZEsKs8veKtiKwlrNimtckHEkj4mRh4pPjsg==}
+  /@esbuild/win32-ia32/0.17.18:
+    resolution: {integrity: sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -3557,8 +3557,8 @@ packages:
     dev: false
     optional: true
 
-  /@esbuild/win32-x64/0.17.6:
-    resolution: {integrity: sha512-n6d8MOyUrNp6G4VSpRcgjs5xj4A91svJSaiwLIDWVWEsZtpN5FA9NlBbZHDmAJc2e8e6SF4tkBD3HAvPF+7igA==}
+  /@esbuild/win32-x64/0.17.18:
+    resolution: {integrity: sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -6513,12 +6513,12 @@ packages:
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
     dev: false
 
-  /@types/mini-css-extract-plugin/1.4.3_esbuild@0.17.6:
+  /@types/mini-css-extract-plugin/1.4.3_esbuild@0.17.18:
     resolution: {integrity: sha512-jyOSVaF4ie2jUGr1uohqeyDrp7ktRthdFxDKzTgbPZtl0QI5geEopW7UKD/DEfn0XgV1KEq/RnZlUmnrEAWbmg==}
     dependencies:
       '@types/node': 16.11.10
       tapable: 2.2.1
-      webpack: 5.64.2_esbuild@0.17.6
+      webpack: 5.64.2_esbuild@0.17.18
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -10311,34 +10311,34 @@ packages:
       '@esbuild/win32-x64': 0.16.17
     dev: false
 
-  /esbuild/0.17.6:
-    resolution: {integrity: sha512-TKFRp9TxrJDdRWfSsSERKEovm6v30iHnrjlcGhLBOtReE28Yp1VSBRfO3GTaOFMoxsNerx4TjrhzSuma9ha83Q==}
+  /esbuild/0.17.18:
+    resolution: {integrity: sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.17.6
-      '@esbuild/android-arm64': 0.17.6
-      '@esbuild/android-x64': 0.17.6
-      '@esbuild/darwin-arm64': 0.17.6
-      '@esbuild/darwin-x64': 0.17.6
-      '@esbuild/freebsd-arm64': 0.17.6
-      '@esbuild/freebsd-x64': 0.17.6
-      '@esbuild/linux-arm': 0.17.6
-      '@esbuild/linux-arm64': 0.17.6
-      '@esbuild/linux-ia32': 0.17.6
-      '@esbuild/linux-loong64': 0.17.6
-      '@esbuild/linux-mips64el': 0.17.6
-      '@esbuild/linux-ppc64': 0.17.6
-      '@esbuild/linux-riscv64': 0.17.6
-      '@esbuild/linux-s390x': 0.17.6
-      '@esbuild/linux-x64': 0.17.6
-      '@esbuild/netbsd-x64': 0.17.6
-      '@esbuild/openbsd-x64': 0.17.6
-      '@esbuild/sunos-x64': 0.17.6
-      '@esbuild/win32-arm64': 0.17.6
-      '@esbuild/win32-ia32': 0.17.6
-      '@esbuild/win32-x64': 0.17.6
+      '@esbuild/android-arm': 0.17.18
+      '@esbuild/android-arm64': 0.17.18
+      '@esbuild/android-x64': 0.17.18
+      '@esbuild/darwin-arm64': 0.17.18
+      '@esbuild/darwin-x64': 0.17.18
+      '@esbuild/freebsd-arm64': 0.17.18
+      '@esbuild/freebsd-x64': 0.17.18
+      '@esbuild/linux-arm': 0.17.18
+      '@esbuild/linux-arm64': 0.17.18
+      '@esbuild/linux-ia32': 0.17.18
+      '@esbuild/linux-loong64': 0.17.18
+      '@esbuild/linux-mips64el': 0.17.18
+      '@esbuild/linux-ppc64': 0.17.18
+      '@esbuild/linux-riscv64': 0.17.18
+      '@esbuild/linux-s390x': 0.17.18
+      '@esbuild/linux-x64': 0.17.18
+      '@esbuild/netbsd-x64': 0.17.18
+      '@esbuild/openbsd-x64': 0.17.18
+      '@esbuild/sunos-x64': 0.17.18
+      '@esbuild/win32-arm64': 0.17.18
+      '@esbuild/win32-ia32': 0.17.18
+      '@esbuild/win32-x64': 0.17.18
 
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -17770,7 +17770,7 @@ packages:
       '@babel/code-frame': 7.18.6
     dev: false
 
-  /rollup-plugin-esbuild/4.9.1_72vqmc7tx7ptj43i3kyzp2skqu:
+  /rollup-plugin-esbuild/4.9.1_yzudisgzitceydsqnwfe45ef5i:
     resolution: {integrity: sha512-qn/x7Wz9p3Xnva99qcb+nopH0d2VJwVnsxJTGEg+Sh2Z3tqQl33MhOwzekVo1YTKgv+yAmosjcBRJygMfGrtLw==}
     engines: {node: '>=12'}
     peerDependencies:
@@ -17780,7 +17780,7 @@ packages:
       '@rollup/pluginutils': 4.2.1
       debug: 4.3.4
       es-module-lexer: 0.9.3
-      esbuild: 0.17.6
+      esbuild: 0.17.18
       joycon: 3.1.1
       jsonc-parser: 3.0.0
       rollup: 2.79.1
@@ -18725,7 +18725,7 @@ packages:
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.1.1
-      webpack: 5.64.2_esbuild@0.17.6
+      webpack: 5.64.2_esbuild@0.17.18
     dev: false
 
   /style-to-object/0.3.0:
@@ -19010,7 +19010,7 @@ packages:
       supports-hyperlinks: 2.2.0
     dev: true
 
-  /terser-webpack-plugin/5.2.5_dhjlflamz74snw5vqhz4pqvd2u:
+  /terser-webpack-plugin/5.2.5_l6vsummtv7buol4fttdxankk5a:
     resolution: {integrity: sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -19026,13 +19026,13 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      esbuild: 0.17.6
+      esbuild: 0.17.18
       jest-worker: 27.3.1
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       source-map: 0.6.1
       terser: 5.10.0
-      webpack: 5.64.2_esbuild@0.17.6
+      webpack: 5.64.2_esbuild@0.17.18
     dev: false
 
   /terser-webpack-plugin/5.2.5_webpack@5.64.2:
@@ -20419,7 +20419,7 @@ packages:
       strip-ansi: 3.0.1
       supports-color: 6.1.0
       url: 0.11.0
-      webpack: 5.64.2_esbuild@0.17.6
+      webpack: 5.64.2_esbuild@0.17.18
       webpack-dev-middleware: 3.7.3_webpack@5.64.2
       webpack-log: 2.0.0
       ws: 6.2.2
@@ -20496,7 +20496,7 @@ packages:
       - esbuild
       - uglify-js
 
-  /webpack/5.64.2_esbuild@0.17.6:
+  /webpack/5.64.2_esbuild@0.17.18:
     resolution: {integrity: sha512-4KGc0+Ozi0aS3EaLNRvEppfZUer+CaORKqL6OBjDLZOPf9YfN8leagFzwe6/PoBdHFxc/utKArl8LMC0Ivtmdg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -20527,7 +20527,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.2.5_dhjlflamz74snw5vqhz4pqvd2u
+      terser-webpack-plugin: 5.2.5_l6vsummtv7buol4fttdxankk5a
       watchpack: 2.3.0
       webpack-sources: 3.2.2
     transitivePeerDependencies:

--- a/test-helpers/package.json
+++ b/test-helpers/package.json
@@ -27,7 +27,7 @@
     "css-loader": "^5.2.4",
     "cssnano": "^5.1.15",
     "cssnano-preset-lite": "^2.1.3",
-    "esbuild": "0.17.6",
+    "esbuild": "0.17.18",
     "got": "^11.8.2",
     "html-webpack-plugin": "^5.3.1",
     "mini-css-extract-plugin": "^1.5.1",


### PR DESCRIPTION
First a big thank you for vanilla-extract.

This PR updates esbuild to the latest esbuild 0.17.x (frm 0.17.6 -> [0.17.19](https://github.com/evanw/esbuild/releases/tag/v0.17.19)). It might bring fixes (and of course create issues) but my motivation is to reduce the number of installed esbuild versions 

```
├─ @esbuild-kit/core-utils@npm:3.1.0
│  └─ esbuild@npm:0.17.18 (via npm:~0.17.6)
├─ @vanilla-extract/integration@npm:6.2.1
│  └─ esbuild@npm:0.17.6 (via npm:0.17.6)
├─ vite@npm:4.3.9 [3ba6e]
│  └─ esbuild@npm:0.17.18 (via npm:^0.17.5)
├─ tsup@npm:7.1.0
│  └─ esbuild@npm:0.18.3 (via npm:^0.18.2)
(...)
```

Depending on how the update is considered, I'll also pr on remix-dev which locks esbuild to 0.17.6 as well