### PR TITLE
Bump `postcss-load-config` to be able to load PostCSS configs defined as ES Modules

### DIFF
--- a/.changeset/tasty-ducks-try.md
+++ b/.changeset/tasty-ducks-try.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Bump `postcss-load-config` so to be able to load PostCSS configs defined as ES Modules

--- a/.changeset/tasty-ducks-try.md
+++ b/.changeset/tasty-ducks-try.md
@@ -2,4 +2,4 @@
 '@vanilla-extract/vite-plugin': patch
 ---
 
-Bump `postcss-load-config` so to be able to load PostCSS configs defined as ES Modules
+Bump `postcss-load-config` to enable loading PostCSS configs defined as ES Modules

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -18,7 +18,7 @@
     "@vanilla-extract/integration": "^6.0.2",
     "outdent": "^0.8.0",
     "postcss": "^8.3.6",
-    "postcss-load-config": "^3.1.0"
+    "postcss-load-config": "^4.0.1"
   },
   "devDependencies": {
     "vite": "npm:vite@^2.7.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,8 +449,8 @@ importers:
         specifier: ^8.3.6
         version: 8.4.21
       postcss-load-config:
-        specifier: ^3.1.0
-        version: 3.1.0(ts-node@10.9.1)
+        specifier: ^4.0.1
+        version: 4.0.1(postcss@8.4.21)(ts-node@10.9.1)
     devDependencies:
       vite:
         specifier: npm:vite@^2.7.0
@@ -14671,6 +14671,24 @@ packages:
       ts-node: 10.9.1(@swc/core@1.2.112)(@types/node@16.11.10)(typescript@4.9.4)
       yaml: 1.10.2
 
+  /postcss-load-config@4.0.1(postcss@8.4.21)(ts-node@10.9.1):
+    resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
+    engines: {node: '>= 14'}
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.0.6
+      postcss: 8.4.21
+      ts-node: 10.9.1(@swc/core@1.2.112)(@types/node@16.11.10)(typescript@4.9.4)
+      yaml: 2.3.4
+    dev: false
+
   /postcss-merge-longhand@5.1.7(postcss@8.4.21):
     resolution: {integrity: sha512-YCI9gZB+PLNskrK0BB3/2OzPnGhPkBEwmwhfYk1ilBHYVAZB7/tkTHFBAnCrvBBOmeYyMYw3DMjT55SyxMBzjQ==}
     engines: {node: ^10 || ^12 || >=14.0}
@@ -18799,6 +18817,11 @@ packages:
   /yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
+
+  /yaml@2.3.4:
+    resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}
+    engines: {node: '>= 14'}
+    dev: false
 
   /yargs-parser@13.1.2:
     resolution: {integrity: sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==}


### PR DESCRIPTION
Discovered by @hi-ogawa here https://github.com/remix-run/remix/pull/8000#discussion_r1392440996