### PR TITLE
Improve type hint of recipe's runtime fn

### DIFF
--- a/.changeset/weak-cherries-beg.md
+++ b/.changeset/weak-cherries-beg.md
@@ -1,0 +1,5 @@
+---
+"@vanilla-extract/recipes": patch
+---
+
+Resolve recipe function input type to simplify hover type

--- a/packages/recipes/src/types.ts
+++ b/packages/recipes/src/types.ts
@@ -46,7 +46,7 @@ export type RecipeClassNames<Variants extends VariantGroups> = {
 };
 
 export type RuntimeFn<Variants extends VariantGroups> = ((
-  options?: VariantSelection<Variants>,
+  options?: Resolve<VariantSelection<Variants>>,
 ) => string) & {
   variants: () => (keyof Variants)[];
   classNames: RecipeClassNames<Variants>;


### PR DESCRIPTION
As per https://www.totaltypescript.com/concepts/the-prettify-helper

**Before:**

![image](https://github.com/vanilla-extract-css/vanilla-extract/assets/9491603/6d18d17a-2ca1-40fa-92de-ab7b85ade66d)

**After:**

![image](https://github.com/vanilla-extract-css/vanilla-extract/assets/9491603/7496dc20-2364-442e-a2b7-89dd2c7f0f32)
