### PR TITLE
Update Prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fast-glob": "^3.2.7",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
-    "prettier": "^2.8.1",
+    "prettier": "^2.8.8",
     "resolve.exports": "^1.1.0",
     "rollup": "^2.7.0",
     "rollup-plugin-dts": "^4.2.2",

--- a/packages/babel-plugin-debug-ids/src/index.ts
+++ b/packages/babel-plugin-debug-ids/src/index.ts
@@ -61,7 +61,7 @@ const styleFunctions = [
   'recipe',
 ] as const;
 
-type StyleFunction = typeof styleFunctions[number];
+type StyleFunction = (typeof styleFunctions)[number];
 
 const extractName = (node: t.Node) => {
   if (t.isObjectProperty(node) && t.isIdentifier(node.key)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ importers:
         specifier: ^29.3.1
         version: 29.4.3
       prettier:
-        specifier: ^2.8.1
-        version: 2.8.1
+        specifier: ^2.8.8
+        version: 2.8.8
       resolve.exports:
         specifier: ^1.1.0
         version: 1.1.0
@@ -761,8 +761,8 @@ importers:
         specifier: ^8.3.6
         version: 8.4.32
       prettier:
-        specifier: ^2.8.1
-        version: 2.8.1
+        specifier: ^2.8.8
+        version: 2.8.8
       serve-handler:
         specifier: ^6.1.3
         version: 6.1.3
@@ -2269,7 +2269,7 @@ packages:
       fs-extra: 7.0.1
       lodash.startcase: 4.4.0
       outdent: 0.5.0
-      prettier: 2.8.1
+      prettier: 2.8.8
       resolve-from: 5.0.0
       semver: 7.5.4
     dev: false
@@ -2460,7 +2460,7 @@ packages:
       '@changesets/types': 5.2.1
       fs-extra: 7.0.1
       human-id: 1.0.2
-      prettier: 2.8.1
+      prettier: 2.8.8
     dev: false
 
   /@colors/colors@1.5.0:
@@ -15324,8 +15324,8 @@ packages:
     resolution: {integrity: sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==}
     engines: {node: '>=4'}
 
-  /prettier@2.8.1:
-    resolution: {integrity: sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==}
+  /prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     dev: false

--- a/test-helpers/package.json
+++ b/test-helpers/package.json
@@ -36,7 +36,7 @@
     "path-browserify": "^1.0.1",
     "portfinder": "^1.0.28",
     "postcss": "^8.3.6",
-    "prettier": "^2.8.1",
+    "prettier": "^2.8.8",
     "serve-handler": "^6.1.3",
     "style-loader": "^2.0.0",
     "vite": "npm:vite@^2.7.0",


### PR DESCRIPTION
[Prettier 2.8.2](https://github.com/prettier/prettier/blob/main/CHANGELOG.md#282) doesn't mutate link references in Markdown files.
[Prettier 2.8.5](https://github.com/prettier/prettier/blob/main/CHANGELOG.md#285) supports TypeScript 5.0 features.