### PR TITLE
Filter all Remix vite plugins before passing to `vite-node`

### DIFF
--- a/.changeset/hip-zebras-hear.md
+++ b/.changeset/hip-zebras-hear.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Fixes a bug where an internal Remix plugin would throw an error inside the `vite-node` compiler

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -146,7 +146,10 @@ export function vanillaExtractPlugin({
                 // If it _is_ loaded with a config file, it will create an infinite loop because it
                 // also has a child compiler which uses the same mechanism to load the config file.
                 // https://github.com/remix-run/remix/pull/7990#issuecomment-1809356626
-                plugin.name !== 'remix',
+                // Additionally, some internal Remix plugins rely on a `ctx` object to be initialized by
+                // the main Remix plugin, and may not function correctly without it. To address this, we
+                // filter out all Remix-related plugins.
+                !plugin.name.startsWith('remix'),
             ),
           },
         });


### PR DESCRIPTION
Fixes #1329.

Explained in a bit more detail [here](https://github.com/vanilla-extract-css/vanilla-extract/issues/1329#issuecomment-1963925841).