### PR TITLE
Bump `eval` to `0.1.8` to fix missing Node globals issues

### DIFF
--- a/.changeset/silver-singers-bathe.md
+++ b/.changeset/silver-singers-bathe.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/integration': patch
+---
+
+Bump `eval` to `0.1.8`

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -19,7 +19,7 @@
     "@vanilla-extract/babel-plugin-debug-ids": "^1.0.2",
     "@vanilla-extract/css": "^1.10.0",
     "esbuild": "0.17.6",
-    "eval": "0.1.6",
+    "eval": "0.1.8",
     "find-up": "^5.0.0",
     "javascript-stringify": "^2.0.1",
     "lodash": "^4.17.21",

--- a/packages/integration/src/processVanillaFile.test.ts
+++ b/packages/integration/src/processVanillaFile.test.ts
@@ -1,6 +1,3 @@
-// @ts-expect-error
-import evalCode from 'eval';
-
 import { serializeVanillaModule } from './processVanillaFile';
 
 describe('serializeVanillaModule', () => {

--- a/packages/integration/src/processVanillaFile.ts
+++ b/packages/integration/src/processVanillaFile.ts
@@ -1,6 +1,5 @@
 import { FileScope, Adapter } from '@vanilla-extract/css';
 import { transformCss } from '@vanilla-extract/css/transformCss';
-// @ts-expect-error
 import evalCode from 'eval';
 import { stringify } from 'javascript-stringify';
 import isPlainObject from 'lodash/isPlainObject';
@@ -95,7 +94,7 @@ export async function processVanillaFile({
     filePath,
     { console, process, __adapter__: cssAdapter },
     true,
-  );
+  ) as Record<string, unknown>;
 
   process.env.NODE_ENV = currentNodeEnv;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,7 +249,7 @@ importers:
       '@vanilla-extract/babel-plugin-debug-ids': ^1.0.2
       '@vanilla-extract/css': ^1.10.0
       esbuild: 0.17.6
-      eval: 0.1.6
+      eval: 0.1.8
       find-up: ^5.0.0
       javascript-stringify: ^2.0.1
       lodash: ^4.17.21
@@ -263,7 +263,7 @@ importers:
       '@vanilla-extract/babel-plugin-debug-ids': link:../babel-plugin-debug-ids
       '@vanilla-extract/css': link:../css
       esbuild: 0.17.6
-      eval: 0.1.6
+      eval: 0.1.8
       find-up: 5.0.0
       javascript-stringify: 2.1.0
       lodash: 4.17.21
@@ -407,7 +407,7 @@ importers:
       copy-webpack-plugin: ^8.1.0
       css-loader: ^5.2.4
       csstype: ^3.0.7
-      eval: 0.1.6
+      eval: 0.1.8
       file-loader: ^6.2.0
       github-slugger: ^1.3.0
       gray-matter: ^4.0.2
@@ -472,7 +472,7 @@ importers:
       copy-webpack-plugin: 8.1.1_webpack@5.64.2
       css-loader: 5.2.7_webpack@5.64.2
       csstype: 3.0.10
-      eval: 0.1.6
+      eval: 0.1.8
       file-loader: 6.2.0_webpack@5.64.2
       github-slugger: 1.4.0
       gray-matter: 4.0.3
@@ -5103,6 +5103,7 @@ packages:
       '@parcel/transformer-react-refresh-wrap': 2.8.3_@parcel+core@2.8.3
       '@parcel/transformer-svg': 2.8.3_@parcel+core@2.8.3
     transitivePeerDependencies:
+      - acorn
       - cssnano
       - postcss
       - purgecss
@@ -5312,6 +5313,7 @@ packages:
       terser: 5.10.0
     transitivePeerDependencies:
       - '@parcel/core'
+      - acorn
     dev: false
 
   /@parcel/package-manager/2.8.3:
@@ -5789,6 +5791,7 @@ packages:
       terser: 5.10.0
       v8-compile-cache: 2.3.0
     transitivePeerDependencies:
+      - acorn
       - supports-color
     dev: false
 
@@ -10076,10 +10079,11 @@ packages:
     resolution: {integrity: sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=}
     engines: {node: '>= 0.6'}
 
-  /eval/0.1.6:
-    resolution: {integrity: sha512-o0XUw+5OGkXw4pJZzQoXUk+H87DHuC+7ZE//oSrRGtatTmr12oTnLfg6QOq9DyTt0c/p4TwzgmkKrBzWTSizyQ==}
+  /eval/0.1.8:
+    resolution: {integrity: sha512-EzV94NYKoO09GLXGjXj9JIlXijVck4ONSr5wiCWDvhsvj5jxSrzTmRU/9C1DyB6uToszLs8aifA6NQ7lEQdvFw==}
     engines: {node: '>= 0.8'}
     dependencies:
+      '@types/node': 16.11.10
       require-like: 0.1.2
 
   /eventemitter3/4.0.7:
@@ -11543,6 +11547,8 @@ packages:
       param-case: 3.0.4
       relateurl: 0.2.7
       terser: 5.10.0
+    transitivePeerDependencies:
+      - acorn
     dev: false
 
   /html-render-webpack-plugin/3.0.1_nzd6q2tbbwu7trnkwxj2tz54fy:
@@ -11551,7 +11557,7 @@ packages:
       express: '>=4.0.0'
     dependencies:
       chalk: 4.1.2
-      eval: 0.1.6
+      eval: 0.1.8
       exception-formatter: 2.1.2
       schema-utils: 3.1.1
     dev: true
@@ -11577,6 +11583,8 @@ packages:
       pretty-error: 4.0.0
       tapable: 2.2.1
       webpack: 5.64.2_webpack-cli@4.9.1
+    transitivePeerDependencies:
+      - acorn
     dev: false
 
   /htmlnano/2.0.3_xx67fuclr4dzzmizs2x43q2w6i:
@@ -16894,7 +16902,7 @@ packages:
     dev: true
 
   /require-like/0.1.2:
-    resolution: {integrity: sha1-rW8wwTvs15cBDEaK+ndcDAprR/o=}
+    resolution: {integrity: sha512-oyrU88skkMtDdauHDuKVrgR+zuItqr6/c//FXzvmxRGMexSDc6hNvJInGW3LL46n+8b50RykrvwSUIIQH2LQ5A==}
 
   /require-main-filename/2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
@@ -18221,7 +18229,32 @@ packages:
       supports-hyperlinks: 2.2.0
     dev: true
 
-  /terser-webpack-plugin/5.2.5_dhjlflamz74snw5vqhz4pqvd2u:
+  /terser-webpack-plugin/5.2.5_acorn@8.8.1+webpack@5.64.2:
+    resolution: {integrity: sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      jest-worker: 27.3.1
+      schema-utils: 3.1.1
+      serialize-javascript: 6.0.0
+      source-map: 0.6.1
+      terser: 5.10.0_acorn@8.8.1
+      webpack: 5.64.2
+    transitivePeerDependencies:
+      - acorn
+
+  /terser-webpack-plugin/5.2.5_dmoaxqo2jb2cxajmot43jz3i7a:
     resolution: {integrity: sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -18242,42 +18275,39 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.0
       source-map: 0.6.1
-      terser: 5.10.0
+      terser: 5.10.0_acorn@8.8.1
       webpack: 5.64.2_esbuild@0.17.6
+    transitivePeerDependencies:
+      - acorn
     dev: false
-
-  /terser-webpack-plugin/5.2.5_webpack@5.64.2:
-    resolution: {integrity: sha512-3luOVHku5l0QBeYS8r4CdHYWEGMmIj3H1U64jgkdZzECcSOJAyJ9TjuqcQZvw1Y+4AOBN9SeYJPJmFn2cM4/2g==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      jest-worker: 27.3.1
-      schema-utils: 3.1.1
-      serialize-javascript: 6.0.0
-      source-map: 0.6.1
-      terser: 5.10.0
-      webpack: 5.64.2
 
   /terser/5.10.0:
     resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
     engines: {node: '>=10'}
     hasBin: true
+    peerDependencies:
+      acorn: ^8.5.0
     peerDependenciesMeta:
       acorn:
         optional: true
     dependencies:
       acorn: 8.8.2
+      commander: 2.20.3
+      source-map: 0.7.3
+      source-map-support: 0.5.21
+    dev: false
+
+  /terser/5.10.0_acorn@8.8.1:
+    resolution: {integrity: sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    peerDependencies:
+      acorn: ^8.5.0
+    peerDependenciesMeta:
+      acorn:
+        optional: true
+    dependencies:
+      acorn: 8.8.1
       commander: 2.20.3
       source-map: 0.7.3
       source-map-support: 0.5.21
@@ -19653,7 +19683,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.2.5_webpack@5.64.2
+      terser-webpack-plugin: 5.2.5_acorn@8.8.1+webpack@5.64.2
       watchpack: 2.3.0
       webpack-sources: 3.2.2
     transitivePeerDependencies:
@@ -19692,7 +19722,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.2.5_dhjlflamz74snw5vqhz4pqvd2u
+      terser-webpack-plugin: 5.2.5_dmoaxqo2jb2cxajmot43jz3i7a
       watchpack: 2.3.0
       webpack-sources: 3.2.2
     transitivePeerDependencies:
@@ -19732,7 +19762,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      terser-webpack-plugin: 5.2.5_webpack@5.64.2
+      terser-webpack-plugin: 5.2.5_acorn@8.8.1+webpack@5.64.2
       watchpack: 2.3.0
       webpack-cli: 4.9.1_u5qztdvzsqoic44qnlo623kp4a
       webpack-sources: 3.2.2

--- a/site/package.json
+++ b/site/package.json
@@ -49,7 +49,7 @@
     "copy-webpack-plugin": "^8.1.0",
     "css-loader": "^5.2.4",
     "csstype": "^3.0.7",
-    "eval": "0.1.6",
+    "eval": "0.1.8",
     "file-loader": "^6.2.0",
     "github-slugger": "^1.3.0",
     "gray-matter": "^4.0.2",


### PR DESCRIPTION
The `eval` package has caused issues [in the past](https://github.com/vanilla-extract-css/vanilla-extract/issues/637) that resulted in [pinning its version](https://github.com/vanilla-extract-css/vanilla-extract/pull/639/files#diff-62f6906083a84673a05063f208cfe697e0134acee3dded6930bab0d43f0789dfR19). At roughly the same time, `0.1.8` was released but we didn't update. `0.1.8` [fixes some issues](https://github.com/pierrec/node-eval/commits/master) we've run into with Node globals, and given its stability over the last ~1 year I think it's safe to update.