### PR TITLE
Don't pass Remix Vite plugin to the vite-node compiler

### DIFF
--- a/.changeset/vite-plugin-remix.md
+++ b/.changeset/vite-plugin-remix.md
@@ -4,4 +4,4 @@
 
 Don't pass Remix Vite plugin to the vite-node compiler
 
-Remix throws an error if it's loaded without a config file, like we do when we initialise the vite-node compiler.
+Remix throws an error if it's loaded without a config file, which is what we do when we initialise the vite-node compiler.

--- a/.changeset/vite-plugin-remix.md
+++ b/.changeset/vite-plugin-remix.md
@@ -1,0 +1,7 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Don't pass Remix Vite plugin to the vite-node compiler
+
+Remix throws an error if it's loaded without a config file, like we do when we initialise the vite-node compiler.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -125,11 +125,13 @@ export function vanillaExtractPlugin({
               plugin !== null &&
               'name' in plugin &&
               // Prevent an infinite loop where the compiler creates a new instance of the plugin,
-              //  which creates a new compiler, which creates a new instance of the plugin, etc.
+              // which creates a new compiler, which creates a new instance of the plugin, etc.
               plugin.name !== 'vanilla-extract' &&
               // Skip Vitest plugins
               plugin.name !== 'vitest' &&
-              !plugin.name.startsWith('vitest:'),
+              !plugin.name.startsWith('vitest:') &&
+              // Skip Remix because it throws an error if it's not loaded with a config file
+              plugin.name !== 'remix',
           ),
         });
       }


### PR DESCRIPTION
Similar to #1300, we need to filter out Remix before passing plugins to the compiler. 
[Remix throws an error](https://github.com/remix-run/remix/blob/f0688dd49f41e4bcdf8bc689a8380c2e0ee5c760/packages/remix-dev/vite/plugin.ts#L966-L970) if it's loaded without a config file, like we do when we initialise the vite-node compiler.

This has been an issue with version 4.x of our Vite plugin since the very beginning. https://github.com/remix-run/remix/pull/7990 was merged long before we released [v4.0.0](https://github.com/vanilla-extract-css/vanilla-extract/releases/tag/%40vanilla-extract/vite-plugin%404.0.0).