### PR TITLE
Skip loading plugins added by Vitest

### DIFF
--- a/.changeset/clever-walls-cross.md
+++ b/.changeset/clever-walls-cross.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Skip loading plugins added by Vitest

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -126,7 +126,10 @@ export function vanillaExtractPlugin({
                 typeof plugin === 'object' &&
                 plugin !== null &&
                 'name' in plugin &&
-                plugin.name !== 'vanilla-extract',
+                plugin.name !== 'vanilla-extract' &&
+                // skip Vitest plugins
+                plugin.name !== 'vitest' &&
+                !plugin.name.startsWith('vitest:'),
             ),
         });
       }

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -118,19 +118,18 @@ export function vanillaExtractPlugin({
           root: config.root,
           identifiers: getIdentOption(),
           cssImportSpecifier: fileIdToVirtualId,
-          vitePlugins: userConfig.plugins
-            ?.flat()
-            // Prevent an infinite loop where the compiler creates a new instance of the plugin, which creates a new compiler etc.
-            .filter(
-              (plugin) =>
-                typeof plugin === 'object' &&
-                plugin !== null &&
-                'name' in plugin &&
-                plugin.name !== 'vanilla-extract' &&
-                // skip Vitest plugins
-                plugin.name !== 'vitest' &&
-                !plugin.name.startsWith('vitest:'),
-            ),
+          vitePlugins: userConfig.plugins?.flat().filter(
+            (plugin) =>
+              typeof plugin === 'object' &&
+              plugin !== null &&
+              'name' in plugin &&
+              // Prevent an infinite loop where the compiler creates a new instance of the plugin,
+              //  which creates a new compiler, which creates a new instance of the plugin, etc.
+              plugin.name !== 'vanilla-extract' &&
+              // Skip Vitest plugins
+              plugin.name !== 'vitest' &&
+              !plugin.name.startsWith('vitest:'),
+          ),
         });
       }
     },


### PR DESCRIPTION
Fixes #1298.

Vitest adds [its own plugins](https://github.com/vitest-dev/vitest/blob/c2cceebbfd28f50c32b9ed6f4519b1fba96171b4/packages/vitest/src/node/plugins/index.ts#L202-L211) before our `config` hook gets a chance to run, so we need to filter them out before passing plugins to the compiler.