### PR TITLE
fix(vite-plugin): Omit React-Router v7 plugin for DevServer

### DIFF
--- a/.changeset/vite-plugin-react-router.md
+++ b/.changeset/vite-plugin-react-router.md
@@ -2,7 +2,4 @@
 '@vanilla-extract/vite-plugin': patch
 ---
 
-Don't pass React-Router Vite plugin to the vite-node compiler
-
-
-React-Router throws an error if it's loaded without a config file, which is what we do when we initialise the vite-node compiler.
+Filter out `react-router` Vite plugin when creating the `vite-node` compiler

--- a/.changeset/vite-plugin-react-router.md
+++ b/.changeset/vite-plugin-react-router.md
@@ -1,0 +1,8 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Don't pass React-Router Vite plugin to the vite-node compiler
+
+
+React-Router throws an error if it's loaded without a config file, which is what we do when we initialise the vite-node compiler.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -40,7 +40,10 @@ const removeIncompatiblePlugins = (plugin: PluginOption) =>
   // Additionally, some internal Remix plugins rely on a `ctx` object to be initialized by
   // the main Remix plugin, and may not function correctly without it. To address this, we
   // filter out all Remix-related plugins.
-  !plugin.name.startsWith('remix');
+  !plugin.name.startsWith('remix') &&
+  // As React-Router plugin works the same as Remix plugin, also ignore it.
+  !plugin.name.startsWith('react-router');
+
 
 interface Options {
   identifiers?: IdentifierOption;

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -44,7 +44,6 @@ const removeIncompatiblePlugins = (plugin: PluginOption) =>
   // As React-Router plugin works the same as Remix plugin, also ignore it.
   !plugin.name.startsWith('react-router');
 
-
 interface Options {
   identifiers?: IdentifierOption;
   unstable_mode?: 'transform' | 'emitCss';


### PR DESCRIPTION
Similar to https://github.com/vanilla-extract-css/vanilla-extract/pull/1308.

Omit React-Router plugin for DevServer in Vanilla-Extract Vite plugin, as React-Router plugin throws when launched without Configuration file. (just like the Remix plugin)