### PR TITLE
docs: add Remix integration page

### DIFF
--- a/site/contents.js
+++ b/site/contents.js
@@ -48,7 +48,16 @@ const contents = [
   {
     group: 'integrations',
     label: 'Integrations',
-    pages: ['vite', 'esbuild', 'webpack', 'next', 'parcel', 'rollup', 'gatsby'],
+    pages: [
+      'vite',
+      'esbuild',
+      'webpack',
+      'next',
+      'parcel',
+      'remix',
+      'rollup',
+      'gatsby',
+    ],
   },
 ];
 

--- a/site/contents.js
+++ b/site/contents.js
@@ -49,14 +49,14 @@ const contents = [
     group: 'integrations',
     label: 'Integrations',
     pages: [
-      'vite',
       'esbuild',
-      'webpack',
+      'gatsby',
       'next',
       'parcel',
       'remix',
       'rollup',
-      'gatsby',
+      'vite',
+      'webpack',
     ],
   },
 ];

--- a/site/docs/integrations/remix.md
+++ b/site/docs/integrations/remix.md
@@ -1,0 +1,13 @@
+---
+title: Remix
+parent: integrations
+---
+
+# Remix
+
+A plugin for integrating vanilla-extract with [Remix](https://remix.run).
+
+See [Vanilla Extract | Remix](https://remix.run/docs/en/main/styling/vanilla-extract) for documentation.
+
+Remix's Vanilla Extract integration is Vite-based.
+See also [Vanilla Extract's Vite integration](/vite).

--- a/site/docs/integrations/remix.md
+++ b/site/docs/integrations/remix.md
@@ -7,7 +7,7 @@ parent: integrations
 
 [Remix](https://remix.run) provides support for Vanilla Extract out of the box. See [Vanilla Extract | Remix](https://remix.run/docs/en/main/styling/vanilla-extract) for details.
 
-Remix's (unstable) Vite compiler also works with the [Vite integration](/vite). It's as simple as adding the `@vanilla-extract/vite-plugin` to your Vite config:
+Remix's (unstable) Vite compiler works with the [Vite integration]. It's as simple as adding the `@vanilla-extract/vite-plugin` to your Vite config:
 
 ```js
 import { unstable_vitePlugin as remix } from '@remix-run/dev';
@@ -20,3 +20,5 @@ export default defineConfig({
 ```
 
 See [Vite (Unstable) | Remix](https://remix.run/docs/en/main/future/vite#add-vanilla-extract-plugin) for more details.
+
+[Vite integration]: /documentation/integrations/vite

--- a/site/docs/integrations/remix.md
+++ b/site/docs/integrations/remix.md
@@ -21,4 +21,4 @@ export default defineConfig({
 
 See [Vite (Unstable) | Remix](https://remix.run/docs/en/main/future/vite#add-vanilla-extract-plugin) for more details.
 
-[Vite integration]: /documentation/integrations/vite
+[vite integration]: /documentation/integrations/vite

--- a/site/docs/integrations/remix.md
+++ b/site/docs/integrations/remix.md
@@ -5,9 +5,18 @@ parent: integrations
 
 # Remix
 
-A plugin for integrating vanilla-extract with [Remix](https://remix.run).
+[Remix](https://remix.run) provides support for Vanilla Extract out of the box. See [Vanilla Extract | Remix](https://remix.run/docs/en/main/styling/vanilla-extract) for details.
 
-See [Vanilla Extract | Remix](https://remix.run/docs/en/main/styling/vanilla-extract) for documentation.
+Remix's (unstable) Vite compiler also works with the [Vite integration](/vite). It's as simple as adding the `@vanilla-extract/vite-plugin` to your Vite config:
 
-Remix's Vanilla Extract integration is Vite-based.
-See also [Vanilla Extract's Vite integration](/vite).
+```js
+import { unstable_vitePlugin as remix } from '@remix-run/dev';
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  plugins: [remix(), vanillaExtractPlugin()]
+});
+```
+
+See [Vite (Unstable) | Remix](https://remix.run/docs/en/main/future/vite#add-vanilla-extract-plugin) for more details.


### PR DESCRIPTION
Per https://github.com/vanilla-extract-css/vanilla-extract/discussions/1266#discussioncomment-8214117, just links to the Remix docs off-site and the Vite docs on-site.

I'm not sold on the phrasing of the page but figured I'd just ask for help. 😄 