### PR TITLE
Fix `@container` queries inside `selectors`

### DIFF
--- a/.changeset/soft-kiwis-pull.md
+++ b/.changeset/soft-kiwis-pull.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': patch
+---
+
+Fixes a bug where `@container` queries inside `selectors` were not being generated

--- a/packages/css/src/transformCss.test.ts
+++ b/packages/css/src/transformCss.test.ts
@@ -1166,6 +1166,50 @@ describe('transformCss', () => {
     `);
   });
 
+  it('should handle container queries inside selectors', () => {
+    expect(
+      transformCss({
+        composedClassLists: [],
+        localClassNames: ['testClass'],
+        cssObjs: [
+          {
+            type: 'local',
+            selector: 'testClass',
+            rule: {
+              containerName: 'myContainer',
+              '@container': {
+                'myContainer (min-width: 700px)': {
+                  color: 'red',
+                },
+              },
+              selectors: {
+                ['h1 &']: {
+                  '@container': {
+                    'myContainer (min-width: 700px)': {
+                      color: 'blue',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      }).join('\n'),
+    ).toMatchInlineSnapshot(`
+      .testClass {
+        container-name: myContainer;
+      }
+      @container myContainer (min-width: 700px) {
+        .testClass {
+          color: red;
+        }
+        h1 .testClass {
+          color: blue;
+        }
+      }
+    `);
+  });
+
   it('should handle @layer declarations', () => {
     expect(
       transformCss({

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -403,6 +403,11 @@ class Stylesheet {
         conditions,
       );
       this.transformMedia(selectorRoot, selectorRule['@media'], conditions);
+      this.transformContainer(
+        selectorRoot,
+        selectorRule['@container'],
+        conditions,
+      );
     });
   }
 


### PR DESCRIPTION
Fixes #1528.

`@container` queries that contain `selectors` are correctly generated, but the inverse is not true. We support `@media` queries inside `selectors`, so I see no reason not to also support `@container` queries inside `selectors`.