### PR TITLE
Fix serialization of exotic react compoonent

### DIFF
--- a/.changeset/ninety-hotels-hear.md
+++ b/.changeset/ninety-hotels-hear.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/integration': major
+---
+
+Support serialisation of exotic react components

--- a/packages/integration/src/processVanillaFile.test.ts
+++ b/packages/integration/src/processVanillaFile.test.ts
@@ -138,6 +138,30 @@ describe('serializeVanillaModule', () => {
     `);
   });
 
+  test('should handle function serialization', () => {
+    const component = { render: () => null };
+
+    Object.defineProperty(component, '__function_serializer__', {
+      value: {
+        importPath: 'my-package',
+        importName: 'myFunction',
+        args: ['arg1', 'arg2'],
+      },
+      writable: false,
+    });
+
+    const exports = {
+      component,
+    };
+
+    expect(serializeVanillaModule(['import "./styles.css"'], exports, null))
+      .toMatchInlineSnapshot(`
+      "import "./styles.css"
+      import { myFunction as _86bce } from 'my-package';
+      export var component = _86bce('arg1','arg2');"
+    `);
+  });
+
   test('should re-use exports in handle serialized function args', () => {
     const complexExport = {
       my: {


### PR DESCRIPTION
Right when we attempt passing `forwardRef` component to `addFunctionSerializer` (following official [guide](https://vanilla-extract.style/documentation/api/add-function-serializer/)) we get error:

```
Invalid exports.

You can only export plain objects, arrays, strings, numbers and null/undefined.
```

This PR adds support for creating generic `styled` react components with custom ref using `addFunctionSerializer`.