### PR TITLE
fix: Next plugin - pages router style loading

### DIFF
--- a/.changeset/honest-pugs-tap.md
+++ b/.changeset/honest-pugs-tap.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/next-plugin': minor
+---
+
+Pages router: use next-style-loader in dev, output css in ssr

--- a/fixtures/features/src/html.ts
+++ b/fixtures/features/src/html.ts
@@ -1,0 +1,12 @@
+import * as styles from './features.css';
+import testNodes from '../test-nodes.json';
+
+export default `
+    <div id="${testNodes.mergedStyle}" class="${styles.mergedStyle}">Merged style</div>
+    <div id="${testNodes.styleWithComposition}" class="${styles.styleWithComposition}">Style with composition</div>
+    <div id="${testNodes.styleVariantsWithComposition}" class="${styles.styleVariantsWithComposition.variant}">Style variants with composition</div>
+    <div id="${testNodes.styleVariantsWithMappedComposition}" class="${styles.styleVariantsWithMappedComposition.variant}">Style variants with mapped composition</div>
+    <div id="${testNodes.compositionOnly}" class="${styles.compositionOnly}">Composition only</div>
+    <div id="${testNodes.styleCompositionInSelector}" class="${styles.styleCompositionInSelector}">Style composition in selector</div>
+    <div id="${testNodes.styleVariantsCompositionInSelector}" class="${styles.styleVariantsCompositionInSelector.variant}">Style variants composition in selector</div>
+  `;

--- a/fixtures/features/src/index.ts
+++ b/fixtures/features/src/index.ts
@@ -1,16 +1,7 @@
-import * as styles from './features.css';
-import testNodes from '../test-nodes.json';
+import html from './html';
 
 function render() {
-  document.body.innerHTML = `
-    <div id="${testNodes.mergedStyle}" class="${styles.mergedStyle}">Merged style</div>
-    <div id="${testNodes.styleWithComposition}" class="${styles.styleWithComposition}">Style with composition</div>
-    <div id="${testNodes.styleVariantsWithComposition}" class="${styles.styleVariantsWithComposition.variant}">Style variants with composition</div>
-    <div id="${testNodes.styleVariantsWithMappedComposition}" class="${styles.styleVariantsWithMappedComposition.variant}">Style variants with mapped composition</div>
-    <div id="${testNodes.compositionOnly}" class="${styles.compositionOnly}">Composition only</div>
-    <div id="${testNodes.styleCompositionInSelector}" class="${styles.styleCompositionInSelector}">Style composition in selector</div>
-    <div id="${testNodes.styleVariantsCompositionInSelector}" class="${styles.styleVariantsCompositionInSelector.variant}">Style variants composition in selector</div>
-  `;
+  document.body.innerHTML = html;
 }
 
 render();

--- a/fixtures/next-app-router/src/app/features/page.tsx
+++ b/fixtures/next-app-router/src/app/features/page.tsx
@@ -1,0 +1,10 @@
+import html from '@fixtures/features/src/html';
+
+export default function Features() {
+  return (
+    <>
+      <span id="features" />
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+    </>
+  );
+}

--- a/fixtures/next-app-router/src/app/sprinkles/page.tsx
+++ b/fixtures/next-app-router/src/app/sprinkles/page.tsx
@@ -1,0 +1,10 @@
+import html from '@fixtures/sprinkles/src/html';
+
+export default function Sprinkles() {
+  return (
+    <>
+      <span id="sprinkles" />
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+    </>
+  );
+}

--- a/fixtures/next-pages-router/src/pages/features/index.tsx
+++ b/fixtures/next-pages-router/src/pages/features/index.tsx
@@ -1,0 +1,10 @@
+import html from '@fixtures/features/src/html';
+
+export default function Features() {
+  return (
+    <>
+      <span id="features" />
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+    </>
+  );
+}

--- a/fixtures/next-pages-router/src/pages/sprinkles/index.tsx
+++ b/fixtures/next-pages-router/src/pages/sprinkles/index.tsx
@@ -1,0 +1,10 @@
+import html from '@fixtures/sprinkles/src/html';
+
+export default function Sprinkles() {
+  return (
+    <>
+      <span id="sprinkles" />
+      <div dangerouslySetInnerHTML={{ __html: html }} />
+    </>
+  );
+}

--- a/fixtures/sprinkles/src/html.ts
+++ b/fixtures/sprinkles/src/html.ts
@@ -1,0 +1,28 @@
+import {
+  sprinkles,
+  mapResponsiveValue,
+  normalizeResponsiveValue,
+  preComposedSprinkles,
+  preComposedSprinklesUsedInSelector,
+  container,
+} from './styles.css';
+import testNodes from '../test-nodes.json';
+
+export default `
+  <div id="${testNodes.root}" class="${container}">
+    <div class="${sprinkles({
+      display: normalizeResponsiveValue('block').mobile,
+      paddingTop: mapResponsiveValue(
+        {
+          mobile: 'small',
+          desktop: 'medium',
+        } as const,
+        (x) => x,
+      ),
+    })}">
+      Sprinkles
+    </div>
+    <div class="${preComposedSprinkles}">Precomposed sprinkles</div>
+    <div class="${preComposedSprinklesUsedInSelector}">Precomposed Sprinkles Used In Selector</div>
+  </div>
+`;

--- a/fixtures/sprinkles/src/index.ts
+++ b/fixtures/sprinkles/src/index.ts
@@ -1,32 +1,7 @@
-import {
-  sprinkles,
-  mapResponsiveValue,
-  normalizeResponsiveValue,
-  preComposedSprinkles,
-  preComposedSprinklesUsedInSelector,
-  container,
-} from './styles.css';
-import testNodes from '../test-nodes.json';
+import html from './html';
 
 function render() {
-  document.body.innerHTML = `
-  <div id="${testNodes.root}" class="${container}">
-    <div class="${sprinkles({
-      display: normalizeResponsiveValue('block').mobile,
-      paddingTop: mapResponsiveValue(
-        {
-          mobile: 'small',
-          desktop: 'medium',
-        } as const,
-        (x) => x,
-      ),
-    })}">
-      Sprinkles
-    </div>
-    <div class="${preComposedSprinkles}">Precomposed sprinkles</div>
-    <div class="${preComposedSprinklesUsedInSelector}">Precomposed Sprinkles Used In Selector</div>
-  </div>
-`;
+  document.body.innerHTML = html;
 }
 
 render();

--- a/test-helpers/src/startFixture/next.ts
+++ b/test-helpers/src/startFixture/next.ts
@@ -17,7 +17,7 @@ const DIST_DIR = 'dist';
 
 // these are the fixtures that are currently
 // configured as routes in the @fixtures/next-* apps
-export const nextFixtures = ['recipes'] as const;
+export const nextFixtures = ['sprinkles', 'recipes', 'features'] as const;
 
 export interface NextFixtureOptions {
   type: 'next-app-router' | 'next-pages-router';

--- a/tests/e2e/fixtures-next-development.playwright.ts
+++ b/tests/e2e/fixtures-next-development.playwright.ts
@@ -11,8 +11,7 @@ const testCases = [
   {
     type: 'next-pages-router',
     mode: 'development',
-    // @TODO - enable after next plugin fix
-    clientSideRouting: false,
+    clientSideRouting: true,
   },
   {
     type: 'next-app-router',


### PR DESCRIPTION
#### Update next plugin
- always output css
- fixes a bug with composed selector global css class not being applied in SSR with pages router
- use `next-style-loader` for pages router in development (as per original comment, next-style-loader can mess up css order in development mode, but this is surely better than no css at all.)
- fixes a bug with new page styles not being added to the document when client side routing https://github.com/vanilla-extract-css/vanilla-extract/issues/1152
- remove appDir config check

#### Add more fixtures to next e2e tests
Didn't want to add them all, as it would increase the workflow time quite a bit.
I think the ones I've added are enough to validate the fixes.

 Not sure if we want to change all the fixtures to have a separate `html.ts` for consistency.