### PR TITLE
Allow custom identifier hashing

### DIFF
--- a/.changeset/curly-lies-flash.md
+++ b/.changeset/curly-lies-flash.md
@@ -1,0 +1,6 @@
+---
+'@vanilla-extract/css': minor
+'site': minor
+---
+
+Users can now provide a custom identifier hashing function

--- a/.changeset/curly-lies-flash.md
+++ b/.changeset/curly-lies-flash.md
@@ -1,6 +1,9 @@
 ---
 '@vanilla-extract/css': minor
-'site': minor
+'@vanilla-extract/dynamic': minor
+'@vanilla-extract/integration': minor
+'@vanilla-extract/recipes': minor
+'@vanilla-extract/sprinkles': minor
 ---
 
 Users can now provide a custom identifier hashing function

--- a/.changeset/curly-lies-flash.md
+++ b/.changeset/curly-lies-flash.md
@@ -1,9 +1,10 @@
 ---
 '@vanilla-extract/css': minor
-'@vanilla-extract/dynamic': minor
-'@vanilla-extract/integration': minor
-'@vanilla-extract/recipes': minor
-'@vanilla-extract/sprinkles': minor
+'@vanilla-extract/webpack-plugin': minor
+'@vanilla-extract/esbuild-plugin': minor
+'@vanilla-extract/rollup-plugin': minor
+'@vanilla-extract/vite-plugin': minor
+'@vanilla-extract/next-plugin': minor
 ---
 
 Users can now provide a custom identifier hashing function

--- a/packages/css/src/identifier.test.ts
+++ b/packages/css/src/identifier.test.ts
@@ -61,24 +61,33 @@ describe('identifier', () => {
 
   describe('with custom callback', () => {
     beforeAll(() => {
+      setFileScope('path/to/file.css.ts', 'packagetest');
       setAdapter({
         appendCss: () => {},
         registerClassName: () => {},
         onEndFileScope: () => {},
         registerComposition: () => {},
         markCompositionUsed: () => {},
-        getIdentOption: () => (scope, refCount, debugId) =>
-          `abc_${debugId}_${scope}_${refCount}`,
+        getIdentOption:
+          () =>
+          ({ hash, debugId, filePath, packageName }) => {
+            const filenameWithExtension = filePath?.split('/').pop();
+            const filenameWithoutExtension =
+              filenameWithExtension?.split('.')?.[0];
+
+            return `abc_${debugId}_${hash}_${packageName}_${filenameWithoutExtension}`;
+          },
       });
     });
 
     afterAll(() => {
       removeAdapter();
+      endFileScope();
     });
 
     it('defers to a custom callback', () => {
       expect(generateIdentifier(`a`)).toMatchInlineSnapshot(
-        `"abc_a_18bazsm_7"`,
+        `"abc_a_s0xkdr0_packagetest_file"`,
       );
     });
 

--- a/packages/css/src/identifier.test.ts
+++ b/packages/css/src/identifier.test.ts
@@ -1,4 +1,5 @@
-import { setFileScope, endFileScope } from './fileScope';
+import { removeAdapter, setAdapter } from './adapter';
+import { endFileScope, setFileScope } from './fileScope';
 import { generateIdentifier } from './identifier';
 
 describe('identifier', () => {
@@ -55,6 +56,36 @@ describe('identifier', () => {
       expect(
         generateIdentifier({ debugFileName: false }),
       ).toMatchInlineSnapshot(`"_18bazsm6"`);
+    });
+  });
+
+  describe('with custom callback', () => {
+    beforeAll(() => {
+      setAdapter({
+        appendCss: () => {},
+        registerClassName: () => {},
+        onEndFileScope: () => {},
+        registerComposition: () => {},
+        markCompositionUsed: () => {},
+        getIdentOption: () => (scope, refCount, debugId) =>
+          `abc_${debugId}_${scope}_${refCount}`,
+      });
+    });
+
+    afterAll(() => {
+      removeAdapter();
+    });
+
+    it('defers to a custom callback', () => {
+      expect(generateIdentifier(`a`)).toMatchInlineSnapshot(
+        `"abc_a_18bazsm_7"`,
+      );
+    });
+
+    it('rejects invalid identifiers', () => {
+      // getIdentOption() does not remove spaces from the debug info so the
+      // resulting identifier should be invalid here.
+      expect(() => generateIdentifier(`a b`)).toThrow();
     });
   });
 });

--- a/packages/css/src/identifier.ts
+++ b/packages/css/src/identifier.ts
@@ -42,7 +42,7 @@ export function generateIdentifier(options?: GenerateIdentifierOptions): string;
 export function generateIdentifier(
   arg?: string | GenerateIdentifierOptions,
 ): string {
-  const indentOption = getIdentOption();
+  const identOption = getIdentOption();
   const { debugId, debugFileName = true } = {
     ...(typeof arg === 'string' ? { debugId: arg } : null),
     ...(typeof arg === 'object' ? arg : null),
@@ -58,7 +58,7 @@ export function generateIdentifier(
 
   let identifier = `${fileScopeHash}${refCount}`;
 
-  if (indentOption === 'debug') {
+  if (identOption === 'debug') {
     const devPrefix = getDevPrefix({ debugId, debugFileName });
 
     if (devPrefix) {
@@ -67,8 +67,13 @@ export function generateIdentifier(
 
     return normalizeIdentifier(identifier);
   }
-  if (typeof indentOption === 'function') {
-    identifier = indentOption(fileScopeHash, refCount, debugId);
+  if (typeof identOption === 'function') {
+    identifier = identOption({
+      hash: identifier,
+      debugId,
+      filePath,
+      packageName,
+    });
 
     if (!identifier.match(/^[A-Z_][0-9A-Z_]+$/i)) {
       throw new Error(

--- a/packages/css/src/identifier.ts
+++ b/packages/css/src/identifier.ts
@@ -28,6 +28,10 @@ function getDevPrefix({
   return parts.join('_');
 }
 
+function normalizeIdentifier(identifier: string) {
+  return identifier.match(/^[0-9]/) ? `_${identifier}` : identifier;
+}
+
 interface GenerateIdentifierOptions {
   debugId?: string;
   debugFileName?: boolean;
@@ -38,6 +42,7 @@ export function generateIdentifier(options?: GenerateIdentifierOptions): string;
 export function generateIdentifier(
   arg?: string | GenerateIdentifierOptions,
 ): string {
+  const indentOption = getIdentOption();
   const { debugId, debugFileName = true } = {
     ...(typeof arg === 'string' ? { debugId: arg } : null),
     ...(typeof arg === 'object' ? arg : null),
@@ -53,13 +58,26 @@ export function generateIdentifier(
 
   let identifier = `${fileScopeHash}${refCount}`;
 
-  if (getIdentOption() === 'debug') {
+  if (indentOption === 'debug') {
     const devPrefix = getDevPrefix({ debugId, debugFileName });
 
     if (devPrefix) {
       identifier = `${devPrefix}__${identifier}`;
     }
+
+    return normalizeIdentifier(identifier);
+  }
+  if (typeof indentOption === 'function') {
+    identifier = indentOption(fileScopeHash, refCount, debugId);
+
+    if (!identifier.match(/^[A-Z_][0-9A-Z_]+$/i)) {
+      throw new Error(
+        `Identifier function returned invalid indentifier: "${identifier}"`,
+      );
+    }
+
+    return identifier;
   }
 
-  return identifier.match(/^[0-9]/) ? `_${identifier}` : identifier;
+  return normalizeIdentifier(identifier);
 }

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -120,10 +120,14 @@ export interface Composition {
   classList: string;
 }
 
-type IdentOption =
-  | 'short'
-  | 'debug'
-  | ((scope: string, refCount: string, debugId: string | undefined) => string);
+type CustomIdentFunction = (params: {
+  hash: string;
+  debugId?: string;
+  filePath?: string;
+  packageName?: string;
+}) => string;
+
+type IdentOption = 'short' | 'debug' | CustomIdentFunction;
 
 export interface Adapter {
   appendCss: (css: CSS, fileScope: FileScope) => void;

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -122,8 +122,8 @@ export interface Composition {
 
 type CustomIdentFunction = (params: {
   hash: string;
+  filePath: string;
   debugId?: string;
-  filePath?: string;
   packageName?: string;
 }) => string;
 

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -1,5 +1,5 @@
-import type { MapLeafNodes, CSSVarFunction } from '@vanilla-extract/private';
-import type { Properties, AtRule } from 'csstype';
+import type { CSSVarFunction, MapLeafNodes } from '@vanilla-extract/private';
+import type { AtRule, Properties } from 'csstype';
 
 import type { SimplePseudos } from './simplePseudos';
 
@@ -120,7 +120,11 @@ export interface Composition {
   classList: string;
 }
 
-type IdentOption = 'short' | 'debug';
+type IdentOption =
+  | 'short'
+  | 'debug'
+  | ((scope: string, refCount: string, debugId: string | undefined) => string);
+
 export interface Adapter {
   appendCss: (css: CSS, fileScope: FileScope) => void;
   registerClassName: (className: string, fileScope: FileScope) => void;

--- a/site/docs/integrations/esbuild.md
+++ b/site/docs/integrations/esbuild.md
@@ -100,7 +100,13 @@ Different formatting of identifiers (e.g. class names, keyframes, CSS Vars, etc)
 
 - `short` identifiers are a 7+ character hash. e.g. `hnw5tz3`
 - `debug` identifiers contain human readable prefixes representing the owning filename and a potential rule level debug name. e.g. `myfile_mystyle_hnw5tz3`
-- A function accepting three parameters: A scope name, an index, and an optional rule level debug name, and returning the identifier.
+- A custom identifier function takes an object parameter with properties `hash`, `filePath`, `debugId`, and `packageName`, and returns a customized identifier. e.g.
+
+```ts
+vanillaExtractPlugin({
+  identifiers: ({ hash }) => `prefix_${hash}`
+});
+```
 
 Each integration will set a default value based on the configuration options passed to the bundler.
 

--- a/site/docs/integrations/esbuild.md
+++ b/site/docs/integrations/esbuild.md
@@ -100,6 +100,7 @@ Different formatting of identifiers (e.g. class names, keyframes, CSS Vars, etc)
 
 - `short` identifiers are a 7+ character hash. e.g. `hnw5tz3`
 - `debug` identifiers contain human readable prefixes representing the owning filename and a potential rule level debug name. e.g. `myfile_mystyle_hnw5tz3`
+- A function accepting three parameters: A scope name, an index, and an optional rule level debug name, and returning the identifier.
 
 Each integration will set a default value based on the configuration options passed to the bundler.
 

--- a/site/docs/integrations/next.md
+++ b/site/docs/integrations/next.md
@@ -57,6 +57,12 @@ Different formatting of identifiers (e.g. class names, keyframes, CSS Vars, etc)
 
 - `short` identifiers are a 7+ character hash. e.g. `hnw5tz3`
 - `debug` identifiers contain human readable prefixes representing the owning filename and a potential rule level debug name. e.g. `myfile_mystyle_hnw5tz3`
-- A function accepting three parameters: A scope name, an index, and an optional rule level debug name, and returning the identifier.
+- A custom identifier function takes an object parameter with properties `hash`, `filePath`, `debugId`, and `packageName`, and returns a customized identifier. e.g.
+
+```ts
+const withVanillaExtract = createVanillaExtractPlugin({
+  identifiers: ({ hash }) => `prefix_${hash}`
+});
+```
 
 Each integration will set a default value based on the configuration options passed to the bundler.

--- a/site/docs/integrations/next.md
+++ b/site/docs/integrations/next.md
@@ -57,5 +57,6 @@ Different formatting of identifiers (e.g. class names, keyframes, CSS Vars, etc)
 
 - `short` identifiers are a 7+ character hash. e.g. `hnw5tz3`
 - `debug` identifiers contain human readable prefixes representing the owning filename and a potential rule level debug name. e.g. `myfile_mystyle_hnw5tz3`
+- A function accepting three parameters: A scope name, an index, and an optional rule level debug name, and returning the identifier.
 
 Each integration will set a default value based on the configuration options passed to the bundler.

--- a/site/docs/integrations/rollup.md
+++ b/site/docs/integrations/rollup.md
@@ -76,7 +76,13 @@ Different formatting of identifiers (e.g. class names, keyframes, CSS Vars, etc)
 
 - `short` identifiers are a 7+ character hash. e.g. `hnw5tz3`
 - `debug` identifiers contain human readable prefixes representing the owning filename and a potential rule level debug name. e.g. `myfile_mystyle_hnw5tz3`
-- A function accepting three parameters: A scope name, an index, and an optional rule level debug name, and returning the identifier.
+- A custom identifier function takes an object parameter with properties `hash`, `filePath`, `debugId`, and `packageName`, and returns a customized identifier. e.g.
+
+```ts
+vanillaExtractPlugin({
+  identifiers: ({ hash }) => `prefix_${hash}`
+});
+```
 
 Each integration will set a default value based on the configuration options passed to the bundler.
 

--- a/site/docs/integrations/rollup.md
+++ b/site/docs/integrations/rollup.md
@@ -76,6 +76,7 @@ Different formatting of identifiers (e.g. class names, keyframes, CSS Vars, etc)
 
 - `short` identifiers are a 7+ character hash. e.g. `hnw5tz3`
 - `debug` identifiers contain human readable prefixes representing the owning filename and a potential rule level debug name. e.g. `myfile_mystyle_hnw5tz3`
+- A function accepting three parameters: A scope name, an index, and an optional rule level debug name, and returning the identifier.
 
 Each integration will set a default value based on the configuration options passed to the bundler.
 

--- a/site/docs/integrations/vite.md
+++ b/site/docs/integrations/vite.md
@@ -51,7 +51,13 @@ Different formatting of identifiers (e.g. class names, keyframes, CSS Vars, etc)
 
 - `short` identifiers are a 7+ character hash. e.g. `hnw5tz3`
 - `debug` identifiers contain human readable prefixes representing the owning filename and a potential rule level debug name. e.g. `myfile_mystyle_hnw5tz3`
-- A function accepting three parameters: A scope name, an index, and an optional rule level debug name, and returning the identifier.
+- A custom identifier function takes an object parameter with properties `hash`, `filePath`, `debugId`, and `packageName`, and returns a customized identifier. e.g.
+
+```ts
+vanillaExtractPlugin({
+  identifiers: ({ hash }) => `prefix_${hash}`
+});
+```
 
 Each integration will set a default value based on the configuration options passed to the bundler.
 

--- a/site/docs/integrations/vite.md
+++ b/site/docs/integrations/vite.md
@@ -51,6 +51,7 @@ Different formatting of identifiers (e.g. class names, keyframes, CSS Vars, etc)
 
 - `short` identifiers are a 7+ character hash. e.g. `hnw5tz3`
 - `debug` identifiers contain human readable prefixes representing the owning filename and a potential rule level debug name. e.g. `myfile_mystyle_hnw5tz3`
+- A function accepting three parameters: A scope name, an index, and an optional rule level debug name, and returning the identifier.
 
 Each integration will set a default value based on the configuration options passed to the bundler.
 

--- a/site/docs/integrations/webpack.md
+++ b/site/docs/integrations/webpack.md
@@ -91,5 +91,6 @@ Different formatting of identifiers (e.g. class names, keyframes, CSS Vars, etc)
 
 - `short` identifiers are a 7+ character hash. e.g. `hnw5tz3`
 - `debug` identifiers contain human readable prefixes representing the owning filename and a potential rule level debug name. e.g. `myfile_mystyle_hnw5tz3`
+- A function accepting three parameters: A scope name, an index, and an optional rule level debug name, and returning the identifier.
 
 Each integration will set a default value based on the configuration options passed to the bundler.

--- a/site/docs/integrations/webpack.md
+++ b/site/docs/integrations/webpack.md
@@ -91,6 +91,12 @@ Different formatting of identifiers (e.g. class names, keyframes, CSS Vars, etc)
 
 - `short` identifiers are a 7+ character hash. e.g. `hnw5tz3`
 - `debug` identifiers contain human readable prefixes representing the owning filename and a potential rule level debug name. e.g. `myfile_mystyle_hnw5tz3`
-- A function accepting three parameters: A scope name, an index, and an optional rule level debug name, and returning the identifier.
+- A custom identifier function takes an object parameter with properties `hash`, `filePath`, `debugId`, and `packageName`, and returns a customized identifier. e.g.
+
+```ts
+VanillaExtractPlugin({
+  identifiers: ({ hash }) => `prefix_${hash}`
+});
+```
 
 Each integration will set a default value based on the configuration options passed to the bundler.


### PR DESCRIPTION
Hello, I am submitting a request to reopen Pull Request #657. This proposed enhancement aims to unlock my team, which is currently facing a classname clash issue, we are using multiple micro-frontends within a host application. Unfortunately, some of the generated hash values from these micro-frontends coincide with hash values from the host application. We are really hoping for this feature to be integrated, like that it will allows us to customize the generated classnames by applying prefixes specific to each micro-frontend and will guarantee the uniqueness of every hash.

Moreover, the implementation of this feature could help multiple persons with similar scenarios and other challenges, we can found in the following discussion:

- https://github.com/vanilla-extract-css/vanilla-extract/discussions/313
- https://github.com/vanilla-extract-css/vanilla-extract/discussions/273
- https://github.com/vanilla-extract-css/vanilla-extract/discussions/234

Also, I'd like to highlight a similar feature available in [Material UI](https://mui.com/system/styles/api/#creategenerateclassname-options-class-name-generator) allowing to customize the generated classnames.

Thank you for your consideration.

Best regards,