### PR TITLE
fix(integration): Don't update filescope if already set

### DIFF
--- a/packages/integration/src/addFileScope.ts
+++ b/packages/integration/src/addFileScope.ts
@@ -26,12 +26,7 @@ export function addFileScope({
 
   const { hasESM, isMixed } = detectSyntax(source);
 
-  if (source.includes('@vanilla-extract/css/fileScope')) {
-    source = source.replace(
-      /setFileScope\(((\n|.)*?)\)/,
-      `setFileScope("${normalizedPath}", "${packageName}")`,
-    );
-  } else {
+  if (!source.includes('@vanilla-extract/css/fileScope')) {
     if (hasESM && !isMixed) {
       source = dedent(`
         import { setFileScope, endFileScope } from "@vanilla-extract/css/fileScope";


### PR DESCRIPTION
Raising the PR to get the discussion started.

Fixes Issues:-
- https://github.com/vanilla-extract-css/vanilla-extract/issues/1441
- https://github.com/vanilla-extract-css/vanilla-extract/issues/940

If we try to consume a library build on Vanilla Extract which just transpiles the styles files, then this replacement of `setFileScope` causes issues in classNames not being consistent because the server takes from the cjs build while client takes form the esm build. This causes the hash of the classNames to differ since @vanilla-extract/integration package again updates the fileScope but differently for cjs and esm files.

I think if the fileScope is already set by the library author, then the consumer app should not be updating it again. 🤔 I may not fully understand the reason why this is done, but I'm happy to help and contribute