### PR TITLE
fix: accept array of font face src

### DIFF
--- a/packages/css/src/transformCss.test.ts
+++ b/packages/css/src/transformCss.test.ts
@@ -1893,6 +1893,48 @@ describe('transformCss', () => {
     `);
   });
 
+  it('should handle font face rules with src as an array', () => {
+    expect(
+      transformCss({
+        composedClassLists: [],
+        localClassNames: [],
+        cssObjs: [
+          {
+            type: 'fontFace',
+            rule: {
+              fontFamily: 'Pretendard',
+              src: [
+                `url("/fonts/Pretendard-Regular.woff") format("woff")`,
+                `url("/fonts/Pretendard-Regular.woff2") format("woff2")`,
+                `local("Pretendard-Regular")`,
+              ],
+            },
+          },
+          {
+            type: 'fontFace',
+            rule: {
+              fontFamily: 'Pretendard',
+              src: [
+                `url("/fonts/Pretendard-Medium.woff") format("woff")`,
+                `url("/fonts/Pretendard-Medium.woff2") format("woff2")`,
+                `local("Pretendard-Medium")`,
+              ],
+            },
+          },
+        ],
+      }).join('\n'),
+    ).toMatchInlineSnapshot(`
+      @font-face {
+        font-family: Pretendard;
+        src: url("/fonts/Pretendard-Regular.woff") format("woff"), url("/fonts/Pretendard-Regular.woff2") format("woff2"), local("Pretendard-Regular");
+      }
+      @font-face {
+        font-family: Pretendard;
+        src: url("/fonts/Pretendard-Medium.woff") format("woff"), url("/fonts/Pretendard-Medium.woff2") format("woff2"), local("Pretendard-Medium");
+      }
+    `);
+  });
+
   it('should not create empty rules', () => {
     expect(
       transformCss({

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -622,6 +622,10 @@ function renderCss(v: any, indent: string = '') {
       const isEmpty = Object.keys(value).length === 0;
 
       if (!isEmpty) {
+        if (key === '@font-face' && Array.isArray(value.src)) {
+          value.src = value.src.join(', ');
+        }
+
         rules.push(
           `${indent}${key} {\n${renderCss(
             value,


### PR DESCRIPTION
### This PR adds support to the fontFace function accept an array of font face src


Implemented a font configuration using the fontFace function that includes multiple src paths.
This method appears to be a valid approach as it can be used without causing any type errors.

```js
type FontFaceRule = {
    src: string | readonly string[];
    ...
}
```

```js
export const Pretendard = fontFace([
  {
    src: [
      `url("/fonts/Pretendard-Regular.woff") format("woff")`,
      `url("/fonts/Pretendard-Regular.woff2") format("woff2")`,
      `local("Pretendard-Regular")`,
    ],
    fontStyle: "normal",
    fontWeight: "400",
    fontDisplay: "swap",
  },
  {
    src: [
      `url("/fonts/Pretendard-Medium.woff") format("woff")`,
      `url("/fonts/Pretendard-Medium.woff2") format("woff2")`,
      `local("Pretendard-Medium")`,
    ],
    fontStyle: "normal",
    fontWeight: "700",
    fontDisplay: "swap",
  },
]);
```

However, after converting the code to CSS, there was a problem that did not match the CSS standard.
The expected CSS format should show all source paths in a comma-separated line within the src property.

The currently generated CSS has each src separated into a separate declaration as follows,
This does not conform to the CSS standard, and as a result, there was a problem with the font not being applied correctly.

```js
@font-face {
    src: url("/fonts/Pretendard-Regular.woff") format("woff");
    src: url("/fonts/Pretendard-Regular.woff2") format("woff2");
    src: local("Pretendard-Regular");
    font-style: normal;
    font-weight: 400;
    font-display: swap;
    font-family: "font_Pretendard__1obv0sp0";
}
```

The correct CSS format should include all paths in the src property separated by commas within one declaration as follows.

```js

@font-face {
    src: url("/fonts/Pretendard-Regular.woff") format("woff"), url("/fonts/Pretendard-Regular.woff2") format("woff2"), local("Pretendard-Regular");
    font-style: normal;
    font-weight: 400;
    font-display: swap;
    font-family: "font_Pretendard__1obv0sp0";
}
```

To resolve this issue, I modified the renderCSS function and added a test code to validate the fix.
