### PR TITLE
Add support for retrieving StyleRule objects by classname

### DIFF
--- a/packages/css/src/adapter.ts
+++ b/packages/css/src/adapter.ts
@@ -1,3 +1,4 @@
+import { cssCache } from './cssCache';
 import type { Adapter } from './types';
 
 export const mockAdapter: Adapter = {
@@ -43,6 +44,12 @@ export const removeAdapter = () => {
 };
 
 export const appendCss: Adapter['appendCss'] = (...props) => {
+  const cssDef = props[0];
+  if (cssDef.type === 'local' || cssDef.type === 'global') {
+    const { selector, rule } = cssDef;
+    cssCache.set(selector, rule);
+  }
+
   return currentAdapter().appendCss(...props);
 };
 

--- a/packages/css/src/cssCache.test.ts
+++ b/packages/css/src/cssCache.test.ts
@@ -1,0 +1,39 @@
+import { cssCache } from './cssCache';
+
+describe('cssCache', () => {
+  it('Supports adding/retrieving style rule associated with a className to/from cache', () => {
+    // throws if className string has more than one class embedded
+    expect(() => cssCache.set('two classes', {})).toThrow(
+      'Invalid className "two classes": found multiple classNames.',
+    );
+    // add to cache
+    expect(cssCache.size).toBe(0);
+    cssCache.set('test0', { content: 'test0' });
+    expect(cssCache.size).toBe(1);
+    cssCache.set('test1', { content: 'test1' });
+    expect(cssCache.size).toBe(2);
+
+    // throws if calling get with multiple classNames embedded in string
+    expect(() => cssCache.get('test0 test1')).toThrow(
+      'Invalid className "test0 test1": found multiple classNames, try CssCache.getAll() instead.',
+    );
+
+    // retrieve from cache
+    expect(cssCache.get('test0')).toEqual({ content: 'test0' });
+    // check exists in cache
+    expect(cssCache.has('test1')).toBe(true);
+  });
+
+  it('Supports retrieving StyleRule objects for a list fo classNames in original definition order', () => {
+    cssCache.set('test0', { content: 'test0' });
+    cssCache.set('test1', { content: 'test1' });
+    cssCache.set('test2', { content: 'test2' });
+
+    // retrieves style rule object for classNames in original order, ignore uncached values
+    expect(cssCache.getAll('test2 not-in-cache test0', 'test1')).toEqual([
+      { content: 'test0' },
+      { content: 'test1' },
+      { content: 'test2' },
+    ]);
+  });
+});

--- a/packages/css/src/cssCache.ts
+++ b/packages/css/src/cssCache.ts
@@ -1,0 +1,67 @@
+import { StyleRule } from './types';
+
+type CssCacheValue = { rule: Readonly<StyleRule>; index: number };
+
+let currentClassNameIndex = 0;
+const cache = new Map<string, CssCacheValue>();
+
+// ensures duplicated rules are applied in the same order they were created in
+export const classNameSortCompareFn = (a: string, b: string) =>
+  (cache.get(a)?.index ?? 0) - (cache.get(b)?.index ?? 0);
+
+export const cssCache = {
+  forEach(
+    callbackFn: (value: Readonly<StyleRule>, className: string) => void,
+  ): void {
+    cache.forEach((value, className) => callbackFn(value.rule, className));
+  },
+
+  get(className: string): Readonly<StyleRule> | undefined {
+    if (className.split(' ').length > 1) {
+      throw new Error(
+        `Invalid className "${className}": found multiple classNames, try CssCache.getAll() instead.`,
+      );
+    }
+
+    return cache.get(className)?.rule;
+  },
+
+  getAll(...classNames: string[]): Readonly<StyleRule>[] {
+    const normalizedClassNames: string[] = [];
+    for (const className of classNames) {
+      className.split(' ').forEach((singleClassName) => {
+        const trimmedSingleClassName = singleClassName.trim();
+        if (trimmedSingleClassName) {
+          normalizedClassNames.push(trimmedSingleClassName);
+        }
+      });
+    }
+
+    return normalizedClassNames
+      .sort(classNameSortCompareFn)
+      .map((className) => cache.get(className)?.rule)
+      .filter((rule) => rule !== undefined) as Readonly<StyleRule>[];
+  },
+
+  has(className: string): boolean {
+    return cache.has(className);
+  },
+
+  set(className: string, rule: StyleRule): void {
+    if (className.split(' ').length > 1) {
+      throw new Error(
+        `Invalid className "${className}": found multiple classNames.`,
+      );
+    }
+    if (!cache.has(className)) {
+      cache.set(className, { rule, index: currentClassNameIndex });
+      currentClassNameIndex += 1;
+    }
+  },
+
+  get size() {
+    return cache.size;
+  },
+};
+
+export type CssCache = typeof cssCache;

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -14,3 +14,4 @@ export * from './style';
 export * from './vars';
 export { createContainer } from './container';
 export * from './layer';
+export * from './cssCache';


### PR DESCRIPTION
For discussion: initial implementation of #1363 

The underlying goal here is to provide an API to be able retrieve style rule objects from a list of classNames, in the order they were originally added in. With that we'd be able to build some interesting things

Consider the following idea:
```ts
// button.css.ts
import { style, cssCache } from "@vanilla-extract/css";

const base = style({ ... });
const small = style({ ... });
const medium = style({ ... });

// we can compose the above styles to build our button
const smallButton = style([base, small]);

// but what if we want a responsive button size in some cases? this PR would allow the following:
const responsiveButton = style([base, {
  '@media': {
    '(max-width: 767px)': cssCache.get(small),
    '(min-width: 768px)': cssCache.get(medium),
  }
}]);
```

This could also be accomplished like so, but has some drawbacks:

```ts
// button.css.ts
import { style } from "@vanilla-extract/css";

const rawStyles = {
  small: {...},
  medium: {...},
};

const base = style({ ... });
const small = style(rawStyles.small);
const medium = style(rawStyles.medium);

const smallButton = style([base, small]);
const mediumButton = style([base, medium]);

const responsiveButton = style([base, {
  '@media': {
    '(max-width: 767px)': rawStyles.small
    '(min-width: 768px)': rawStyles.medium,
  }
}]);
```

What if the button styles are coming from a library and you don't have access to the raw style objects weren't exported? You're out of luck :(

The ultimate goal of this PR for me is to add what needed underneath to support a recipes API closer to what stitches provides (while still being fully static), where you can define variants and can optionally enable different variants at different breakpoints like so: 

```ts
const button = recipe({
  base: {...},
  variants: {
    size: {
      small: [smallText, {...}],
      medium: [mediumText, {...}]
    }
  }
});

const responsiveButton = responsiveRecipe(
  button,
  {
    size: {
      '@media (max-width: 767px)': 'small',
      '@media (min-width: 768px)': 'medium'
    }
  }
);
```

---

My first instinct was that the CSS cache should probably exist in the adapter, but on a first glance it wasn't obvious where the logic lives, so for now I've bolted it on to the `appendCss` function in `packages/css/src/adapter.ts`.