### PR TITLE
fix(recipes): applying recipes throws for unknown options

### DIFF
--- a/.changeset/calm-impalas-itch.md
+++ b/.changeset/calm-impalas-itch.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/recipes': patch
+---
+
+Applying recipes now ignores unknown options instead of throwing a runtime TypeError.

--- a/packages/recipes/src/createRuntimeFn.ts
+++ b/packages/recipes/src/createRuntimeFn.ts
@@ -45,7 +45,7 @@ export const createRuntimeFn = <Variants extends VariantGroups>(
 
         const selectionClassName =
           // @ts-expect-error
-          config.variantClassNames[variantName][selection];
+          config.variantClassNames[variantName]?.[selection];
 
         if (selectionClassName) {
           className += ' ' + selectionClassName;

--- a/tests/recipes/recipes.test.ts
+++ b/tests/recipes/recipes.test.ts
@@ -24,6 +24,13 @@ describe('recipes', () => {
     );
   });
 
+  it('should ignore unknown variants', () => {
+    const props = { other: 'unknown-option' } as Parameters<typeof basic>[0];
+    expect(basic(props)).toMatchInlineSnapshot(
+      `"recipes_basic__niwegb0 recipes_basic_spaceWithDefault_small__niwegb1"`,
+    );
+  });
+
   it('should return requested variants', () => {
     expect(
       basic({


### PR DESCRIPTION
I recently started to move from [class-variance-authority](https://cva.style/docs/getting-started/variants) to vanilla-extract with recipes for the additional type safety. So far I am loving it apart from some nit-picks.

I am using both in React components where I find it quite handy to pass the props object to the recipe so it can apply all variants that are provided by the consumer. This works flawlessly with _class-variance-authority_. However, I noticed that the following code throws a runtime error "TypeError: Cannot read properties of undefined" in _vanilla-extract_ when non-variant properties are applied as well. I would love to avoid having to de-structure and construct a variant options object all the time.

```typescript
import { text, type TextVariants } from './text.css';

export interface TextProps extends TextVariants, ComponentPropsWithoutRef<"span"> {}

export function Text(props: TextProps) {
  return (
    <span {...props} className={text(props)}>
      {props.children}
    </span>
  );
}
```

This PR addresses the type error by ignoring unknown options when applying a recipe function. Therefore, recipes no longer throw a runtime error.