### PR TITLE
Fix `walkObject` to work with module namespace objects

### DIFF
--- a/.changeset/chilly-hairs-serve.md
+++ b/.changeset/chilly-hairs-serve.md
@@ -2,14 +2,14 @@
 '@vanilla-extract/private': patch
 ---
 
-**walkObject**: Use an empty object instead of calling the input object's `constructor` when mapping over it
+**walkObject**: Use an empty object to initialize a clone instead of calling the input object's `constructor`
 
 This allows `walkObject` to be used on module namespace objects:
 
 ```ts
 import * as ns from './foo';
 
-// Would sometimes cause a runtime error
+// Runtime error in `vite-node`
 walkObject(ns, myMappingFunction);
 ```
 

--- a/.changeset/chilly-hairs-serve.md
+++ b/.changeset/chilly-hairs-serve.md
@@ -1,0 +1,19 @@
+---
+'@vanilla-extract/private': patch
+---
+
+**walkObject**: Use an empty object instead of calling the input object's `constructor` when mapping over it
+
+This allows `walkObject` to be used on module namespace objects:
+
+```ts
+import * as ns from './foo';
+
+// Would sometimes cause a runtime error
+walkObject(ns, myMappingFunction);
+```
+
+The previous implementation did not work with these objects because [they do not have a `constructor` function][es6 spec].
+`esbuild` seems to have papered over this issue by providing a `constructor` function on these objects, but this seems to not be the case with `vite-node`, hence the need for this fix.
+
+[es6 spec]: https://262.ecma-international.org/6.0/#sec-module-namespace-objects

--- a/.changeset/rare-days-suffer.md
+++ b/.changeset/rare-days-suffer.md
@@ -1,0 +1,10 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Update `@vanilla-extract/css` dependency
+
+This fixes a bug where APIs that used the `walkObject` utility (e.g. `createTheme`) would fail when used with module namespace objects inside `vite-node`.
+This was due to the previous implementation using the input object's `constructor` to initialize a clone, which does not work with module namespace objects because [they do not have a `constructor` function][es6 spec].
+
+[es6 spec]: https://262.ecma-international.org/6.0/#sec-module-namespace-objects

--- a/.changeset/warm-bulldogs-sin.md
+++ b/.changeset/warm-bulldogs-sin.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': patch
+---
+
+Update `@vanilla-extract/private` dependency

--- a/packages/private/src/walkObject.ts
+++ b/packages/private/src/walkObject.ts
@@ -11,7 +11,7 @@ export function walkObject<T extends Walkable, MapTo>(
   fn: (value: Primitive, path: Array<string>) => MapTo,
   path: Array<string> = [],
 ): MapLeafNodes<T, MapTo> {
-  const clone = obj.constructor();
+  const clone = {} as any;
 
   for (let key in obj) {
     const value = obj[key];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -933,6 +933,9 @@ importers:
       '@vanilla-extract/integration':
         specifier: '*'
         version: link:../packages/integration
+      '@vanilla-extract/private':
+        specifier: '*'
+        version: link:../packages/private
       '@vanilla-extract/recipes':
         specifier: '*'
         version: link:../packages/recipes

--- a/tests/package.json
+++ b/tests/package.json
@@ -12,6 +12,7 @@
     "@vanilla-extract/css": "*",
     "@vanilla-extract/dynamic": "*",
     "@vanilla-extract/integration": "*",
+    "@vanilla-extract/private": "*",
     "@vanilla-extract/recipes": "*",
     "@vanilla-extract/sprinkles": "*",
     "vite-tsconfig-paths": "^4.3.1"

--- a/tests/walkObject/tokens.ts
+++ b/tests/walkObject/tokens.ts
@@ -1,0 +1,1 @@
+export const space = { small: '8px', large: '16px' };

--- a/tests/walkObject/walkObject.vitest.test.ts
+++ b/tests/walkObject/walkObject.vitest.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect } from 'vitest';
+import { walkObject } from '@vanilla-extract/private';
+import * as tokens from './tokens';
+
+describe('walkObject', () => {
+  test('walkObject', () => {
+    const obj = {
+      a: {
+        b: {
+          c: 1,
+        },
+        d: 2,
+      },
+      e: 3,
+    };
+
+    const result = walkObject(obj, (value) => String(value));
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "a": {
+          "b": {
+            "c": "1",
+          },
+          "d": "2",
+        },
+        "e": "3",
+      }
+    `);
+  });
+
+  test('walkObject module namespace object', () => {
+    const result = walkObject(tokens, (value) => `foo${value}`);
+
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "space": {
+          "large": "foo16px",
+          "small": "foo8px",
+        },
+      }
+    `);
+  });
+});


### PR DESCRIPTION
Fixes #1360.

`walkObject` doesn't work on module namespace objects when running inside `vite-node`. This is because [module namespace objects don't have a `constructor` function](https://262.ecma-international.org/6.0/#sec-module-namespace-objects).

This "bug" has gone unnoticed for a long time because `esbuild` was modifying the export in some way that made it work, but `vite-node` doesn't seem to do this.

I don't think we need to use `constructor` anymore since `walkObject` is constrained to only work on objects, at least as far as the type signature is concerned.