### PR TITLE
Fix link to function serialization API in the docs

### DIFF
--- a/site/docs/packages/recipes.md
+++ b/site/docs/packages/recipes.md
@@ -9,7 +9,7 @@ Create multi-variant styles with a type-safe runtime API, heavily inspired by [S
 
 As with the rest of vanilla-extract, all styles are generated at build time.
 
-> 💡 Recipes is an optional package built on top of vanilla-extract using its [function serialization API.](../../api/add-function-serializer) It doesn't have privileged access to vanilla-extract internals so you're also free to build alternative implementations.
+> 💡 Recipes is an optional package built on top of vanilla-extract using its [function serialization API.](../api/add-function-serializer) It doesn't have privileged access to vanilla-extract internals so you're also free to build alternative implementations.
 
 ## Setup
 

--- a/site/docs/packages/sprinkles.md
+++ b/site/docs/packages/sprinkles.md
@@ -11,7 +11,7 @@ Generate a static set of custom utility classes and compose them either statical
 
 Basically, it’s like building your own zero-runtime, type-safe version of [Tailwind], [Styled System], etc.
 
-> 💡 Sprinkles is an optional package built on top of vanilla-extract using its [function serialization API.](../../api/add-function-serializer) It doesn't have privileged access to vanilla-extract internals so you're also free to build alternative implementations, e.g. [Rainbow Sprinkles.](https://github.com/wayfair/rainbow-sprinkles)
+> 💡 Sprinkles is an optional package built on top of vanilla-extract using its [function serialization API.](../api/add-function-serializer) It doesn't have privileged access to vanilla-extract internals so you're also free to build alternative implementations, e.g. [Rainbow Sprinkles.](https://github.com/wayfair/rainbow-sprinkles)
 
 ## Setup
 


### PR DESCRIPTION
On the pages explaining recipes and sprinkles, the link to the function serialization API results in a 404, because it points to `../../api` instead of `../api`.
