### PR TITLE
Handle option field that doesn't exist in config

### DIFF
--- a/packages/recipes/src/createRuntimeFn.ts
+++ b/packages/recipes/src/createRuntimeFn.ts
@@ -45,7 +45,7 @@ export const createRuntimeFn = <Variants extends VariantGroups>(
 
         const selectionClassName =
           // @ts-expect-error
-          config.variantClassNames[variantName][selection];
+          config.variantClassNames?.[variantName]?.[selection];
 
         if (selectionClassName) {
           className += ' ' + selectionClassName;

--- a/tests/recipes/recipes.test.ts
+++ b/tests/recipes/recipes.test.ts
@@ -24,6 +24,13 @@ describe('recipes', () => {
     );
   });
 
+  it('should not fall on arbitrary fields', () => {
+    // @ts-expect-error Field should be not defined in this test
+    expect(basic({ notHere: 'arbitrary-prop' })).toMatchInlineSnapshot(
+      `"recipes_basic__niwegb0 recipes_basic_spaceWithDefault_small__niwegb1"`,
+    );
+  });
+
   it('should return requested variants', () => {
     expect(
       basic({


### PR DESCRIPTION
if you pass object with fields that doesn't exist in the variants (i.e. just pass props as is) - runtime function will fall with exception.