### PR TITLE
Fix broken compiled example in `keyframes` docs

### DIFF
--- a/site/docs/api/keyframes.md
+++ b/site/docs/api/keyframes.md
@@ -42,6 +42,12 @@ import {
   style
 } from '@vanilla-extract/css';
 
+const angle = createVar({
+  syntax: '<angle>',
+  inherits: false,
+  initialValue: '0deg'
+});
+
 const angleKeyframes = keyframes({
   '0%': {
     vars: {


### PR DESCRIPTION
I broke this in #1092 when trying to make changes in a code suggestion. https://github.com/vanilla-extract-css/vanilla-extract/pull/1092/commits/a0a4b948da64969aa669fe98a1503ea5723f59a9#diff-c74ddbc9d698db9ae1cd5e784a93f9392240cade1b5ce2aec615fb1f8d9d8db7L36