### PR TITLE
feat: allow `globalFontFace` to accept array of font face rules

### DIFF
--- a/.changeset/eighty-shirts-lie.md
+++ b/.changeset/eighty-shirts-lie.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': minor
+---
+
+Supports passing multiple font face rules to `globalFontFace`

--- a/.changeset/eighty-shirts-lie.md
+++ b/.changeset/eighty-shirts-lie.md
@@ -2,4 +2,4 @@
 '@vanilla-extract/css': minor
 ---
 
-Supports passing multiple font face rules to `globalFontFace`
+Add support for passing multiple font face rules to `globalFontFace`

--- a/.changeset/eighty-shirts-lie.md
+++ b/.changeset/eighty-shirts-lie.md
@@ -3,3 +3,19 @@
 ---
 
 Add support for passing multiple font face rules to `globalFontFace`
+
+**EXAMPLE USAGE:**
+
+```ts
+const gentium = 'GlobalGentium';
+
+globalFontFace(gentium, [
+  {
+    src: 'local("Gentium")',
+    fontWeight: 'normal'
+  },
+  {
+    src: 'local("Gentium Bold")',
+    fontWeight: 'bold'
+  }
+]);

--- a/packages/css/src/style.ts
+++ b/packages/css/src/style.ts
@@ -121,11 +121,18 @@ export function fontFace(
   return fontFamily;
 }
 
-export function globalFontFace(fontFamily: string, rule: FontFaceRule) {
-  appendCss(
-    { type: 'fontFace', rule: { ...rule, fontFamily } },
-    getFileScope(),
-  );
+export function globalFontFace(
+  fontFamily: string,
+  rule: FontFaceRule | FontFaceRule[],
+) {
+  const rules = Array.isArray(rule) ? rule : [rule];
+
+  for (const singleRule of rules) {
+    appendCss(
+      { type: 'fontFace', rule: { ...singleRule, fontFamily } },
+      getFileScope(),
+    );
+  }
 }
 
 export function keyframes(rule: CSSKeyframes, debugId?: string) {

--- a/site/docs/global-api/global-font-face.md
+++ b/site/docs/global-api/global-font-face.md
@@ -25,3 +25,33 @@ export const font = style({
   fontFamily: comicSans
 });
 ```
+
+## Multiple Global Fonts with Single Family
+
+The `globalFontFace` function allows you to pass an array of font-face rules that may contain different rules but treat them as if they are from one font family.
+
+```ts compiled
+// text.css.ts
+
+import {
+  globalFontFace,
+  style
+} from '@vanilla-extract/css';
+
+const gentium = 'GlobalGentium';
+
+globalFontFace(gentium, [
+  {
+    src: 'local("Gentium")',
+    fontWeight: 'normal'
+  },
+  {
+    src: 'local("Gentium Bold")',
+    fontWeight: 'bold'
+  }
+]);
+
+export const font = style({
+  fontFamily: gentium
+});
+```


### PR DESCRIPTION
This PR adds support to `globalFontFace` function to accept an array of font face rules.

example:
```ts
import {
  globalFontFace,
  style
} from '@vanilla-extract/css';

const gentium = 'GlobalGentium';

globalFontFace(gentium, [
  {
    src: 'local("Gentium")',
    fontWeight: 'normal'
  },
  {
    src: 'local("Gentium Bold")',
    fontWeight: 'bold'
  }
]);

export const font = style({
  fontFamily: gentium
});
```

If you need any additional documentation or clarification, please let me know.
Thank you!