### PR TITLE
css: Fix conditional rule merging bug

### DIFF
--- a/.changeset/four-humans-hammer.md
+++ b/.changeset/four-humans-hammer.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': patch
+---
+
+Fixes a bug where declarations with identical selectors would not be merged correctly inside conditional rules

--- a/packages/css/src/conditionalRulesets.ts
+++ b/packages/css/src/conditionalRulesets.ts
@@ -196,7 +196,10 @@ export class ConditionalRuleset {
       const selectors: any = {};
 
       for (const rule of rules) {
-        selectors[rule.selector] = rule.rule;
+        selectors[rule.selector] = {
+          ...selectors[rule.selector],
+          ...rule.rule,
+        };
       }
 
       Object.assign(selectors, ...children.renderToArray());

--- a/packages/css/src/conditionalRulesets.ts
+++ b/packages/css/src/conditionalRulesets.ts
@@ -197,6 +197,7 @@ export class ConditionalRuleset {
 
       for (const rule of rules) {
         selectors[rule.selector] = {
+          // Preserve existing declarations if a rule with the same selector has already been added
           ...selectors[rule.selector],
           ...rule.rule,
         };

--- a/packages/css/src/transformCss.test.ts
+++ b/packages/css/src/transformCss.test.ts
@@ -583,6 +583,7 @@ describe('transformCss', () => {
       @layer myLayer;
       @layer myLayer {
         .testClass {
+          color: red;
           font-size: 32px;
         }
       }

--- a/packages/css/src/transformCss.test.ts
+++ b/packages/css/src/transformCss.test.ts
@@ -549,6 +549,46 @@ describe('transformCss', () => {
     `);
   });
 
+  it.only('should merge declarations with the same selector when merging conditional rules', () => {
+    expect(
+      transformCss({
+        composedClassLists: [],
+        localClassNames: [],
+        cssObjs: [
+          {
+            type: 'local',
+            selector: '.testClass',
+            rule: {
+              '@layer': {
+                myLayer: {
+                  color: 'red',
+                },
+              },
+            },
+          },
+          {
+            type: 'local',
+            selector: '.testClass',
+            rule: {
+              '@layer': {
+                myLayer: {
+                  fontSize: '32px',
+                },
+              },
+            },
+          },
+        ],
+      }).join('\n'),
+    ).toMatchInlineSnapshot(`
+      @layer myLayer;
+      @layer myLayer {
+        .testClass {
+          font-size: 32px;
+        }
+      }
+    `);
+  });
+
   it('should handle simple pseudos', () => {
     expect(
       transformCss({

--- a/packages/css/src/transformCss.test.ts
+++ b/packages/css/src/transformCss.test.ts
@@ -549,7 +549,7 @@ describe('transformCss', () => {
     `);
   });
 
-  it.only('should merge declarations with the same selector when merging conditional rules', () => {
+  it('should merge declarations with the same selector when merging conditional rules', () => {
     expect(
       transformCss({
         composedClassLists: [],


### PR DESCRIPTION
Fixes #1417.

This fix doesn't preserve the separate declarations, but AFAIK this doesn't have any practical effect on the CSS, other than making it smaller. I also don't think it would be possible to preserve the separate declarations without refactoring how the merging works, so I'm happy with this solution for now.