### PR TITLE
`addFileScope`: Don't mangle non-template strings that contain newlines

### DIFF
--- a/.changeset/clean-tigers-drive.md
+++ b/.changeset/clean-tigers-drive.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/integration': patch
+---
+
+`addFileScope`: Fixes a bug where non-template strings that contained a newline where being mangled

--- a/.changeset/silver-cows-march.md
+++ b/.changeset/silver-cows-march.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/integration': patch
+---
+
+Bump `dedent` dependency to `^1.5.3`

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -112,7 +112,7 @@
     "css-what": "^6.1.0",
     "cssesc": "^3.0.0",
     "csstype": "^3.0.7",
-    "dedent": "^1.5.1",
+    "dedent": "^1.5.3",
     "deep-object-diff": "^1.1.9",
     "deepmerge": "^4.2.2",
     "media-query-parser": "^2.0.2",

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -18,7 +18,7 @@
     "@babel/plugin-syntax-typescript": "^7.23.3",
     "@vanilla-extract/babel-plugin-debug-ids": "^1.0.5",
     "@vanilla-extract/css": "^1.15.1",
-    "dedent": "^1.5.1",
+    "dedent": "^1.5.3",
     "esbuild": "npm:esbuild@~0.17.6 || ~0.18.0 || ~0.19.0",
     "eval": "0.1.8",
     "find-up": "^5.0.0",

--- a/packages/integration/src/addFileScope.test.ts
+++ b/packages/integration/src/addFileScope.test.ts
@@ -147,6 +147,24 @@ describe('ESM', () => {
       vanillaFileScope.endFileScope();
     `);
   });
+
+  test('should preserve non-template strings that contain newline characters', () => {
+    const source = `export const multiLineString = "\\nfoo\\n";`;
+
+    expect(
+      addFileScope({
+        source,
+        rootPath: '/the-root',
+        filePath: '/the-root/app/app.css.ts',
+        packageName: 'my-package',
+      }),
+    ).toMatchInlineSnapshot(`
+      import { setFileScope, endFileScope } from "@vanilla-extract/css/fileScope";
+      setFileScope("app/app.css.ts", "my-package");
+      export const multiLineString = "\\nfoo\\n";
+      endFileScope();
+    `);
+  });
 });
 
 describe('CJS', () => {
@@ -263,6 +281,24 @@ describe('CJS', () => {
 
       const myStyle = _css.style({});
       exports.myStyle = myStyle;
+      __vanilla_filescope__.endFileScope();
+    `);
+  });
+
+  test('should preserve non-template strings that contain newline characters', () => {
+    const source = `exports.multiLineString =  "\\nfoo\\n";`;
+
+    expect(
+      addFileScope({
+        source,
+        rootPath: '/the-root',
+        filePath: '/the-root/app/app.css.ts',
+        packageName: 'my-package',
+      }),
+    ).toMatchInlineSnapshot(`
+      const __vanilla_filescope__ = require("@vanilla-extract/css/fileScope");
+      __vanilla_filescope__.setFileScope("app/app.css.ts", "my-package");
+      exports.multiLineString =  "\\nfoo\\n";
       __vanilla_filescope__.endFileScope();
     `);
   });

--- a/packages/integration/src/addFileScope.ts
+++ b/packages/integration/src/addFileScope.ts
@@ -33,19 +33,19 @@ export function addFileScope({
     );
   } else {
     if (hasESM && !isMixed) {
-      source = dedent`
+      source = dedent(`
         import { setFileScope, endFileScope } from "@vanilla-extract/css/fileScope";
         setFileScope("${normalizedPath}", "${packageName}");
         ${source}
         endFileScope();
-      `;
+      `);
     } else {
-      source = dedent`
+      source = dedent(`
         const __vanilla_filescope__ = require("@vanilla-extract/css/fileScope");
         __vanilla_filescope__.setFileScope("${normalizedPath}", "${packageName}");
         ${source}
         __vanilla_filescope__.endFileScope();
-      `;
+      `);
     }
   }
 
@@ -55,12 +55,12 @@ export function addFileScope({
         ? 'import * as __vanilla_css_adapter__ from "@vanilla-extract/css/adapter";'
         : 'const __vanilla_css_adapter__ = require("@vanilla-extract/css/adapter");';
 
-    source = dedent`
+    source = dedent(`
       ${adapterImport}
       __vanilla_css_adapter__.setAdapter(${globalAdapterIdentifier});
       ${source}
       __vanilla_css_adapter__.removeAdapter();
-    `;
+    `);
   }
 
   return source;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -402,8 +402,8 @@ importers:
         specifier: ^3.0.7
         version: 3.0.10
       dedent:
-        specifier: ^1.5.1
-        version: 1.5.1
+        specifier: ^1.5.3
+        version: 1.5.3
       deep-object-diff:
         specifier: ^1.1.9
         version: 1.1.9
@@ -469,8 +469,8 @@ importers:
         specifier: ^1.15.1
         version: link:../css
       dedent:
-        specifier: ^1.5.1
-        version: 1.5.1
+        specifier: ^1.5.3
+        version: 1.5.3
       esbuild:
         specifier: npm:esbuild@~0.17.6 || ~0.18.0 || ~0.19.0
         version: 0.19.12
@@ -623,8 +623,8 @@ importers:
         specifier: ^2.5.1
         version: 2.5.1
       dedent:
-        specifier: ^1.5.1
-        version: 1.5.1
+        specifier: ^1.5.3
+        version: 1.5.3
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
@@ -5751,6 +5751,7 @@ packages:
       ws: 7.5.6
     transitivePeerDependencies:
       - '@types/node'
+      - babel-plugin-macros
       - bluebird
       - bufferutil
       - less
@@ -6808,20 +6809,22 @@ packages:
       - supports-color
     dev: true
 
-  /@vanilla-extract/css@1.15.0:
-    resolution: {integrity: sha512-B21dRQTiRJ9xMlW3RGOYMfGo11S2Bgcke6YrEJxGBovJFMsMwaex2mQC4XnVvreWMlYef+Na+zBUFDw7tfKMcw==}
+  /@vanilla-extract/css@1.15.1:
+    resolution: {integrity: sha512-puAfTKAUtsMr2+D+grQNjU5umsdw9zdVgQflUlbzS/tGORaAHdgaYz7jfKPmz1c4ZcpJ6uFNOiI50NDOAzzhyg==}
     dependencies:
       '@emotion/hash': 0.9.0
       '@vanilla-extract/private': 1.0.4
-      chalk: 4.1.2
       css-what: 6.1.0
       cssesc: 3.0.0
       csstype: 3.0.10
+      dedent: 1.5.3
       deep-object-diff: 1.1.9
       deepmerge: 4.2.2
       media-query-parser: 2.0.2
       modern-ahocorasick: 1.0.0
-      outdent: 0.8.0
+      picocolors: 1.0.0
+    transitivePeerDependencies:
+      - babel-plugin-macros
     dev: true
 
   /@vanilla-extract/integration@6.5.0(@types/node@20.9.5):
@@ -6830,7 +6833,7 @@ packages:
       '@babel/core': 7.23.9
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.23.9)
       '@vanilla-extract/babel-plugin-debug-ids': 1.0.5
-      '@vanilla-extract/css': 1.15.0
+      '@vanilla-extract/css': 1.15.1
       esbuild: 0.19.12
       eval: 0.1.8
       find-up: 5.0.0
@@ -6842,6 +6845,7 @@ packages:
       vite-node: 1.5.0(@types/node@20.9.5)
     transitivePeerDependencies:
       - '@types/node'
+      - babel-plugin-macros
       - less
       - lightningcss
       - sass
@@ -9277,14 +9281,13 @@ packages:
       strip-dirs: 2.1.0
     dev: true
 
-  /dedent@1.5.1:
-    resolution: {integrity: sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==}
+  /dedent@1.5.3:
+    resolution: {integrity: sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==}
     peerDependencies:
       babel-plugin-macros: ^3.1.0
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
-    dev: false
 
   /deep-eql@4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
@@ -12677,7 +12680,7 @@ packages:
       '@types/node': 20.9.5
       chalk: 4.1.2
       co: 4.6.0
-      dedent: 1.5.1
+      dedent: 1.5.3
       is-generator-fn: 2.1.0
       jest-each: 29.7.0
       jest-matcher-utils: 29.7.0

--- a/site/package.json
+++ b/site/package.json
@@ -14,7 +14,7 @@
     "@docsearch/react": "3.3.3",
     "@mdx-js/react": "^1.6.22",
     "classnames": "^2.5.1",
-    "dedent": "^1.5.1",
+    "dedent": "^1.5.3",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",


### PR DESCRIPTION
Fixes #1405.

TL;DR: multi-line strings with literal newlines were being manged by `dedent` (ultimately because of SWC, see extra notes below).

These used to be correctly dedented by `outdent` in `@vanilla-extract/integration@7.1.2`, but [since swapping to `dedent`](https://github.com/vanilla-extract-css/vanilla-extract/releases/tag/%40vanilla-extract%2Fintegration%407.1.3), it was no longer being handled correctly.

The fix is simple though: call `dedent` as a function, rather than a string tag. [This was actually a bug in `dedent` that was fixed relatively recently](https://github.com/dmnd/dedent/pull/91), hence the version bump.

## Extra notes

I was stumped for a while trying to reproduce this within VE's test suite. I was seeing identical output between `dedent` and `outdent`. I then realised that there are actually two loaders being used in the reproduction: Vanilla Extract's, and the swc loader.

It turns out that [swc targets ES3 syntax by default](https://github.com/swc-project/swc/blob/main/packages/types/index.ts#L9-L12). This results in all template strings being converted to regular strings, because template strings were only added in ES6. In the case of multi-line strings, you end up with something like:

```ts
// input
const multiLineString = `
    foo
`;

// SWC ES3 output (eventually mangled by dedent)
var multiLineString = "\n   foo\n";
```

So an alternative way to fix this is to configure storybook to either not use SWC, or configure SWC to target ES6 or greater:

```ts
// .storybook/main.js
const config = {
  swc: (config) => {
    return {
      ...config,
      jsc: {
        ...config.jsc,
        target: "es6",
      },
    };
  },
}
```

Obviously fixing the issue within VE is the best option, but I'm glad I'm at least aware of potential Storybook + SWC issues going forward.