### PR TITLE
`vite`: Fix astro dev server page load error by marking `cssesc` as external in the `vite-node` server

### DIFF
--- a/.changeset/tame-hornets-turn.md
+++ b/.changeset/tame-hornets-turn.md
@@ -2,4 +2,4 @@
 '@vanilla-extract/integration': patch
 ---
 
-Fixes an error that sometimes occurred when loading a page via the astro dev sever
+Fixes an error that sometimes occurred when loading a page via the astro dev server

--- a/.changeset/tame-hornets-turn.md
+++ b/.changeset/tame-hornets-turn.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/integration': patch
+---
+
+Fixes an error that sometimes occurred when loading a page via the astro dev sever

--- a/packages/integration/src/compiler.ts
+++ b/packages/integration/src/compiler.ts
@@ -110,6 +110,11 @@ const createViteServer = async ({
     },
     ssr: {
       noExternal: true,
+      // `cssesc` is CJS-only, so we need to mark it as external as Vite's transform pipeline
+      // can't handle CJS during dev-time.
+      // See https://github.com/withastro/astro/blob/0879cc2ce7e15a2e7330c68d6667d9a2edea52ab/packages/astro/src/core/create-vite.ts#L86
+      // and https://github.com/withastro/astro/issues/11395
+      external: ['cssesc'],
     },
     plugins: [
       {


### PR DESCRIPTION
Fixes #1453. Fixes #1519.

[Astro mark `cssesc` as external during dev time](https://github.com/withastro/astro/blob/0879cc2ce7e15a2e7330c68d6667d9a2edea52ab/packages/astro/src/core/create-vite.ts#L86) to work around this issue, so we should too. As far as the compiler is concerned, we don't differentiate between dev and non-dev, so I've chosen to omit the logic that only marks `cssesc` as external during dev time.

This issue was actually introduced by #1395 as it resulted in astro's vite plugins being propagated through to the `vite-node` server (not sure which specific plugin is the culprit though). Filtering those plugins out _also_ fixes this bug, but IMO this targeted fix is the better option.