### PR TITLE
site: Fix code editor text decoration style in Safari

### DIFF
--- a/site/src/Code/ErrorHighlighter.css.ts
+++ b/site/src/Code/ErrorHighlighter.css.ts
@@ -2,7 +2,7 @@ import { style } from '@vanilla-extract/css';
 import { vars } from '../themes.css';
 
 export const errorUnderline = style({
-  textDecoration: 'dashed',
+  textDecorationStyle: 'dashed',
   textDecorationColor: vars.palette.red,
   textDecorationThickness: '3px',
   textDecorationLine: 'underline',


### PR DESCRIPTION
In Safari, specifying `text-decoration-style` in the `text-decoration` shorthand is [only supported if you use the prefixed `-webkit-text-decoration`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration#browser_compatibility). The production site currently looks like this in Safari (no dashed underline):

<img width="1346" alt="image" src="https://github.com/user-attachments/assets/6de7eb1f-a40e-4a95-b4fe-53114298239a" />

With this fix it will match Chrome (Firefox's dashes are a bit wider):
<img width="1360" alt="image" src="https://github.com/user-attachments/assets/7e001fdb-51d0-434d-a3fd-efd4485ea631" />
