### PR TITLE
Update and add changeset

### DIFF
--- a/.changeset/chilly-hairs-serve.md
+++ b/.changeset/chilly-hairs-serve.md
@@ -7,6 +7,7 @@
 This allows `walkObject` to be used on module namespace objects:
 
 ```ts
+import { walkObject } from '@vanilla-extract/private';
 import * as ns from './foo';
 
 // Runtime error in `vite-node`

--- a/.changeset/rare-days-suffer.md
+++ b/.changeset/rare-days-suffer.md
@@ -2,9 +2,8 @@
 '@vanilla-extract/vite-plugin': patch
 ---
 
-Update `@vanilla-extract/css` dependency
+Update `@vanilla-extract/integration` dependency
 
-This fixes a bug where APIs that used the `walkObject` utility (e.g. `createTheme`) would fail when used with module namespace objects inside `vite-node`.
-This was due to the previous implementation using the input object's `constructor` to initialize a clone, which does not work with module namespace objects because [they do not have a `constructor` function][es6 spec].
+This fixes a bug where APIs that used the `walkObject` utility (e.g. `createTheme`) would fail when used with module namespace objects inside `vite-node`. This was due to the previous implementation using the input object's `constructor` to initialize a clone, which does not work with module namespace objects because [they do not have a `constructor` function][es6 spec].
 
 [es6 spec]: https://262.ecma-international.org/6.0/#sec-module-namespace-objects

--- a/.changeset/soft-weeks-confess.md
+++ b/.changeset/soft-weeks-confess.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/integration': patch
+---
+
+Update `@vanilla-extract/css` dependency


### PR DESCRIPTION
Updating some changesets, and adding one for `@vanilla-extract/integration` so the fix in `@vanilla-extract/private` will make it all the way to the vite plugin release.