### PR TITLE
vite: Fix CSS output not updating in watch mode

### DIFF
--- a/.changeset/gentle-ligers-act.md
+++ b/.changeset/gentle-ligers-act.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Fixes a bug that was causing output CSS files to not update during watch mode

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -156,7 +156,14 @@ export function vanillaExtractPlugin({
       }
     },
     buildEnd() {
-      compiler?.close();
+      // When using the rollup watcher, we don't want to close the compiler after every build.
+      // Instead, we close it when the watcher is closed via the closeWatcher hook.
+      if (!config.build.watch) {
+        compiler?.close();
+      }
+    },
+    closeWatcher() {
+      return compiler?.close();
     },
     async transform(code, id) {
       const [validId] = id.split('?');


### PR DESCRIPTION
Fixes #1351.
Fixes #1372.

Thanks to @szszoke for the [lead](https://github.com/vanilla-extract-css/vanilla-extract/issues/1351#issuecomment-2082422153).

Snapshot version: `0.0.0-fix-watch-mode-20240429115131`.

While it would be nice to have some kind of fixture/integration test for vite watch mode, it would be a bit involved, so I'd prefer to ship the fix first, and look into a test later.

I wonder if this also addresses the issue that prompted #1327.