### PR TITLE
Pin `changesets/action` to `v1`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: pnpm i
 
       - name: Create release PR or publish to npm
-        uses: changesets/action@main
+        uses: changesets/action@v1
         with:
           version: pnpm run version
           publish: pnpm release


### PR DESCRIPTION
Not sure why but [`main` doesn't seem to work](https://github.com/vanilla-extract-css/vanilla-extract/actions/runs/6807432494/job/18510438611#step:6:13).