### PR TITLE
vite: Create compiler during `buildStart` instead of `configResolved`

### DIFF
--- a/.changeset/hungry-berries-deliver.md
+++ b/.changeset/hungry-berries-deliver.md
@@ -2,4 +2,4 @@
 "@vanilla-extract/vite-plugin": patch
 ---
 
-Fix a bug that could cause a `vite-node` compiler to be created but never destroyed
+Move `vite-node` compiler creation to a more appropriate plugin hook to ensure correct cleanup of resources

--- a/.changeset/hungry-berries-deliver.md
+++ b/.changeset/hungry-berries-deliver.md
@@ -1,0 +1,5 @@
+---
+"@vanilla-extract/vite-plugin": patch
+---
+
+Fix a bug that could cause a `vite-node` compiler to be created but never destroyed

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -115,7 +115,7 @@ export function vanillaExtractPlugin({
       packageName = getPackageInfo(config.root).name;
     },
     async buildStart() {
-      if (mode !== 'transform' && !compiler) {
+      if (mode !== 'transform') {
         const { loadConfigFromFile } = await vitePromise;
         const configFile = await loadConfigFromFile(
           {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -113,8 +113,9 @@ export function vanillaExtractPlugin({
     async configResolved(_resolvedConfig) {
       config = _resolvedConfig;
       packageName = getPackageInfo(config.root).name;
-
-      if (mode !== 'transform') {
+    },
+    async buildStart() {
+      if (mode !== 'transform' && !compiler) {
         const { loadConfigFromFile } = await vitePromise;
         const configFile = await loadConfigFromFile(
           {


### PR DESCRIPTION
Related: https://github.com/dai-shi/waku/pull/559