### PR TITLE
Update getting-started.md

### DIFF
--- a/site/docs/overview/getting-started.md
+++ b/site/docs/overview/getting-started.md
@@ -53,7 +53,7 @@ By importing the style we receive the scoped class name that was generated and w
 
 ```ts compiled
 // app.ts
-import { container } from './styles.css.ts';
+import { container } from './app.css.ts';
 
 document.write(`
   <section class="${container}">


### PR DESCRIPTION
Not sure if this is intended, but when following allowing the setup i noticed these were named differently. 
Does it make sense to match the name from the above example?
![image](https://github.com/vanilla-extract-css/vanilla-extract/assets/16158800/16b849bd-5574-422c-b105-b5be4cdbc0ff)
