### PR TITLE
Load a new Vite config object for the vite-node compiler

### DIFF
--- a/.changeset/integration-plugins.md
+++ b/.changeset/integration-plugins.md
@@ -1,0 +1,7 @@
+---
+'@vanilla-extract/integration': minor
+---
+
+A Vite config object can be passed to the vite-node compiler via the `viteConfig` option
+
+`viteResolve` and `vitePlugins` options are deprecated and will be removed in a future version.

--- a/.changeset/vite-plugin-plugins.md
+++ b/.changeset/vite-plugin-plugins.md
@@ -1,0 +1,7 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Resolve and pass a new copy of the Vite config to the vite-node compiler
+
+Previously, we were passing the same Vite config object to the vite-node compiler. This was causing compatibility issues with other plugins, such as Vitest and Remix.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -138,7 +138,11 @@ export function vanillaExtractPlugin({
                 'name' in plugin &&
                 // Prevent an infinite loop where the compiler creates a new instance of the plugin,
                 // which creates a new compiler, which creates a new instance of the plugin, etc.
-                plugin.name !== 'vanilla-extract',
+                plugin.name !== 'vanilla-extract' &&
+                // Skip Remix because it throws an error if it's not loaded with a config file.
+                // If it _is_ loaded with a config file, it will create an infinite loop because it
+                // also has a child compiler which uses the same mechanism to load the config file.
+                plugin.name !== 'remix',
             ),
           },
         });

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -142,6 +142,7 @@ export function vanillaExtractPlugin({
                 // Skip Remix because it throws an error if it's not loaded with a config file.
                 // If it _is_ loaded with a config file, it will create an infinite loop because it
                 // also has a child compiler which uses the same mechanism to load the config file.
+                // https://github.com/remix-run/remix/pull/7990#issuecomment-1809356626
                 plugin.name !== 'remix',
             ),
           },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { PlaywrightTestConfig, devices } from '@playwright/test';
 
+// Prevent Vite from attempting to clear the screen
+process.stdout.isTTY = false;
+
 const config: PlaywrightTestConfig = {
   testMatch: '**/*.playwright.ts',
   updateSnapshots: 'none',

--- a/test-helpers/src/startFixture/vite.ts
+++ b/test-helpers/src/startFixture/vite.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import http from 'http';
 
-import { createServer, build, InlineConfig } from 'vite';
+import type { InlineConfig } from 'vite';
 import handler from 'serve-handler';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import inspect from 'vite-plugin-inspect';
@@ -53,6 +53,8 @@ export const startViteFixture = async (
       minify: false,
     },
   };
+
+  const { createServer, build } = await import('vite');
 
   if (mode === 'development') {
     const server = await createServer(config);


### PR DESCRIPTION
Fixes #1313.

This is similar to the fix provided by @hi-ogawa in https://github.com/remix-run/remix/pull/7990.
I believe this is a better fix than #1300 ~~and #1308~~ (see note below). 

Now that we load a new copy of the Vite config, we don't have to worry about filtering plugins before passing them to the vite-node compiler, since they don't share any state with the app's Vite config. 

Edit: We still need to filter out Remix because the plugins are incompatible **with and without** a config file.