### PR TITLE
vite: Fix HMR invalidation

### DIFF
--- a/.changeset/twelve-pans-dress.md
+++ b/.changeset/twelve-pans-dress.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Fixes a bug where Vanilla Extract files with extensions other than `css.ts` were not being invalidated during HMR

--- a/fixtures/features/src/html.ts
+++ b/fixtures/features/src/html.ts
@@ -10,3 +10,9 @@ export default `
     <div id="${testNodes.styleCompositionInSelector}" class="${styles.styleCompositionInSelector}">Style composition in selector</div>
     <div id="${testNodes.styleVariantsCompositionInSelector}" class="${styles.styleVariantsCompositionInSelector.variant}">Style variants composition in selector</div>
   `;
+
+// @ts-expect-error Vite env not defined
+if (import.meta.hot) {
+  // @ts-expect-error Vite env not defined
+  import.meta.hot.accept();
+}

--- a/fixtures/features/src/index.ts
+++ b/fixtures/features/src/index.ts
@@ -5,10 +5,3 @@ function render() {
 }
 
 render();
-
-// Uncomment to enable HMR with Vite
-// if (import.meta.hot) {
-//   import.meta.hot.accept('./features.css', () => {
-//     render();
-//   });
-// }

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -214,7 +214,7 @@ export function vanillaExtractPlugin({
           // We have to invalidate the virtual module & deps, not the real one we just transformed
           // The deps have to be invalidated in case one of them changing was the trigger causing
           // the current transformation
-          if (file.endsWith('.css.ts')) {
+          if (cssFileFilter.test(file)) {
             invalidateModule(fileIdToVirtualId(file));
           }
         }


### PR DESCRIPTION
Fixes #1481.

#1438 broke HMR invalidation for files that don't end in `.css.ts`, e.g. `.css.tsx` which is a [valid](https://github.com/vanilla-extract-css/vanilla-extract/blob/d271b9f9e0e4f0bc668ded78bb15938627957a7a/packages/integration/src/filters.ts#L3), though uncommon, VE file extension.

This PR fixes this issue, as well as enables vite HMR for the `features` fixture to enable easier testing of HMR in the future.