### PR TITLE
docs: Fix broken links

### DIFF
--- a/site/docs/api/add-function-serializer.md
+++ b/site/docs/api/add-function-serializer.md
@@ -9,7 +9,7 @@ parent: api
 
 Typically, if you try to export a function from one of your stylesheets, you'll get an error that you can only export plain objects, arrays, strings, numbers and `null`/`undefined`.
 
-If you're wanting to create higher level abstractions like [Sprinkles](../../packages/sprinkles) or [Recipes](../../packages/recipes), this is a big problem!
+If you're wanting to create higher level abstractions like [Sprinkles](/documentation/packages/sprinkles) or [Recipes](/documentation/packages/recipes), this is a big problem!
 
 To address this limitation, the `addFunctionSerializer` utility allows you to annotate your functions with instructions on how to serialize them.
 

--- a/site/docs/packages/recipes.md
+++ b/site/docs/packages/recipes.md
@@ -9,7 +9,7 @@ Create multi-variant styles with a type-safe runtime API, heavily inspired by [S
 
 As with the rest of vanilla-extract, all styles are generated at build time.
 
-> 💡 Recipes is an optional package built on top of vanilla-extract using its [function serialization API.](../api/add-function-serializer) It doesn't have privileged access to vanilla-extract internals so you're also free to build alternative implementations.
+> 💡 Recipes is an optional package built on top of vanilla-extract using its [function serialization API.](/documentation/api/add-function-serializer) It doesn't have privileged access to vanilla-extract internals so you're also free to build alternative implementations.
 
 ## Setup
 

--- a/site/docs/packages/sprinkles.md
+++ b/site/docs/packages/sprinkles.md
@@ -11,7 +11,7 @@ Generate a static set of custom utility classes and compose them either statical
 
 Basically, it’s like building your own zero-runtime, type-safe version of [Tailwind], [Styled System], etc.
 
-> 💡 Sprinkles is an optional package built on top of vanilla-extract using its [function serialization API.](../api/add-function-serializer) It doesn't have privileged access to vanilla-extract internals so you're also free to build alternative implementations, e.g. [Rainbow Sprinkles.](https://github.com/wayfair/rainbow-sprinkles)
+> 💡 Sprinkles is an optional package built on top of vanilla-extract using its [function serialization API.](/documentation/api/add-function-serializer) It doesn't have privileged access to vanilla-extract internals so you're also free to build alternative implementations, e.g. [Rainbow Sprinkles.](https://github.com/wayfair/rainbow-sprinkles)
 
 ## Setup
 


### PR DESCRIPTION
Relative path syntax is a bit weird, and was causing some links to point to nowhere. Seems like we use absolute paths everywhere else in the docs, and they're easier to understand too IMO, so this PR fixes some broken links by converting them to absolute paths.

Fixes #1350.
Also fixes some other links that were broken.