### PR TITLE
Allow rollup@4.x.x as peer dependency

### DIFF
--- a/.changeset/clean-wolves-attend.md
+++ b/.changeset/clean-wolves-attend.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/rollup-plugin': minor
+---
+
+Allow rollup@4.x.x as peer dependency

--- a/.changeset/clean-wolves-attend.md
+++ b/.changeset/clean-wolves-attend.md
@@ -2,4 +2,5 @@
 '@vanilla-extract/rollup-plugin': minor
 ---
 
-Allow rollup@4.x.x as peer dependency
+PR: https://github.com/vanilla-extract-css/vanilla-extract/pull/1290
+Allow rollup@4.x.x as peer dependency. See https://github.com/vanilla-extract-css/vanilla-extract/discussions/1289 for additional context.

--- a/.changeset/clean-wolves-attend.md
+++ b/.changeset/clean-wolves-attend.md
@@ -1,6 +1,5 @@
 ---
-'@vanilla-extract/rollup-plugin': minor
+'@vanilla-extract/rollup-plugin': patch
 ---
 
-PR: https://github.com/vanilla-extract-css/vanilla-extract/pull/1290
-Allow rollup@4.x.x as peer dependency. See https://github.com/vanilla-extract-css/vanilla-extract/discussions/1289 for additional context.
+Add Rollup v4 to peer dependencies

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -26,6 +26,6 @@
     "rollup-plugin-esbuild": "^4.9.1"
   },
   "peerDependencies": {
-    "rollup": "^2.0.0 || ^3.0.0"
+    "rollup": "^2.0.0 || ^3.0.0 || ^4.0.0"
   }
 }


### PR DESCRIPTION
Spinning up this PR from https://github.com/vanilla-extract-css/vanilla-extract/discussions/1289.
@mrm007 I don't know exactly what to test/verify for this change though. 
Heres the breaking changes from 3.x.x to 4.x.x: https://github.com/rollup/rollup/releases/tag/v4.0.0

I've done a quick scan, and it seems theres a few references to `preserveModules` in a test, which I am unsure if might cause errors down the line if the peer dependency is on `4.x.x` due to the breaking change note:
```
inlineDynamicImports, manualChunks and preserveModules have been removed on input option level: Please use the corresponding output options of the same names (https://github.com/rollup/rollup/pull/5143)
```

Other than that it looks to me this should be safe. 
Anything else we need to verify for this?