### PR TITLE
vite: Ensure compiler is re-used between builds

### DIFF
--- a/.changeset/odd-crews-itch.md
+++ b/.changeset/odd-crews-itch.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Ensure the compiler instance is re-used between builds

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -117,7 +117,8 @@ export function vanillaExtractPlugin({
       packageName = getPackageInfo(config.root).name;
     },
     async buildStart() {
-      if (mode !== 'transform') {
+      // Ensure we re-use the compiler instance between builds, e.g. in watch mode
+      if (mode !== 'transform' && !compiler) {
         const { loadConfigFromFile } = await vitePromise;
         const configFile = await loadConfigFromFile(
           {


### PR DESCRIPTION
This change was meant to be included in #1397.