### PR TITLE
Default `emitCssInSsr` if Remix plugin is present

### DIFF
--- a/.changeset/proud-months-tell.md
+++ b/.changeset/proud-months-tell.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Default `emitCssInSsr` to `true` when Remix Vite plugin is present

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -78,6 +78,7 @@ export function vanillaExtractPlugin({
         config.plugins.some((plugin) =>
           [
             'astro:build',
+            'remix',
             'solid-start-server',
             'vite-plugin-qwik',
             'vite-plugin-svelte',


### PR DESCRIPTION
This flag needed to be enabled in the Remix Vite plugin test suite in order for it to pass when using VE, so this PR adds Remix to the ever growing list of frameworks that need this feature enabled. This seems to be a sign that this should maybe be the default, but since that's likely to be considered a breaking change, it makes sense that this could go through as a non-breaking fix in the meantime.