### PR TITLE
Fix changes to nested imports not updating styles during development

### DIFF
--- a/.changeset/chilled-paws-shop.md
+++ b/.changeset/chilled-paws-shop.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Correctly update rendered styles when changes are made to .css.ts files imported by .css.ts files

--- a/.changeset/chilled-paws-shop.md
+++ b/.changeset/chilled-paws-shop.md
@@ -2,4 +2,4 @@
 '@vanilla-extract/vite-plugin': patch
 ---
 
-Correctly update rendered styles when changes are made to .css.ts files imported by .css.ts files
+Fixes a bug where changes to `.css.ts` dependencies of top-level `.css.ts` files would not generate new CSS

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -213,8 +213,14 @@ export function vanillaExtractPlugin({
 
         addWatchFiles.call(this, absoluteId, watchFiles);
 
-        // We have to invalidate the virtual module, not the real one we just transformed
-        invalidateModule(fileIdToVirtualId(absoluteId));
+        // We have to invalidate the virtual module & deps, not the real one we just transformed
+        // The deps have to be invalidate in case one of them changing was the trigger causing
+        // the current transformation
+        Array.from(watchFiles).forEach((file) => {
+          if (file.endsWith('.css.ts')) {
+            invalidateModule(fileIdToVirtualId(file));
+          }
+        });
 
         return {
           code: source,

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -196,7 +196,7 @@ export function vanillaExtractPlugin({
         const result: TransformResult = {
           code: source,
           map: { mappings: '' },
-        }
+        };
 
         // We don't need to watch files in build mode
         if (config.command === 'build' && !config.build.watch) {
@@ -204,7 +204,10 @@ export function vanillaExtractPlugin({
         }
 
         for (const file of watchFiles) {
-          if (!file.includes('node_modules') && normalizePath(file) !== absoluteId) {
+          if (
+            !file.includes('node_modules') &&
+            normalizePath(file) !== absoluteId
+          ) {
             this.addWatchFile(file);
           }
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -5,8 +5,8 @@ import type {
   ResolvedConfig,
   ConfigEnv,
   ViteDevServer,
-  Rollup,
   PluginOption,
+  TransformResult,
   UserConfig,
 } from 'vite';
 import {
@@ -92,23 +92,6 @@ export function vanillaExtractPlugin({
         // Vite uses this timestamp to add `?t=` query string automatically for HMR.
         module.lastHMRTimestamp =
           module.lastInvalidationTimestamp || Date.now();
-      }
-    }
-  }
-
-  function addWatchFiles(
-    this: Rollup.PluginContext,
-    fromId: string,
-    files: Set<string>,
-  ) {
-    // We don't need to watch files in build mode
-    if (config.command === 'build' && !config.build.watch) {
-      return;
-    }
-
-    for (const file of files) {
-      if (!file.includes('node_modules') && normalizePath(file) !== fromId) {
-        this.addWatchFile(file);
       }
     }
   }
@@ -210,22 +193,30 @@ export function vanillaExtractPlugin({
           absoluteId,
           { outputCss: true },
         );
+        const result: TransformResult = {
+          code: source,
+          map: { mappings: '' },
+        }
 
-        addWatchFiles.call(this, absoluteId, watchFiles);
+        // We don't need to watch files in build mode
+        if (config.command === 'build' && !config.build.watch) {
+          return result;
+        }
 
-        // We have to invalidate the virtual module & deps, not the real one we just transformed
-        // The deps have to be invalidate in case one of them changing was the trigger causing
-        // the current transformation
-        Array.from(watchFiles).forEach((file) => {
+        for (const file of watchFiles) {
+          if (!file.includes('node_modules') && normalizePath(file) !== absoluteId) {
+            this.addWatchFile(file);
+          }
+
+          // We have to invalidate the virtual module & deps, not the real one we just transformed
+          // The deps have to be invalidated in case one of them changing was the trigger causing
+          // the current transformation
           if (file.endsWith('.css.ts')) {
             invalidateModule(fileIdToVirtualId(file));
           }
-        });
+        }
 
-        return {
-          code: source,
-          map: { mappings: '' },
-        };
+        return result;
       }
     },
     resolveId(source) {


### PR DESCRIPTION
Fixes https://github.com/vanilla-extract-css/vanilla-extract/issues/1427

Tracked down an issue where .css.ts files that are imported by .css.ts files trigger updates, but changes aren't propagated to rendered component during development. By invalidating all deps of a .css.ts file, instead of just the root file, the expected behavior occurs.