### PR TITLE
Support extracting a CSS var name

### DIFF
--- a/.changeset/cool-pumas-hope.md
+++ b/.changeset/cool-pumas-hope.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': minor
+---
+
+Support extracting a css var name

--- a/packages/css/src/vars.test.ts
+++ b/packages/css/src/vars.test.ts
@@ -1,4 +1,36 @@
-import { fallbackVar, createGlobalThemeContract } from './vars';
+import { getVarName, fallbackVar, createGlobalThemeContract } from './vars';
+
+describe('getVarName', () => {
+  it('supports a valid var', () => {
+    expect(getVarName('var(--foo-bar)')).toEqual('--foo-bar');
+  });
+
+  it('supports a css variable with a fallback', () => {
+    expect(getVarName('var(--foo-bar, #FF0000)')).toEqual('--foo-bar');
+  });
+
+  it('upports multiple fallbacks resolving to a string', () => {
+    expect(getVarName('var(--foo, var(--bar, var(--baz, blue)))')).toEqual(
+      '--foo',
+    );
+  });
+
+  it('supports multiple fallbacks resolving to a number', () => {
+    expect(getVarName('var(--foo, var(--bar, var(--baz, 10px)))')).toEqual(
+      '--foo',
+    );
+  });
+
+  it('supports multiple fallbacks resolving to a var', () => {
+    expect(
+      getVarName('var(--foo, var(--bar, var(--baz, var(--final-fallback))))'),
+    ).toEqual('--foo');
+  });
+
+  it('supports an invalid var', () => {
+    expect(getVarName('var--foobar')).toEqual(undefined);
+  });
+});
 
 describe('fallbackVar', () => {
   it('supports a single string fallback', () => {

--- a/packages/css/src/vars.ts
+++ b/packages/css/src/vars.ts
@@ -23,6 +23,11 @@ export function createVar(debugId?: string): CSSVarFunction {
   return `var(--${cssVarName})` as const;
 }
 
+export function getVarName(cssVar: CSSVarFunction): string | undefined {
+  const [, varName] = /(?:var\()(--[a-z-]+)(.*)(\))/.exec(cssVar) ?? [];
+  return varName;
+}
+
 export function fallbackVar(
   ...values: [string, ...Array<string>]
 ): CSSVarFunction {


### PR DESCRIPTION
Ran into some situations where we were setting CSS var names from inside components (not ideal) but this meant that it was handy to have a way of getting the CSS variable name to be able to set it.

Example usage would be:
```ts
import { createVar, getVarName } from "@vanilla-extract/css";

const maxHeight = createVar();

export const root = style({
  vars: {
    [maxHeight]: "0px",
  },
  height: `calc(100vh - ${maxHeight})`,
});

// maxHeight could be exported and this could be called in a different file
export const maxHeightVarName = getVarName(maxHeight);
```