### PR TITLE
Fix changeset release type

### DIFF
--- a/.changeset/new-kangaroos-punch.md
+++ b/.changeset/new-kangaroos-punch.md
@@ -1,5 +1,5 @@
 ---
-"@vanilla-extract/css": feat
+"@vanilla-extract/css": minor
 ---
 
 Add some missing [simple pseudo selectors]


### PR DESCRIPTION
Changesets doesn't like any release that's not `major`/`minor`/`patch`, and it gives you an unhelpful error if that happens. [I wrote the bad changeset though](https://github.com/vanilla-extract-css/vanilla-extract/pull/1207/commits/196e180971be9678456d9799afe56820371c552a) 😅.