### PR TITLE
Fix incorrect selector transformation when a substring of a selector matches another local classname

### DIFF
--- a/.changeset/flat-humans-hammer.md
+++ b/.changeset/flat-humans-hammer.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': patch
+---
+
+Fixes a bug that caused invalid selectors to be generated when adjacent classnames contained a substring equal to another local classname

--- a/packages/css/src/transformCss.test.ts
+++ b/packages/css/src/transformCss.test.ts
@@ -2299,6 +2299,61 @@ describe('transformCss', () => {
       }
     `);
   });
+
+  it('should handle adjacent classnames containing a separate local classname as a substring', () => {
+    // Note that `classname2` starts and ends with the same character, so when two `classname1`s are
+    // adjacent, the resulting string will contain `classname2` as a substring
+    const classname1 = 'debugName_hash1';
+    const classname2 = 'debugName_hash1d';
+
+    expect(
+      transformCss({
+        composedClassLists: [],
+        localClassNames: [classname1, classname2],
+
+        cssObjs: [
+          {
+            type: 'local',
+            selector: classname1,
+            rule: {
+              selectors: {
+                ['&&']: {
+                  background: 'black',
+                },
+                [`${classname2}&`]: {
+                  background: 'orange',
+                },
+                [`&${classname2}&`]: {
+                  background: 'orange',
+                },
+                [`${classname2}${classname2}&`]: {
+                  background: 'orange',
+                },
+              },
+            },
+          },
+          {
+            type: 'local',
+            selector: classname2,
+            rule: {},
+          },
+        ],
+      }).join('\n'),
+    ).toMatchInlineSnapshot(`
+      .debugName_hash1.debugName_hash1 {
+        background: black;
+      }
+      .debugName_hash1d.debugName_hash1 {
+        background: orange;
+      }
+      .debugName_hash1.debugName_hash1d.debugName_hash1 {
+        background: orange;
+      }
+      .debugName_hash1d.debugName_hash1d.debugName_hash1 {
+        background: orange;
+      }
+    `);
+  });
 });
 
 endFileScope();

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -317,11 +317,20 @@ class Stylesheet {
       const [endIndex, [firstMatch]] = results[i];
       const startIndex = endIndex - firstMatch.length + 1;
 
-      if (startIndex >= lastReplaceIndex) {
-        // Class names can be substrings of other class names
-        // e.g. '_1g1ptzo1' and '_1g1ptzo10'
-        // If the startIndex >= lastReplaceIndex, then
-        // this is the case and this replace should be skipped
+      // Class names can be substrings of other class names
+      // e.g. '_1g1ptzo1' and '_1g1ptzo10'
+      //
+      // Additionally, concatenated classnames can contain substrings equal to other classnames
+      // e.g. '&&' where '&' is 'debugName_hash1' and 'debugName_hash1d' is also a local classname
+      // Before transforming the selector, this would look like `debugName_hash1debugName_hash1`
+      // which contains the substring `debugName_hash1d`’.
+      //
+      // In either of these cases, the last replace index will occur either before or within the
+      // current replacement range (from `startIndex` to `endIndex`).
+      // If this occurs, we skip the replacement to avoid transforming the selector incorrectly.
+      const skipReplacement = lastReplaceIndex <= endIndex;
+
+      if (skipReplacement) {
         continue;
       }
 


### PR DESCRIPTION
Fixes #1501.

## The bug

Depending on the hash of a scoped classname, a selector such as `&&` would end up transformed into a selector that was not scoped to the classname represented by `&`, which would cause an [invalid selector error](https://github.com/vanilla-extract-css/vanilla-extract/blob/704724367568055478469429f817dc60b5fef44c/packages/css/src/validateSelector.ts#L24).

An example from the test case I added involves the local classnames `debugName_hash1` and `debugName_hash1d`. The `&&` selector would become `debugName_hash1debugName_hash1`, which contains `debugName_hash1d` as a substring.

When this occurs, the local classname search returns 3 results of the form:

```
[
  [14, ['debugName_hash1']],
  [15, ['debugName_hash1d']],
  [29, ['debugName_hash1']],
]
```

Note that we iterate over these search results in reverse order. In the above case, the replacement for the middle element would overlap with characters already replaced by the last element, which causes the bug.

It might not be obvious as to when this specific set of classnames would ever be generated. That is, a classname that both contains a substring equal to another classnae, _and_ both starts and ends with the same character.

As mentioned in #1501, the `refCount` appended to a classname hash increments by 1 for every classname generated in a file. This value is encoded as a base 36 value, so it goes from `0-9a-z`, then `1(0-9a-z)`, etc.

This means that once you roll over to the `a-z` range, you'll eventually end up with a classname that satisfies both of the constraints mentioned above. Ideally you wouldn't need to write a selector like `&&` as increasing specificity shouldn't be much of an issue if you're using scoped classnames, but regardless this shouldn't break selector transformation.

## The Fix

The previous logic of checking `startIndex >= lastReplaceIndex` didn't cover this case. By ensuring that we only ever do a replacement when `lastReplaceIndex > endIndex`, the replacement will only affect characters that have not already been replaced. We actually want to negate this logic as we `continue` when we _don't_ want to replace. This is how we end up with `lastReplaceIndex <= endIndex` as the skip condition.

To test out this fix, install `@vanilla-extract/css@fix-buggy-selector-transform`.