### PR TITLE
test, ci: Playwright config tweaks, update action versions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: pnpm/action-setup@v3
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           node-version-file: ${{ matrix.node == '' && '.nvmrc' || '' }}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,10 @@ const config: PlaywrightTestConfig = defineConfig({
       maxDiffPixelRatio: 0.02,
     },
   },
+  fullyParallel: true,
   workers: process.env.CI ? cpus().length : undefined,
+  retries: process.env.CI ? 2 : 0,
+  forbidOnly: !!process.env.CI,
   snapshotDir: 'tests/e2e/snapshots',
   // put all snapshots in one directory
   // https://playwright.dev/docs/api/class-testconfig#test-config-snapshot-path-template

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,7 +13,6 @@ const config: PlaywrightTestConfig = defineConfig({
       maxDiffPixelRatio: 0.02,
     },
   },
-  fullyParallel: true,
   workers: process.env.CI ? cpus().length : undefined,
   retries: process.env.CI ? 2 : 0,
   forbidOnly: !!process.env.CI,


### PR DESCRIPTION
- Retry test failures on CI. Should help with flakey tests.
- Forbid `.only` on CI (fail the build)
- Update a github action version to fix a deprecation warning