### PR TITLE
vite: Fix `.css.ts` file resolution on Windows

### DIFF
--- a/.changeset/eight-peas-provide.md
+++ b/.changeset/eight-peas-provide.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Fix `.css.ts` file resolution on Windows

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -47,8 +47,10 @@ export function vanillaExtractPlugin({
     if (
       filePath.startsWith(config.root) ||
       // In monorepos the absolute path will be outside of config.root, so we check that they have the same root on the file system
+      // Paths from vite are always normalized, so we have to use the posix path separator
       (path.isAbsolute(filePath) &&
-        filePath.split(path.sep)[1] === config.root.split(path.sep)[1])
+        filePath.split(path.posix.sep)[1] ===
+          config.root.split(path.posix.sep)[1])
     ) {
       resolvedId = filePath;
     } else {


### PR DESCRIPTION
We were incorrectly splitting the path inside `getAbsoluteId` on Windows because `path.sep` is OS-specific. We can use the static `path.posix.sep` instead because vite will always give us [normalized paths](https://vitejs.dev/guide/api-plugin#path-normalization).

Fixes #1339.
Fixes #1344.