### PR TITLE
Update dependency `@vanilla-extract/integration`

### DIFF
--- a/.changeset/silly-seahorses-tickle.md
+++ b/.changeset/silly-seahorses-tickle.md
@@ -1,0 +1,11 @@
+---
+'@vanilla-extract/esbuild-plugin': patch
+'@vanilla-extract/esbuild-plugin-next': patch
+'@vanilla-extract/next-plugin': patch
+'@vanilla-extract/parcel-transformer': patch
+'@vanilla-extract/rollup-plugin': patch
+'@vanilla-extract/vite-plugin': patch
+'@vanilla-extract/webpack-plugin': patch
+---
+
+Update dependency `@vanilla-extract/integration`

--- a/packages/esbuild-plugin-next/package.json
+++ b/packages/esbuild-plugin-next/package.json
@@ -16,7 +16,7 @@
   "author": "SEEK",
   "license": "MIT",
   "dependencies": {
-    "@vanilla-extract/integration": "^6.2.5"
+    "@vanilla-extract/integration": "^6.3.0"
   },
   "peerDependencies": {
     "esbuild": ">=0.17.6"

--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -15,7 +15,7 @@
   "author": "SEEK",
   "license": "MIT",
   "dependencies": {
-    "@vanilla-extract/integration": "^6.2.5"
+    "@vanilla-extract/integration": "^6.3.0"
   },
   "peerDependencies": {
     "esbuild": ">=0.17.6"

--- a/packages/parcel-transformer/package.json
+++ b/packages/parcel-transformer/package.json
@@ -19,6 +19,6 @@
   "license": "MIT",
   "dependencies": {
     "@parcel/plugin": "^2.7.0",
-    "@vanilla-extract/integration": "^6.2.5"
+    "@vanilla-extract/integration": "^6.3.0"
   }
 }

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -15,7 +15,7 @@
   "author": "SEEK",
   "license": "MIT",
   "dependencies": {
-    "@vanilla-extract/integration": "^6.2.5"
+    "@vanilla-extract/integration": "^6.3.0"
   },
   "devDependencies": {
     "@fixtures/themed": "*",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -15,7 +15,7 @@
   "author": "SEEK",
   "license": "MIT",
   "dependencies": {
-    "@vanilla-extract/integration": "^6.2.5",
+    "@vanilla-extract/integration": "^6.3.0",
     "outdent": "^0.8.0",
     "postcss": "^8.3.6",
     "postcss-load-config": "^4.0.1"

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -56,7 +56,7 @@
     "webpack": "^4.30.0 || ^5.20.2"
   },
   "dependencies": {
-    "@vanilla-extract/integration": "^6.2.5",
+    "@vanilla-extract/integration": "^6.3.0",
     "chalk": "^4.1.1",
     "debug": "^4.3.1",
     "loader-utils": "^2.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,7 +319,7 @@ importers:
   packages/esbuild-plugin:
     dependencies:
       '@vanilla-extract/integration':
-        specifier: ^6.2.5
+        specifier: ^6.3.0
         version: link:../integration
     devDependencies:
       esbuild:
@@ -329,7 +329,7 @@ importers:
   packages/esbuild-plugin-next:
     dependencies:
       '@vanilla-extract/integration':
-        specifier: ^6.2.5
+        specifier: ^6.3.0
         version: link:../integration
     devDependencies:
       esbuild:
@@ -417,7 +417,7 @@ importers:
         specifier: ^2.7.0
         version: 2.8.3(@parcel/core@2.8.3)
       '@vanilla-extract/integration':
-        specifier: ^6.2.5
+        specifier: ^6.3.0
         version: link:../integration
 
   packages/private: {}
@@ -431,7 +431,7 @@ importers:
   packages/rollup-plugin:
     dependencies:
       '@vanilla-extract/integration':
-        specifier: ^6.2.5
+        specifier: ^6.3.0
         version: link:../integration
     devDependencies:
       '@fixtures/themed':
@@ -464,7 +464,7 @@ importers:
   packages/vite-plugin:
     dependencies:
       '@vanilla-extract/integration':
-        specifier: ^6.2.5
+        specifier: ^6.3.0
         version: link:../integration
       outdent:
         specifier: ^0.8.0
@@ -483,7 +483,7 @@ importers:
   packages/webpack-plugin:
     dependencies:
       '@vanilla-extract/integration':
-        specifier: ^6.2.5
+        specifier: ^6.3.0
         version: link:../integration
       chalk:
         specifier: ^4.1.1


### PR DESCRIPTION
As per https://github.com/vanilla-extract-css/vanilla-extract/pull/1160#discussion_r1296699881, we should have included every plugin affected by #1252 and #1273.