### PR TITLE
Remove github admonitions from changesets

### DIFF
--- a/.changeset/three-shirts-knock.md
+++ b/.changeset/three-shirts-knock.md
@@ -29,9 +29,6 @@ export default defineConfig({
 });
 ```
 
-> [!NOTE]
-> When providing a plugin filter function, the `vite-tsconfig-paths` plugin will no longer be forwarded through by default.
-> If you wish to forward this plugin through, you must include it in your filter function.
+When providing a plugin filter function, the `vite-tsconfig-paths` plugin will no longer be forwarded through by default. If you wish to forward this plugin, you must include it in your filter function.
 
-> [!IMPORTANT]
-> The `unstable_pluginFilter` API is considered unstable and may be changed or removed without notice in a future non-major version.
+**NOTE**: The `unstable_pluginFilter` API is considered unstable and may be changed or removed without notice in a future non-major version.


### PR DESCRIPTION
I keep forgetting that [admonitions](https://github.com/orgs/community/discussions/16925) don't format correctly in changelogs.