### PR TITLE
fix(site/ColorModeToggle/ColorModeToggle.tsx): change ColorMode title colour to color

### DIFF
--- a/site/src/ColorModeToggle/ColorModeToggle.tsx
+++ b/site/src/ColorModeToggle/ColorModeToggle.tsx
@@ -65,7 +65,7 @@ export const ColorModeToggle = () => {
       borderRadius="full"
       cursor="pointer"
       className={styles.root}
-      title="Toggle colour mode"
+      title="Toggle color mode"
       onClick={() => setColorMode(colorMode === 'light' ? 'dark' : 'light')}
     />
   );


### PR DESCRIPTION
* in british "colour" is right but vanilla-extract is using in international so i think naming "color" is good more than.
* we named component as "ColorModeToggle" so i think naming "color" is in contextually consistent.