### PR TITLE
chore(.github/workflows/validate.yml): change playwright runs-on 'macos-14' to 'macos-latest'

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -70,7 +70,7 @@ jobs:
         run: pnpm test:unit
   playwright:
     name: Playwright tests
-    runs-on: macos-14
+    runs-on: macos-latest
     env:
       CI: true
     steps:


### PR DESCRIPTION
* We are using `ubuntu-latest` and `windows-latest` in the `validate.yml`. Therefore, it would be better to use `macos-latest` for macOS as well.