### PR TITLE
Widen `esbuild` dependency range, update dev deps

### DIFF
--- a/.changeset/plenty-hairs-change.md
+++ b/.changeset/plenty-hairs-change.md
@@ -1,0 +1,6 @@
+---
+'@vanilla-extract/jest-transform': patch
+'@vanilla-extract/integration': patch
+---
+
+Widen `esbuild` dependency range to include `~0.22.0` and `~0.23.0`

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "rollup": "^2.7.0",
     "rollup-plugin-dts": "^4.2.2",
     "rollup-plugin-node-externals": "^5.0.0",
-    "tsx": "^4.7.2",
-    "typescript": "^5.3.3",
+    "tsx": "^4.17.0",
+    "typescript": "^5.5.4",
     "vitest": "^1.5.0"
   },
   "preconstruct": {

--- a/packages/esbuild-plugin-next/package.json
+++ b/packages/esbuild-plugin-next/package.json
@@ -28,6 +28,6 @@
     }
   },
   "devDependencies": {
-    "esbuild": "~0.21.5"
+    "esbuild": "~0.23.1"
   }
 }

--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -27,6 +27,6 @@
     }
   },
   "devDependencies": {
-    "esbuild": "~0.21.5"
+    "esbuild": "~0.23.1"
   }
 }

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -20,7 +20,7 @@
     "@vanilla-extract/babel-plugin-debug-ids": "workspace:^",
     "@vanilla-extract/css": "workspace:^",
     "dedent": "^1.5.3",
-    "esbuild": "npm:esbuild@~0.17.6 || ~0.18.0 || ~0.19.0 || ~0.20.0 || ~0.21.0",
+    "esbuild": "npm:esbuild@>=0.17.6 <0.24.0",
     "eval": "0.1.8",
     "find-up": "^5.0.0",
     "javascript-stringify": "^2.0.1",

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "dependencies": {
     "@vanilla-extract/integration": "workspace:^",
-    "esbuild": "npm:esbuild@~0.17.6 || ~0.18.0 || ~0.19.0 || ~0.20.0 || ~0.21.0"
+    "esbuild": "npm:esbuild@>=0.17.6 <0.24.0"
   },
   "devDependencies": {
     "@jest/transform": "^29.0.3"

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -22,7 +22,7 @@
     "@fixtures/themed": "workspace:*",
     "@rollup/plugin-json": "^4.1.0",
     "@vanilla-extract/css": "workspace:^",
-    "esbuild": "~0.21.5",
+    "esbuild": "~0.23.1",
     "rollup": "^2.7.0",
     "rollup-plugin-esbuild": "^4.9.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,7 +472,7 @@ importers:
         specifier: ^1.5.3
         version: 1.5.3
       esbuild:
-        specifier: npm:esbuild@~0.17.6 || ~0.18.0 || ~0.19.0 || ~0.20.0 || ~0.21.0
+        specifier: npm:esbuild@>=0.17.6 <0.24.0
         version: 0.21.5
       eval:
         specifier: 0.1.8
@@ -503,7 +503,7 @@ importers:
         specifier: workspace:^
         version: link:../integration
       esbuild:
-        specifier: npm:esbuild@~0.17.6 || ~0.18.0 || ~0.19.0 || ~0.20.0 || ~0.21.0
+        specifier: npm:esbuild@>=0.17.6 <0.24.0
         version: 0.21.5
     devDependencies:
       '@jest/transform':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 2.8.2
       '@testing-library/jest-dom':
         specifier: ^6.4.2
-        version: 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3)))(vitest@1.5.0(@types/node@20.9.5)(jsdom@20.0.3)(terser@5.26.0))
+        version: 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4)))(vitest@1.5.0(@types/node@20.9.5)(jsdom@20.0.3)(terser@5.26.0))
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -58,7 +58,7 @@ importers:
         version: 3.3.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))
+        version: 29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -73,16 +73,16 @@ importers:
         version: 2.79.1
       rollup-plugin-dts:
         specifier: ^4.2.2
-        version: 4.2.2(rollup@2.79.1)(typescript@5.3.3)
+        version: 4.2.2(rollup@2.79.1)(typescript@5.5.4)
       rollup-plugin-node-externals:
         specifier: ^5.0.0
         version: 5.0.0(rollup@2.79.1)
       tsx:
-        specifier: ^4.7.2
-        version: 4.7.2
+        specifier: ^4.17.0
+        version: 4.17.0
       typescript:
-        specifier: ^5.3.3
-        version: 5.3.3
+        specifier: ^5.5.4
+        version: 5.5.4
       vitest:
         specifier: ^1.5.0
         version: 1.5.0(@types/node@20.9.5)(jsdom@20.0.3)(terser@5.26.0)
@@ -113,13 +113,13 @@ importers:
     dependencies:
       '@remix-run/node':
         specifier: ^2.8.0
-        version: 2.8.0(typescript@5.3.3)
+        version: 2.8.0(typescript@5.5.4)
       '@remix-run/react':
         specifier: ^2.8.0
-        version: 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)
+        version: 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4)
       '@remix-run/serve':
         specifier: ^2.8.0
-        version: 2.8.0(typescript@5.3.3)
+        version: 2.8.0(typescript@5.5.4)
       '@vanilla-extract/css':
         specifier: workspace:*
         version: link:../../packages/css
@@ -135,7 +135,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.8.0
-        version: 2.8.0(@remix-run/serve@2.8.0(typescript@5.3.3))(@types/node@20.9.5)(terser@5.26.0)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))(typescript@5.3.3)(vite@5.1.4(@types/node@20.9.5)(terser@5.26.0))
+        version: 2.8.0(@remix-run/serve@2.8.0(typescript@5.5.4))(@types/node@20.9.5)(terser@5.26.0)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))(typescript@5.5.4)(vite@5.1.4(@types/node@20.9.5)(terser@5.26.0))
       '@types/react':
         specifier: ^18.2.55
         version: 18.2.55
@@ -189,7 +189,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       tailwindcss:
         specifier: ^2.1.2
-        version: 2.2.19(autoprefixer@10.4.17(postcss@8.4.35))(postcss@8.4.35)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))
+        version: 2.2.19(autoprefixer@10.4.17(postcss@8.4.35))(postcss@8.4.35)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))
       webpack:
         specifier: ^5.90.0
         version: 5.90.0(webpack-cli@5.1.4)
@@ -441,8 +441,8 @@ importers:
         version: link:../integration
     devDependencies:
       esbuild:
-        specifier: ~0.21.5
-        version: 0.21.5
+        specifier: ~0.23.1
+        version: 0.23.1
 
   packages/esbuild-plugin-next:
     dependencies:
@@ -451,8 +451,8 @@ importers:
         version: link:../integration
     devDependencies:
       esbuild:
-        specifier: ~0.21.5
-        version: 0.21.5
+        specifier: ~0.23.1
+        version: 0.23.1
 
   packages/integration:
     dependencies:
@@ -473,7 +473,7 @@ importers:
         version: 1.5.3
       esbuild:
         specifier: npm:esbuild@>=0.17.6 <0.24.0
-        version: 0.21.5
+        version: 0.23.1
       eval:
         specifier: 0.1.8
         version: 0.1.8
@@ -504,7 +504,7 @@ importers:
         version: link:../integration
       esbuild:
         specifier: npm:esbuild@>=0.17.6 <0.24.0
-        version: 0.21.5
+        version: 0.23.1
     devDependencies:
       '@jest/transform':
         specifier: ^29.0.3
@@ -556,14 +556,14 @@ importers:
         specifier: workspace:^
         version: link:../css
       esbuild:
-        specifier: ~0.21.5
-        version: 0.21.5
+        specifier: ~0.23.1
+        version: 0.23.1
       rollup:
         specifier: ^2.7.0
         version: 2.79.1
       rollup-plugin-esbuild:
         specifier: ^4.9.1
-        version: 4.9.1(esbuild@0.21.5)(rollup@2.79.1)
+        version: 4.9.1(esbuild@0.23.1)(rollup@2.79.1)
 
   packages/sprinkles:
     devDependencies:
@@ -808,7 +808,7 @@ importers:
         version: 2.11.0
       '@types/mini-css-extract-plugin':
         specifier: ^1.2.2
-        version: 1.4.3(esbuild@0.21.5)
+        version: 1.4.3(esbuild@0.23.1)
       '@types/webpack-dev-server':
         specifier: ^3.11.1
         version: 3.11.6
@@ -829,10 +829,10 @@ importers:
         version: link:../packages/webpack-plugin
       babel-loader:
         specifier: ^9.1.3
-        version: 9.1.3(@babel/core@7.23.9)(webpack@5.90.0(esbuild@0.21.5))
+        version: 9.1.3(@babel/core@7.23.9)(webpack@5.90.0(esbuild@0.23.1))
       css-loader:
         specifier: ^6.9.1
-        version: 6.10.0(webpack@5.90.0(esbuild@0.21.5))
+        version: 6.10.0(webpack@5.90.0(esbuild@0.23.1))
       cssnano:
         specifier: ^5.1.15
         version: 5.1.15(postcss@8.4.35)
@@ -840,17 +840,17 @@ importers:
         specifier: ^2.1.3
         version: 2.1.3(postcss@8.4.35)
       esbuild:
-        specifier: ~0.21.5
-        version: 0.21.5
+        specifier: ~0.23.1
+        version: 0.23.1
       got:
         specifier: ^11.8.2
         version: 11.8.3
       html-webpack-plugin:
         specifier: ^5.3.1
-        version: 5.5.0(webpack@5.90.0(esbuild@0.21.5))
+        version: 5.5.0(webpack@5.90.0(esbuild@0.23.1))
       mini-css-extract-plugin:
         specifier: ^2.7.7
-        version: 2.7.7(webpack@5.90.0(esbuild@0.21.5))
+        version: 2.7.7(webpack@5.90.0(esbuild@0.23.1))
       minimist:
         specifier: ^1.2.5
         version: 1.2.8
@@ -871,7 +871,7 @@ importers:
         version: 6.1.3
       style-loader:
         specifier: ^2.0.0
-        version: 2.0.0(webpack@5.90.0(esbuild@0.21.5))
+        version: 2.0.0(webpack@5.90.0(esbuild@0.23.1))
       vite:
         specifier: ^5.0.11
         version: 5.1.4(@types/node@20.9.5)(terser@5.26.0)
@@ -880,10 +880,10 @@ importers:
         version: 0.8.3(rollup@4.9.1)(vite@5.1.4(@types/node@20.9.5)(terser@5.26.0))
       webpack:
         specifier: ^5.90.0
-        version: 5.90.0(esbuild@0.21.5)
+        version: 5.90.0(esbuild@0.23.1)
       webpack-dev-server:
         specifier: ^4.15.1
-        version: 4.15.1(webpack@5.90.0(esbuild@0.21.5))
+        version: 4.15.1(webpack@5.90.0(esbuild@0.23.1))
       webpack-merge:
         specifier: ^5.7.3
         version: 5.8.0
@@ -908,7 +908,7 @@ importers:
         version: 10.0.0
       '@testing-library/jest-dom':
         specifier: ^6.4.2
-        version: 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3)))(vitest@1.5.0(@types/node@20.9.5)(jsdom@20.0.3)(terser@5.26.0))
+        version: 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4)))(vitest@1.5.0(@types/node@20.9.5)(jsdom@20.0.3)(terser@5.26.0))
       '@vanilla-extract-private/test-helpers':
         specifier: workspace:*
         version: link:../test-helpers
@@ -932,7 +932,7 @@ importers:
         version: link:../packages/sprinkles
       vite-tsconfig-paths:
         specifier: ^4.3.1
-        version: 4.3.1(typescript@5.3.3)(vite@5.1.4(@types/node@20.9.5)(terser@5.26.0))
+        version: 4.3.1(typescript@5.5.4)(vite@5.1.4(@types/node@20.9.5)(terser@5.26.0))
 
 packages:
 
@@ -1807,9 +1807,9 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.21.5':
-    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
-    engines: {node: '>=12'}
+  '@esbuild/aix-ppc64@0.23.1':
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
@@ -1825,9 +1825,9 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.21.5':
-    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm64@0.23.1':
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -1843,9 +1843,9 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.21.5':
-    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
-    engines: {node: '>=12'}
+  '@esbuild/android-arm@0.23.1':
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
@@ -1861,9 +1861,9 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.21.5':
-    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
-    engines: {node: '>=12'}
+  '@esbuild/android-x64@0.23.1':
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -1879,9 +1879,9 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.21.5':
-    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-arm64@0.23.1':
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
@@ -1897,9 +1897,9 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.21.5':
-    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
-    engines: {node: '>=12'}
+  '@esbuild/darwin-x64@0.23.1':
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -1915,9 +1915,9 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.21.5':
-    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-arm64@0.23.1':
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
@@ -1933,9 +1933,9 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.21.5':
-    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
-    engines: {node: '>=12'}
+  '@esbuild/freebsd-x64@0.23.1':
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -1951,9 +1951,9 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.21.5':
-    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm64@0.23.1':
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
@@ -1969,9 +1969,9 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.21.5':
-    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-arm@0.23.1':
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -1987,9 +1987,9 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.21.5':
-    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ia32@0.23.1':
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
@@ -2005,9 +2005,9 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.21.5':
-    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-loong64@0.23.1':
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -2023,9 +2023,9 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.21.5':
-    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-mips64el@0.23.1':
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
@@ -2041,9 +2041,9 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.21.5':
-    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-ppc64@0.23.1':
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -2059,9 +2059,9 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.21.5':
-    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-riscv64@0.23.1':
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
@@ -2077,9 +2077,9 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.21.5':
-    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-s390x@0.23.1':
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -2095,9 +2095,9 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.21.5':
-    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
-    engines: {node: '>=12'}
+  '@esbuild/linux-x64@0.23.1':
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
@@ -2113,11 +2113,17 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.21.5':
-    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
-    engines: {node: '>=12'}
+  '@esbuild/netbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.23.1':
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.17.6':
     resolution: {integrity: sha512-xaxeSunhQRsTNGFanoOkkLtnmMn5QbA0qBhNet/XLVsc+OVkpIWPHcr3zTW2gxVU5YOHFbIHR9ODuaUdNza2Vw==}
@@ -2131,9 +2137,9 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.21.5':
-    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
-    engines: {node: '>=12'}
+  '@esbuild/openbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
@@ -2149,9 +2155,9 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.21.5':
-    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
-    engines: {node: '>=12'}
+  '@esbuild/sunos-x64@0.23.1':
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -2167,9 +2173,9 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.21.5':
-    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-arm64@0.23.1':
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -2185,9 +2191,9 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.21.5':
-    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-ia32@0.23.1':
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+    engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
@@ -2203,9 +2209,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.21.5':
-    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
-    engines: {node: '>=12'}
+  '@esbuild/win32-x64@0.23.1':
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -5701,9 +5707,9 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
-  esbuild@0.21.5:
-    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
-    engines: {node: '>=12'}
+  esbuild@0.23.1:
+    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.1.1:
@@ -6247,8 +6253,8 @@ packages:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
     engines: {node: '>= 0.4'}
 
-  get-tsconfig@4.7.3:
-    resolution: {integrity: sha512-ZvkrzoUA0PQZM6fy6+/Hce561s+faD1rsNwhnO5FelNjyy7EMGJ3Rz1AQ8GYDWjhRs/7dBLOEJvhK8MiEJOAFg==}
+  get-tsconfig@4.7.6:
+    resolution: {integrity: sha512-ZAqrLlu18NbDdRaHq+AKXzAmqIUPswPWKUchfytdAjiRFnCe5ojG2bstg6mRiZabkKfCoL/e98pbBELIV/YCeA==}
 
   get-value@2.0.6:
     resolution: {integrity: sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==}
@@ -10720,8 +10726,8 @@ packages:
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
-  tsx@4.7.2:
-    resolution: {integrity: sha512-BCNd4kz6fz12fyrgCTEdZHGJ9fWTGeUzXmQysh0RVocDY3h4frk05ZNCXSy4kIenF7y/QnrdiVpTsyNRn6vlAw==}
+  tsx@4.17.0:
+    resolution: {integrity: sha512-eN4mnDA5UMKDt4YZixo9tBioibaMBpoxBkD+rIPAjVmYERSG0/dWEY1CEFuV89CgASlKL499q8AhmkMnnjtOJg==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -10801,8 +10807,8 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  typescript@5.3.3:
-    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+  typescript@5.5.4:
+    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -12698,7 +12704,7 @@ snapshots:
   '@esbuild/aix-ppc64@0.19.12':
     optional: true
 
-  '@esbuild/aix-ppc64@0.21.5':
+  '@esbuild/aix-ppc64@0.23.1':
     optional: true
 
   '@esbuild/android-arm64@0.17.6':
@@ -12707,7 +12713,7 @@ snapshots:
   '@esbuild/android-arm64@0.19.12':
     optional: true
 
-  '@esbuild/android-arm64@0.21.5':
+  '@esbuild/android-arm64@0.23.1':
     optional: true
 
   '@esbuild/android-arm@0.17.6':
@@ -12716,7 +12722,7 @@ snapshots:
   '@esbuild/android-arm@0.19.12':
     optional: true
 
-  '@esbuild/android-arm@0.21.5':
+  '@esbuild/android-arm@0.23.1':
     optional: true
 
   '@esbuild/android-x64@0.17.6':
@@ -12725,7 +12731,7 @@ snapshots:
   '@esbuild/android-x64@0.19.12':
     optional: true
 
-  '@esbuild/android-x64@0.21.5':
+  '@esbuild/android-x64@0.23.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.17.6':
@@ -12734,7 +12740,7 @@ snapshots:
   '@esbuild/darwin-arm64@0.19.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.21.5':
+  '@esbuild/darwin-arm64@0.23.1':
     optional: true
 
   '@esbuild/darwin-x64@0.17.6':
@@ -12743,7 +12749,7 @@ snapshots:
   '@esbuild/darwin-x64@0.19.12':
     optional: true
 
-  '@esbuild/darwin-x64@0.21.5':
+  '@esbuild/darwin-x64@0.23.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.17.6':
@@ -12752,7 +12758,7 @@ snapshots:
   '@esbuild/freebsd-arm64@0.19.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.21.5':
+  '@esbuild/freebsd-arm64@0.23.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.17.6':
@@ -12761,7 +12767,7 @@ snapshots:
   '@esbuild/freebsd-x64@0.19.12':
     optional: true
 
-  '@esbuild/freebsd-x64@0.21.5':
+  '@esbuild/freebsd-x64@0.23.1':
     optional: true
 
   '@esbuild/linux-arm64@0.17.6':
@@ -12770,7 +12776,7 @@ snapshots:
   '@esbuild/linux-arm64@0.19.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.21.5':
+  '@esbuild/linux-arm64@0.23.1':
     optional: true
 
   '@esbuild/linux-arm@0.17.6':
@@ -12779,7 +12785,7 @@ snapshots:
   '@esbuild/linux-arm@0.19.12':
     optional: true
 
-  '@esbuild/linux-arm@0.21.5':
+  '@esbuild/linux-arm@0.23.1':
     optional: true
 
   '@esbuild/linux-ia32@0.17.6':
@@ -12788,7 +12794,7 @@ snapshots:
   '@esbuild/linux-ia32@0.19.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.21.5':
+  '@esbuild/linux-ia32@0.23.1':
     optional: true
 
   '@esbuild/linux-loong64@0.17.6':
@@ -12797,7 +12803,7 @@ snapshots:
   '@esbuild/linux-loong64@0.19.12':
     optional: true
 
-  '@esbuild/linux-loong64@0.21.5':
+  '@esbuild/linux-loong64@0.23.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.17.6':
@@ -12806,7 +12812,7 @@ snapshots:
   '@esbuild/linux-mips64el@0.19.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.21.5':
+  '@esbuild/linux-mips64el@0.23.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.17.6':
@@ -12815,7 +12821,7 @@ snapshots:
   '@esbuild/linux-ppc64@0.19.12':
     optional: true
 
-  '@esbuild/linux-ppc64@0.21.5':
+  '@esbuild/linux-ppc64@0.23.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.17.6':
@@ -12824,7 +12830,7 @@ snapshots:
   '@esbuild/linux-riscv64@0.19.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.21.5':
+  '@esbuild/linux-riscv64@0.23.1':
     optional: true
 
   '@esbuild/linux-s390x@0.17.6':
@@ -12833,7 +12839,7 @@ snapshots:
   '@esbuild/linux-s390x@0.19.12':
     optional: true
 
-  '@esbuild/linux-s390x@0.21.5':
+  '@esbuild/linux-s390x@0.23.1':
     optional: true
 
   '@esbuild/linux-x64@0.17.6':
@@ -12842,7 +12848,7 @@ snapshots:
   '@esbuild/linux-x64@0.19.12':
     optional: true
 
-  '@esbuild/linux-x64@0.21.5':
+  '@esbuild/linux-x64@0.23.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.17.6':
@@ -12851,7 +12857,10 @@ snapshots:
   '@esbuild/netbsd-x64@0.19.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.21.5':
+  '@esbuild/netbsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.23.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.17.6':
@@ -12860,7 +12869,7 @@ snapshots:
   '@esbuild/openbsd-x64@0.19.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.21.5':
+  '@esbuild/openbsd-x64@0.23.1':
     optional: true
 
   '@esbuild/sunos-x64@0.17.6':
@@ -12869,7 +12878,7 @@ snapshots:
   '@esbuild/sunos-x64@0.19.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.21.5':
+  '@esbuild/sunos-x64@0.23.1':
     optional: true
 
   '@esbuild/win32-arm64@0.17.6':
@@ -12878,7 +12887,7 @@ snapshots:
   '@esbuild/win32-arm64@0.19.12':
     optional: true
 
-  '@esbuild/win32-arm64@0.21.5':
+  '@esbuild/win32-arm64@0.23.1':
     optional: true
 
   '@esbuild/win32-ia32@0.17.6':
@@ -12887,7 +12896,7 @@ snapshots:
   '@esbuild/win32-ia32@0.19.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.21.5':
+  '@esbuild/win32-ia32@0.23.1':
     optional: true
 
   '@esbuild/win32-x64@0.17.6':
@@ -12896,7 +12905,7 @@ snapshots:
   '@esbuild/win32-x64@0.19.12':
     optional: true
 
-  '@esbuild/win32-x64@0.21.5':
+  '@esbuild/win32-x64@0.23.1':
     optional: true
 
   '@import-maps/resolve@1.0.1': {}
@@ -12929,7 +12938,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))':
+  '@jest/core@29.7.0(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -12943,7 +12952,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))
+      jest-config: 29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -14576,7 +14585,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@remix-run/dev@2.8.0(@remix-run/serve@2.8.0(typescript@5.3.3))(@types/node@20.9.5)(terser@5.26.0)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))(typescript@5.3.3)(vite@5.1.4(@types/node@20.9.5)(terser@5.26.0))':
+  '@remix-run/dev@2.8.0(@remix-run/serve@2.8.0(typescript@5.5.4))(@types/node@20.9.5)(terser@5.26.0)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))(typescript@5.5.4)(vite@5.1.4(@types/node@20.9.5)(terser@5.26.0))':
     dependencies:
       '@babel/core': 7.23.9
       '@babel/generator': 7.23.6
@@ -14588,9 +14597,9 @@ snapshots:
       '@babel/types': 7.23.9
       '@mdx-js/mdx': 2.3.0
       '@npmcli/package-json': 4.0.1
-      '@remix-run/node': 2.8.0(typescript@5.3.3)
+      '@remix-run/node': 2.8.0(typescript@5.5.4)
       '@remix-run/router': 1.15.2
-      '@remix-run/server-runtime': 2.8.0(typescript@5.3.3)
+      '@remix-run/server-runtime': 2.8.0(typescript@5.5.4)
       '@types/mdx': 2.0.11
       '@vanilla-extract/integration': 6.5.0(@types/node@20.9.5)(terser@5.26.0)
       arg: 5.0.2
@@ -14619,7 +14628,7 @@ snapshots:
       pidtree: 0.6.0
       postcss: 8.4.35
       postcss-discard-duplicates: 5.1.0(postcss@8.4.35)
-      postcss-load-config: 4.0.2(postcss@8.4.35)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))
+      postcss-load-config: 4.0.2(postcss@8.4.35)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))
       postcss-modules: 6.0.0(postcss@8.4.35)
       prettier: 2.8.8
       pretty-ms: 7.0.1
@@ -14632,8 +14641,8 @@ snapshots:
       tsconfig-paths: 4.2.0
       ws: 7.5.6
     optionalDependencies:
-      '@remix-run/serve': 2.8.0(typescript@5.3.3)
-      typescript: 5.3.3
+      '@remix-run/serve': 2.8.0(typescript@5.5.4)
+      typescript: 5.5.4
       vite: 5.1.4(@types/node@20.9.5)(terser@5.26.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -14650,16 +14659,16 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@remix-run/express@2.8.0(express@4.18.2)(typescript@5.3.3)':
+  '@remix-run/express@2.8.0(express@4.18.2)(typescript@5.5.4)':
     dependencies:
-      '@remix-run/node': 2.8.0(typescript@5.3.3)
+      '@remix-run/node': 2.8.0(typescript@5.5.4)
       express: 4.18.2
     optionalDependencies:
-      typescript: 5.3.3
+      typescript: 5.5.4
 
-  '@remix-run/node@2.8.0(typescript@5.3.3)':
+  '@remix-run/node@2.8.0(typescript@5.5.4)':
     dependencies:
-      '@remix-run/server-runtime': 2.8.0(typescript@5.3.3)
+      '@remix-run/server-runtime': 2.8.0(typescript@5.5.4)
       '@remix-run/web-fetch': 4.4.2
       '@remix-run/web-file': 3.1.0
       '@remix-run/web-stream': 1.1.0
@@ -14668,25 +14677,25 @@ snapshots:
       source-map-support: 0.5.21
       stream-slice: 0.1.2
     optionalDependencies:
-      typescript: 5.3.3
+      typescript: 5.5.4
 
-  '@remix-run/react@2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.3.3)':
+  '@remix-run/react@2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4)':
     dependencies:
       '@remix-run/router': 1.15.2
-      '@remix-run/server-runtime': 2.8.0(typescript@5.3.3)
+      '@remix-run/server-runtime': 2.8.0(typescript@5.5.4)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-router: 6.22.2(react@18.2.0)
       react-router-dom: 6.22.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     optionalDependencies:
-      typescript: 5.3.3
+      typescript: 5.5.4
 
   '@remix-run/router@1.15.2': {}
 
-  '@remix-run/serve@2.8.0(typescript@5.3.3)':
+  '@remix-run/serve@2.8.0(typescript@5.5.4)':
     dependencies:
-      '@remix-run/express': 2.8.0(express@4.18.2)(typescript@5.3.3)
-      '@remix-run/node': 2.8.0(typescript@5.3.3)
+      '@remix-run/express': 2.8.0(express@4.18.2)(typescript@5.5.4)
+      '@remix-run/node': 2.8.0(typescript@5.5.4)
       chokidar: 3.5.3
       compression: 1.7.4
       express: 4.18.2
@@ -14697,7 +14706,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@remix-run/server-runtime@2.8.0(typescript@5.3.3)':
+  '@remix-run/server-runtime@2.8.0(typescript@5.5.4)':
     dependencies:
       '@remix-run/router': 1.15.2
       '@types/cookie': 0.6.0
@@ -14706,7 +14715,7 @@ snapshots:
       set-cookie-parser: 2.6.0
       source-map: 0.7.3
     optionalDependencies:
-      typescript: 5.3.3
+      typescript: 5.5.4
 
   '@remix-run/web-blob@3.1.0':
     dependencies:
@@ -14915,7 +14924,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3)))(vitest@1.5.0(@types/node@20.9.5)(jsdom@20.0.3)(terser@5.26.0))':
+  '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4)))(vitest@1.5.0(@types/node@20.9.5)(jsdom@20.0.3)(terser@5.26.0))':
     dependencies:
       '@adobe/css-tools': 4.3.3
       '@babel/runtime': 7.23.9
@@ -14928,7 +14937,7 @@ snapshots:
     optionalDependencies:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.12
-      jest: 29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))
+      jest: 29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))
       vitest: 1.5.0(@types/node@20.9.5)(jsdom@20.0.3)(terser@5.26.0)
 
   '@tootallnate/once@2.0.0': {}
@@ -15117,11 +15126,11 @@ snapshots:
 
   '@types/mime@1.3.2': {}
 
-  '@types/mini-css-extract-plugin@1.4.3(esbuild@0.21.5)':
+  '@types/mini-css-extract-plugin@1.4.3(esbuild@0.23.1)':
     dependencies:
       '@types/node': 20.9.5
       tapable: 2.2.1
-      webpack: 5.90.0(esbuild@0.21.5)
+      webpack: 5.90.0(esbuild@0.23.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -15852,12 +15861,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.1.3(@babel/core@7.23.9)(webpack@5.90.0(esbuild@0.21.5)):
+  babel-loader@9.1.3(@babel/core@7.23.9)(webpack@5.90.0(esbuild@0.23.1)):
     dependencies:
       '@babel/core': 7.23.9
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.90.0(esbuild@0.21.5)
+      webpack: 5.90.0(esbuild@0.23.1)
 
   babel-loader@9.1.3(@babel/core@7.23.9)(webpack@5.90.0(webpack-cli@5.1.4)):
     dependencies:
@@ -16687,13 +16696,13 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 3.6.0
 
-  create-jest@29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3)):
+  create-jest@29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
-      jest-config: 29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))
+      jest-config: 29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -16732,7 +16741,7 @@ snapshots:
     dependencies:
       postcss: 8.4.35
 
-  css-loader@6.10.0(webpack@5.90.0(esbuild@0.21.5)):
+  css-loader@6.10.0(webpack@5.90.0(esbuild@0.23.1)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.35)
       postcss: 8.4.35
@@ -16743,7 +16752,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.0
     optionalDependencies:
-      webpack: 5.90.0(esbuild@0.21.5)
+      webpack: 5.90.0(esbuild@0.23.1)
 
   css-loader@6.10.0(webpack@5.90.0(webpack-cli@5.1.4)):
     dependencies:
@@ -17418,31 +17427,32 @@ snapshots:
       '@esbuild/win32-ia32': 0.19.12
       '@esbuild/win32-x64': 0.19.12
 
-  esbuild@0.21.5:
+  esbuild@0.23.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.21.5
-      '@esbuild/android-arm': 0.21.5
-      '@esbuild/android-arm64': 0.21.5
-      '@esbuild/android-x64': 0.21.5
-      '@esbuild/darwin-arm64': 0.21.5
-      '@esbuild/darwin-x64': 0.21.5
-      '@esbuild/freebsd-arm64': 0.21.5
-      '@esbuild/freebsd-x64': 0.21.5
-      '@esbuild/linux-arm': 0.21.5
-      '@esbuild/linux-arm64': 0.21.5
-      '@esbuild/linux-ia32': 0.21.5
-      '@esbuild/linux-loong64': 0.21.5
-      '@esbuild/linux-mips64el': 0.21.5
-      '@esbuild/linux-ppc64': 0.21.5
-      '@esbuild/linux-riscv64': 0.21.5
-      '@esbuild/linux-s390x': 0.21.5
-      '@esbuild/linux-x64': 0.21.5
-      '@esbuild/netbsd-x64': 0.21.5
-      '@esbuild/openbsd-x64': 0.21.5
-      '@esbuild/sunos-x64': 0.21.5
-      '@esbuild/win32-arm64': 0.21.5
-      '@esbuild/win32-ia32': 0.21.5
-      '@esbuild/win32-x64': 0.21.5
+      '@esbuild/aix-ppc64': 0.23.1
+      '@esbuild/android-arm': 0.23.1
+      '@esbuild/android-arm64': 0.23.1
+      '@esbuild/android-x64': 0.23.1
+      '@esbuild/darwin-arm64': 0.23.1
+      '@esbuild/darwin-x64': 0.23.1
+      '@esbuild/freebsd-arm64': 0.23.1
+      '@esbuild/freebsd-x64': 0.23.1
+      '@esbuild/linux-arm': 0.23.1
+      '@esbuild/linux-arm64': 0.23.1
+      '@esbuild/linux-ia32': 0.23.1
+      '@esbuild/linux-loong64': 0.23.1
+      '@esbuild/linux-mips64el': 0.23.1
+      '@esbuild/linux-ppc64': 0.23.1
+      '@esbuild/linux-riscv64': 0.23.1
+      '@esbuild/linux-s390x': 0.23.1
+      '@esbuild/linux-x64': 0.23.1
+      '@esbuild/netbsd-x64': 0.23.1
+      '@esbuild/openbsd-arm64': 0.23.1
+      '@esbuild/openbsd-x64': 0.23.1
+      '@esbuild/sunos-x64': 0.23.1
+      '@esbuild/win32-arm64': 0.23.1
+      '@esbuild/win32-ia32': 0.23.1
+      '@esbuild/win32-x64': 0.23.1
 
   escalade@3.1.1: {}
 
@@ -18053,7 +18063,7 @@ snapshots:
       call-bind: 1.0.5
       get-intrinsic: 1.2.2
 
-  get-tsconfig@4.7.3:
+  get-tsconfig@4.7.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -18512,14 +18522,14 @@ snapshots:
 
   html-void-elements@1.0.5: {}
 
-  html-webpack-plugin@5.5.0(webpack@5.90.0(esbuild@0.21.5)):
+  html-webpack-plugin@5.5.0(webpack@5.90.0(esbuild@0.23.1)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.90.0(esbuild@0.21.5)
+      webpack: 5.90.0(esbuild@0.23.1)
 
   html-webpack-plugin@5.5.0(webpack@5.90.0(webpack-cli@5.1.4)):
     dependencies:
@@ -19159,16 +19169,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3)):
+  jest-cli@29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))
+      '@jest/core': 29.7.0(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))
+      create-jest: 29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))
       exit: 0.1.2
       import-local: 3.0.3
-      jest-config: 29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))
+      jest-config: 29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -19178,7 +19188,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3)):
+  jest-config@29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4)):
     dependencies:
       '@babel/core': 7.23.9
       '@jest/test-sequencer': 29.7.0
@@ -19204,7 +19214,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.9.5
-      ts-node: 10.9.1(@types/node@20.9.5)(typescript@5.3.3)
+      ts-node: 10.9.1(@types/node@20.9.5)(typescript@5.5.4)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -19473,12 +19483,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3)):
+  jest@29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))
+      '@jest/core': 29.7.0(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))
       '@jest/types': 29.6.3
       import-local: 3.0.3
-      jest-cli: 29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))
+      jest-cli: 29.7.0(@types/node@20.9.5)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -20524,10 +20534,10 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@2.7.7(webpack@5.90.0(esbuild@0.21.5)):
+  mini-css-extract-plugin@2.7.7(webpack@5.90.0(esbuild@0.23.1)):
     dependencies:
       schema-utils: 4.2.0
-      webpack: 5.90.0(esbuild@0.21.5)
+      webpack: 5.90.0(esbuild@0.23.1)
 
   mini-css-extract-plugin@2.7.7(webpack@5.90.0(webpack-cli@5.1.4)):
     dependencies:
@@ -21593,21 +21603,21 @@ snapshots:
     optionalDependencies:
       ts-node: 10.9.1(@types/node@16.11.10)(typescript@4.9.4)
 
-  postcss-load-config@3.1.0(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3)):
+  postcss-load-config@3.1.0(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4)):
     dependencies:
       import-cwd: 3.0.0
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
-      ts-node: 10.9.1(@types/node@20.9.5)(typescript@5.3.3)
+      ts-node: 10.9.1(@types/node@20.9.5)(typescript@5.5.4)
 
-  postcss-load-config@4.0.2(postcss@8.4.35)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3)):
+  postcss-load-config@4.0.2(postcss@8.4.35)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4)):
     dependencies:
       lilconfig: 3.1.0
       yaml: 2.3.4
     optionalDependencies:
       postcss: 8.4.35
-      ts-node: 10.9.1(@types/node@20.9.5)(typescript@5.3.3)
+      ts-node: 10.9.1(@types/node@20.9.5)(typescript@5.5.4)
 
   postcss-merge-longhand@5.1.7(postcss@8.4.35):
     dependencies:
@@ -22426,20 +22436,20 @@ snapshots:
     dependencies:
       glob: 7.2.0
 
-  rollup-plugin-dts@4.2.2(rollup@2.79.1)(typescript@5.3.3):
+  rollup-plugin-dts@4.2.2(rollup@2.79.1)(typescript@5.5.4):
     dependencies:
       magic-string: 0.26.4
       rollup: 2.79.1
-      typescript: 5.3.3
+      typescript: 5.5.4
     optionalDependencies:
       '@babel/code-frame': 7.23.5
 
-  rollup-plugin-esbuild@4.9.1(esbuild@0.21.5)(rollup@2.79.1):
+  rollup-plugin-esbuild@4.9.1(esbuild@0.23.1)(rollup@2.79.1):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       debug: 4.3.4(supports-color@9.2.3)
       es-module-lexer: 0.9.3
-      esbuild: 0.21.5
+      esbuild: 0.23.1
       joycon: 3.1.1
       jsonc-parser: 3.2.0
       rollup: 2.79.1
@@ -23040,11 +23050,11 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  style-loader@2.0.0(webpack@5.90.0(esbuild@0.21.5)):
+  style-loader@2.0.0(webpack@5.90.0(esbuild@0.23.1)):
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.3.0
-      webpack: 5.90.0(esbuild@0.21.5)
+      webpack: 5.90.0(esbuild@0.23.1)
 
   style-to-object@0.3.0:
     dependencies:
@@ -23167,7 +23177,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@2.2.19(autoprefixer@10.4.17(postcss@8.4.35))(postcss@8.4.35)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3)):
+  tailwindcss@2.2.19(autoprefixer@10.4.17(postcss@8.4.35))(postcss@8.4.35)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4)):
     dependencies:
       arg: 5.0.2
       autoprefixer: 10.4.17(postcss@8.4.35)
@@ -23193,7 +23203,7 @@ snapshots:
       object-hash: 2.2.0
       postcss: 8.4.35
       postcss-js: 3.0.3
-      postcss-load-config: 3.1.0(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3))
+      postcss-load-config: 3.1.0(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))
       postcss-nested: 5.0.6(postcss@8.4.35)
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
@@ -23259,16 +23269,16 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.2.0
 
-  terser-webpack-plugin@5.3.10(esbuild@0.21.5)(webpack@5.90.0(esbuild@0.21.5)):
+  terser-webpack-plugin@5.3.10(esbuild@0.23.1)(webpack@5.90.0(esbuild@0.23.1)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.22
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.26.0
-      webpack: 5.90.0(esbuild@0.21.5)
+      webpack: 5.90.0(esbuild@0.23.1)
     optionalDependencies:
-      esbuild: 0.21.5
+      esbuild: 0.23.1
 
   terser-webpack-plugin@5.3.10(webpack@5.90.0(webpack-cli@5.1.4)):
     dependencies:
@@ -23446,7 +23456,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.1(@types/node@20.9.5)(typescript@5.3.3):
+  ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.8
@@ -23460,14 +23470,14 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.3.3
+      typescript: 5.5.4
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
 
-  tsconfck@3.0.1(typescript@5.3.3):
+  tsconfck@3.0.1(typescript@5.5.4):
     optionalDependencies:
-      typescript: 5.3.3
+      typescript: 5.5.4
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -23484,10 +23494,10 @@ snapshots:
       tslib: 1.14.1
       typescript: 4.9.4
 
-  tsx@4.7.2:
+  tsx@4.17.0:
     dependencies:
-      esbuild: 0.19.12
-      get-tsconfig: 4.7.3
+      esbuild: 0.23.1
+      get-tsconfig: 4.7.6
     optionalDependencies:
       fsevents: 2.3.3
 
@@ -23563,7 +23573,7 @@ snapshots:
 
   typescript@4.9.4: {}
 
-  typescript@5.3.3: {}
+  typescript@5.5.4: {}
 
   typographic-apostrophes-for-possessive-plurals@1.0.5: {}
 
@@ -23956,11 +23966,11 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-tsconfig-paths@4.3.1(typescript@5.3.3)(vite@5.1.4(@types/node@20.9.5)(terser@5.26.0)):
+  vite-tsconfig-paths@4.3.1(typescript@5.5.4)(vite@5.1.4(@types/node@20.9.5)(terser@5.26.0)):
     dependencies:
       debug: 4.3.4(supports-color@9.2.3)
       globrex: 0.1.2
-      tsconfck: 3.0.1(typescript@5.3.3)
+      tsconfck: 3.0.1(typescript@5.5.4)
     optionalDependencies:
       vite: 5.1.4(@types/node@20.9.5)(terser@5.26.0)
     transitivePeerDependencies:
@@ -24110,14 +24120,14 @@ snapshots:
     optionalDependencies:
       webpack-dev-server: 4.15.1(webpack-cli@5.1.4)(webpack@5.90.0)
 
-  webpack-dev-middleware@5.3.3(webpack@5.90.0(esbuild@0.21.5)):
+  webpack-dev-middleware@5.3.3(webpack@5.90.0(esbuild@0.23.1)):
     dependencies:
       colorette: 2.0.16
       memfs: 3.5.3
       mime-types: 2.1.34
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.90.0(esbuild@0.21.5)
+      webpack: 5.90.0(esbuild@0.23.1)
 
   webpack-dev-middleware@5.3.3(webpack@5.90.0(webpack-cli@5.1.4)):
     dependencies:
@@ -24169,7 +24179,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@4.15.1(webpack@5.90.0(esbuild@0.21.5)):
+  webpack-dev-server@4.15.1(webpack@5.90.0(esbuild@0.23.1)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.3.5
@@ -24199,10 +24209,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack-dev-middleware: 5.3.3(webpack@5.90.0(esbuild@0.21.5))
+      webpack-dev-middleware: 5.3.3(webpack@5.90.0(esbuild@0.23.1))
       ws: 8.16.0
     optionalDependencies:
-      webpack: 5.90.0(esbuild@0.21.5)
+      webpack: 5.90.0(esbuild@0.23.1)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -24249,7 +24259,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.90.0(esbuild@0.21.5):
+  webpack@5.90.0(esbuild@0.23.1):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -24272,7 +24282,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(esbuild@0.21.5)(webpack@5.90.0(esbuild@0.21.5))
+      terser-webpack-plugin: 5.3.10(esbuild@0.23.1)(webpack@5.90.0(esbuild@0.23.1))
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:

--- a/test-helpers/package.json
+++ b/test-helpers/package.json
@@ -31,7 +31,7 @@
     "css-loader": "^6.9.1",
     "cssnano": "^5.1.15",
     "cssnano-preset-lite": "^2.1.3",
-    "esbuild": "~0.21.5",
+    "esbuild": "~0.23.1",
     "got": "^11.8.2",
     "html-webpack-plugin": "^5.3.1",
     "mini-css-extract-plugin": "^2.7.7",


### PR DESCRIPTION
Widens the `esbuild` dependency range in a few packages to include `~0.22.0` and `~0.23.0`. Also updates some `esbuild` dev deps, and a few monorepo deps that depend on `esbuild` so we don't end up with multiple versions of `esbuild` in the lockfile.