### PR TITLE
feat: 🎸 expose esbuild log options

### DIFF
--- a/.changeset/soft-wombats-shop.md
+++ b/.changeset/soft-wombats-shop.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/integration': minor
+---
+
+Exposed esbuild log options for better control of build reporting

--- a/packages/integration/src/compile.ts
+++ b/packages/integration/src/compile.ts
@@ -49,7 +49,7 @@ export interface CompileOptions {
   cwd?: string;
   esbuildOptions?: Pick<
     EsbuildOptions,
-    'plugins' | 'external' | 'define' | 'loader' | 'tsconfig' | 'conditions'
+    'plugins' | 'external' | 'define' | 'loader' | 'tsconfig' | 'conditions' | 'logLevel' | 'logLimit' | 'logOverride'
   >;
 }
 export async function compile({
@@ -74,6 +74,9 @@ export async function compile({
     define: esbuildOptions?.define,
     tsconfig: esbuildOptions?.tsconfig,
     conditions: esbuildOptions?.conditions,
+    logLevel: esbuildOptions?.logLevel,
+    logLimit: esbuildOptions?.logLimit,
+    logOverride: esbuildOptions?.logOverride,
   });
 
   const { outputFiles, metafile } = result;


### PR DESCRIPTION
To enable better control over what is reported during a build, the esbuild log options have been exposed to allow users to fine tune what they deem important to have logged