### PR TITLE
Make `esbuild` an optional peer dependency

### DIFF
--- a/.changeset/loud-laws-poke.md
+++ b/.changeset/loud-laws-poke.md
@@ -1,0 +1,6 @@
+---
+'@vanilla-extract/esbuild-plugin-next': patch
+'@vanilla-extract/esbuild-plugin': patch
+---
+
+Make `esbuild` an optional peer dependency

--- a/packages/esbuild-plugin-next/package.json
+++ b/packages/esbuild-plugin-next/package.json
@@ -18,6 +18,14 @@
   "dependencies": {
     "@vanilla-extract/integration": "^6.0.2"
   },
+  "peerDependencies": {
+    "esbuild": ">=0.17.6"
+  },
+  "peerDependenciesMeta": {
+    "esbuild": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "esbuild": "0.17.6"
   }

--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -17,6 +17,14 @@
   "dependencies": {
     "@vanilla-extract/integration": "^6.2.0"
   },
+  "peerDependencies": {
+    "esbuild": ">=0.17.6"
+  },
+  "peerDependenciesMeta": {
+    "esbuild": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "esbuild": "0.17.6"
   }


### PR DESCRIPTION
Prior art and discussions: https://github.com/vanilla-extract-css/vanilla-extract/pull/1018, https://github.com/vanilla-extract-css/vanilla-extract/pull/1171

`esbuild` is now a peer dependency in `esbuild-plugin` and `esbuild-plugin-next`.
Why make it a peer dependency? Because our script to bundle types bundles the `Plugin` type from `esbuild` into the output, which can cause a type error when consumers try to use it.
It's [marked as optional](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependenciesmeta), so it won't crash on install when consumers don't have `esbuild` in their dependencies.

I believe this is a better solution than both #1018 and #1171.
#1171 is too intrusive and adds `esbuild` everywhere, and consumers have to include it in their dependencies.
Relevant xkcd: https://xkcd.com/927/

### Before

https://unpkg.com/browse/@vanilla-extract/esbuild-plugin@2.3.0/dist/vanilla-extract-esbuild-plugin.cjs.d.ts (`Plugin` type is inlined)

### After

```ts
import { IdentifierOption, CompileOptions } from '@vanilla-extract/integration';
import { Plugin } from 'esbuild';

interface VanillaExtractPluginOptions {
    outputCss?: boolean;
    /**
     * @deprecated Use `esbuildOptions.external` instead.
     */
    externals?: Array<string>;
    runtime?: boolean;
    processCss?: (css: string) => Promise<string>;
    identifiers?: IdentifierOption;
    esbuildOptions?: CompileOptions['esbuildOptions'];
}
declare function vanillaExtractPlugin({ outputCss, externals, runtime, processCss, identifiers, esbuildOptions, }?: VanillaExtractPluginOptions): Plugin;

export { vanillaExtractPlugin };
```
