### PR TITLE
fix(vite-plugin): prevent extra style module invalidations when using PostCSS

### DIFF
--- a/.changeset/great-geckos-marry.md
+++ b/.changeset/great-geckos-marry.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Prevent unnecessary module invalidations when using PostCSS

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -214,7 +214,7 @@ export function vanillaExtractPlugin({
           if (
             server &&
             cssMap.has(absoluteId) &&
-            cssMap.get(absoluteId) !== source
+            cssMap.get(absoluteId) !== cssSource
           ) {
             const { moduleGraph } = server;
             const modules = Array.from(


### PR DESCRIPTION
Currently the CSS code that was processed with PostCSS (`cssSource`) is written to the `cssMap` cache:
https://github.com/vanilla-extract-css/vanilla-extract/blob/27552826716993d9923d2aa5f30513594ff3c1ee/packages/vite-plugin/src/index.ts#L241

However, the invalidation uses the source code that was not processed by PostCSS (`source`):
https://github.com/vanilla-extract-css/vanilla-extract/blob/27552826716993d9923d2aa5f30513594ff3c1ee/packages/vite-plugin/src/index.ts#L217

This results in unnecessary invalidation of those modules that may not have changed.