### PR TITLE
Update changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@1.5.0/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@3.0.3/schema.json",
   "changelog": [
     "@changesets/changelog-github",
     { "repo": "vanilla-extract-css/vanilla-extract" }
@@ -9,6 +9,12 @@
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
+  "snapshot": {
+    "useCalculatedVersion": true
+  },
+  "privatePackages": {
+    "tag": false, "version": false
+  },
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   }


### PR DESCRIPTION
- Use the calculated version when publishing snapshots. This means a patch release snapshot for a package on `1.0.0` will be `1.0.1-etc` rather than `0.0.0-etc`. This aligns better with semver, and is just nicer to work with IMO.
- There's now proper support for ignoring private packages, so I've enabled that. This cuts down on noise in version packages PRs.