### PR TITLE
css: Improve type-checking performance of `CSSVarFunction`

### DIFF
--- a/.changeset/nervous-cougars-glow.md
+++ b/.changeset/nervous-cougars-glow.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': patch
+---
+
+`css`: Improve type-checking performance of string literal types that include CSS variables

--- a/.changeset/two-kids-relax.md
+++ b/.changeset/two-kids-relax.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/private': patch
+---
+
+Simplify `CSSVarFunction` type to improve type-checking performance

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,11 @@
+# Benchmarks
+
+This package contains scripts for benchmarking the runtime and type-checking performance of Vanilla Extract APIs.
+
+## Running a Benchmark
+
+Run a benchmark by executing it with `tsx`:
+
+```sh
+pnpm tsx ./src/css-var-string-literal.ts
+```

--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@vanilla-extract-private/benchmarks",
+  "private": true,
+  "version": "0.0.1",
+  "author": "SEEK",
+  "license": "MIT",
+  "dependencies": {
+    "@arktype/attest": "^0.43.3",
+    "@vanilla-extract/css": "workspace:*",
+    "tsx": "^4.17.0",
+    "typescript": "^5.5.4"
+  }
+}

--- a/benchmarks/src/css-var-string-literal.ts
+++ b/benchmarks/src/css-var-string-literal.ts
@@ -1,0 +1,31 @@
+import { bench } from '@arktype/attest';
+
+import { style, createVar } from '@vanilla-extract/css';
+import { setFileScope } from '@vanilla-extract/css/fileScope';
+
+setFileScope('benchmarks/css-var-string-literal.ts');
+
+const narrowVar = createVar();
+const narrowMask = `
+  repeating-linear-gradient(45deg, #0005 0 calc(1 * ${narrowVar}), black calc(2 * ${narrowVar}) calc(3 * ${narrowVar}), #0005 calc(4 * ${narrowVar}) calc(5 * ${narrowVar})) no-repeat,
+  repeating-linear-gradient(-45deg, #0005 0 calc(1 * ${narrowVar}), black calc(2 * ${narrowVar}) calc(3 * ${narrowVar}), #0005 calc(4 * ${narrowVar}) calc(5 * ${narrowVar})) no-repeat
+` as const;
+
+const broadVar = narrowVar as string;
+const broadMask = `
+  repeating-linear-gradient(45deg, #0005 0 calc(1 * ${broadVar}), black calc(2 * ${broadVar}) calc(3 * ${broadVar}), #0005 calc(4 * ${broadVar}) calc(5 * ${broadVar})) no-repeat,
+  repeating-linear-gradient(-45deg, #0005 0 calc(1 * ${broadVar}), black calc(2 * ${broadVar}) calc(3 * ${broadVar}), #0005 calc(4 * ${broadVar}) calc(5 * ${broadVar})) no-repeat
+` as const;
+
+// Baseline
+bench('broad mask', () => {
+  style({
+    mask: broadMask,
+  });
+}).types([8003, 'instantiations']);
+
+bench('narrow mask', () => {
+  style({
+    mask: narrowMask,
+  });
+}).types([8003, 'instantiations']);

--- a/benchmarks/tsconfig.json
+++ b/benchmarks/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["src"]
+}

--- a/packages/private/src/types.ts
+++ b/packages/private/src/types.ts
@@ -1,6 +1,4 @@
-export type CSSVarFunction =
-  | `var(--${string})`
-  | `var(--${string}, ${string | number})`;
+export type CSSVarFunction = `var(--${string})` | `var(--${string}, ${string})`;
 
 export type Contract = {
   [key: string]: CSSVarFunction | null | Contract;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3813,6 +3813,7 @@ packages:
   '@playwright/test@1.43.1':
     resolution: {integrity: sha512-HgtQzFgNEEo4TE22K/X7sYTYNqEMMTZmFS8kTq6m8hXj+m1D8TgwgIbumHddJa9h4yl4GkKb8/bgAl2+g7eDgA==}
     engines: {node: '>=16'}
+    deprecated: Please update to the latest version of Playwright to test up-to-date browsers.
     hasBin: true
 
   '@pnpm/config.env-replace@1.1.0':
@@ -9395,9 +9396,6 @@ packages:
 
   pathe@1.1.1:
     resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
-
-  pathe@2.0.1:
-    resolution: {integrity: sha512-6jpjMpOth5S9ITVu5clZ7NOgHNsv5vRQdheL9ztp2vZmM6fRbLvyua1tiBIL4lk8SAe3ARzeXEly6siXCjDHDw==}
 
   pathe@2.0.2:
     resolution: {integrity: sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==}
@@ -16207,13 +16205,13 @@ snapshots:
   '@vitest/runner@3.0.2':
     dependencies:
       '@vitest/utils': 3.0.2
-      pathe: 2.0.1
+      pathe: 2.0.2
 
   '@vitest/snapshot@3.0.2':
     dependencies:
       '@vitest/pretty-format': 3.0.2
       magic-string: 0.30.17
-      pathe: 2.0.1
+      pathe: 2.0.2
 
   '@vitest/spy@3.0.2':
     dependencies:
@@ -22130,8 +22128,6 @@ snapshots:
 
   pathe@1.1.1: {}
 
-  pathe@2.0.1: {}
-
   pathe@2.0.2: {}
 
   pathval@2.0.0: {}
@@ -24538,7 +24534,7 @@ snapshots:
       cac: 6.7.14
       debug: 4.4.0(supports-color@9.2.3)
       es-module-lexer: 1.6.0
-      pathe: 2.0.1
+      pathe: 2.0.2
       vite: 6.0.10(@types/node@20.9.5)(terser@5.26.0)(tsx@4.17.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -24636,7 +24632,7 @@ snapshots:
       debug: 4.4.0(supports-color@9.2.3)
       expect-type: 1.1.0
       magic-string: 0.30.17
-      pathe: 2.0.1
+      pathe: 2.0.2
       std-env: 3.8.0
       tinybench: 2.9.0
       tinyexec: 0.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,21 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2(@types/node@20.9.5)(jsdom@20.0.3)(terser@5.26.0)(tsx@4.17.0)
 
+  benchmarks:
+    dependencies:
+      '@arktype/attest':
+        specifier: ^0.43.3
+        version: 0.43.3(typescript@5.5.4)
+      '@vanilla-extract/css':
+        specifier: workspace:*
+        version: link:../packages/css
+      tsx:
+        specifier: ^4.17.0
+        version: 4.17.0
+      typescript:
+        specifier: ^5.5.4
+        version: 5.5.4
+
   examples/next:
     dependencies:
       next:
@@ -1035,6 +1050,21 @@ packages:
 
   '@antfu/utils@0.7.10':
     resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
+
+  '@ark/fs@0.43.3':
+    resolution: {integrity: sha512-ypenAnHxiq41TlnLNVfbvmSMKI71LqX5s96L2dihsfVYaMVAy4OzAHrX35Bg1KKMbvvDZYn50b7Pd6FyEEFnIg==}
+
+  '@ark/schema@0.43.3':
+    resolution: {integrity: sha512-6h5dDQmbBs51C/nrZspcpGxsoODDqUgQ6DSfD0+Nml7MAPR2BJx9qS+q4KssQt6kOaOod6EpUpHrZaaUhUUNcg==}
+
+  '@ark/util@0.43.3':
+    resolution: {integrity: sha512-QdfJzSvz1B1zTzufZ4W3zVTccAnQ8ifpSToDLtzXACjT82RE2vuOlowqX2/w1/4q3Ws3ZPCI8G3hJe+g9Hl6zw==}
+
+  '@arktype/attest@0.43.3':
+    resolution: {integrity: sha512-iY41kXHYsFhx4hzVSiIlWMPxOBztelyOBkx7MZbITkKNNE9/0YwHmoo67C/LzLKDRuvPM5krP8ww8P0A9Au0wQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: '*'
 
   '@babel/code-frame@7.24.7':
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
@@ -3807,6 +3837,11 @@ packages:
   '@preconstruct/hook@0.4.0':
     resolution: {integrity: sha512-a7mrlPTM3tAFJyz43qb4pPVpUx8j8TzZBFsNFqcKcE/sEakNXRlQAuCT4RGZRf9dQiiUnBahzSIWawU4rENl+Q==}
 
+  '@prettier/sync@0.5.2':
+    resolution: {integrity: sha512-Yb569su456XNx5BsH/Vyem7xD6g/y9iLmLUzRKM1a/dhU/D7HqqvkAG72znulXlMXztbV0iiu9O5AL8K98TzZQ==}
+    peerDependencies:
+      prettier: '*'
+
   '@remix-run/dev@2.8.0':
     resolution: {integrity: sha512-kZtmK/7vKk7QV8CGCyC9Or3wP7EwL4rOJS9vObmTRAPv8mLyznR8bJxeNVWA7ICnCGejF8s2X3abVJrkEMiFlg==}
     engines: {node: '>=18.0.0'}
@@ -4463,6 +4498,15 @@ packages:
     resolution: {integrity: sha512-MxnrdIyArnTi+XyFLR+kt/uNAcdOnmT+879os7qDRI+EYySR4crXJq9BXPfRzzLGq0wgxkwidrCJ9WCAoacm1w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@typescript/analyze-trace@0.10.1':
+    resolution: {integrity: sha512-RnlSOPh14QbopGCApgkSx5UBgGda5MX1cHqp2fsqfiDyCwGL/m1jaeB9fzu7didVS81LQqGZZuxFBcg8YU8EVw==}
+    hasBin: true
+
+  '@typescript/vfs@1.6.0':
+    resolution: {integrity: sha512-hvJUjNVeBMp77qPINuUvYXj4FyWeeMMKZkxEATEU3hqBAQ7qdTBCUFT7Sp0Zu0faeEtFf+ldXxMEDr/bk73ISg==}
+    peerDependencies:
+      typescript: '*'
+
   '@vanilla-extract/babel-plugin-debug-ids@1.0.6':
     resolution: {integrity: sha512-C188vUEYmw41yxg3QooTs8r1IdbDQQ2mH7L5RkORBnHx74QlmsNfqVmKwAVTgrlYt8JoRaWMtPfGm/Ql0BNQrA==}
 
@@ -4818,6 +4862,9 @@ packages:
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  arktype@2.1.3:
+    resolution: {integrity: sha512-BnyskWms/1oYaVq2zKQ9qmYBWWOiYMsXusZLQothveeuACOM18DjKWTpoBO9jpC4dF1MoB7d0CwJaVf7CYHdpw==}
 
   arr-diff@4.0.0:
     resolution: {integrity: sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==}
@@ -5351,6 +5398,9 @@ packages:
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -7888,6 +7938,15 @@ packages:
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
+  jsonparse@1.3.1:
+    resolution: {integrity: sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==}
+    engines: {'0': node >= 0.2.0}
+
+  jsonstream-next@3.0.0:
+    resolution: {integrity: sha512-aAi6oPhdt7BKyQn1SrIIGZBt0ukKuOUE1qV6kJ3GgioSOYzsRc8z9Hfr1BVmacA/jLe9nARfmgMGgn68BqIAgg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   jsonwebtoken@8.5.1:
     resolution: {integrity: sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==}
     engines: {node: '>=4', npm: '>=1.4.28'}
@@ -8267,6 +8326,9 @@ packages:
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  make-synchronized@0.2.9:
+    resolution: {integrity: sha512-4wczOs8SLuEdpEvp3vGo83wh8rjJ78UsIk7DIX5fxdfmfMJGog4bQzxfvOwq7Q3yCHLC4jp1urPHIxRS/A93gA==}
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -9720,6 +9782,11 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  prettier@3.4.2:
+    resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-error@4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}
 
@@ -10555,6 +10622,9 @@ packages:
   split2@1.1.1:
     resolution: {integrity: sha512-cfurE2q8LamExY+lJ9Ex3ZfBwqAPduzOKVscPDXNCLLMvyaeD3DTz1yk7fVIs6Chco+12XeD0BB6HEoYzPYbXA==}
 
+  split2@3.2.2:
+    resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -10914,6 +10984,9 @@ packages:
   through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
 
+  through2@4.0.2:
+    resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
+
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
@@ -11034,6 +11107,10 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
+
+  treeify@1.1.0:
+    resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
+    engines: {node: '>=0.6'}
 
   trim-lines@1.1.3:
     resolution: {integrity: sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==}
@@ -11890,9 +11967,17 @@ packages:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -12033,6 +12118,27 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.22
 
   '@antfu/utils@0.7.10': {}
+
+  '@ark/fs@0.43.3': {}
+
+  '@ark/schema@0.43.3':
+    dependencies:
+      '@ark/util': 0.43.3
+
+  '@ark/util@0.43.3': {}
+
+  '@arktype/attest@0.43.3(typescript@5.5.4)':
+    dependencies:
+      '@ark/fs': 0.43.3
+      '@ark/util': 0.43.3
+      '@prettier/sync': 0.5.2(prettier@3.4.2)
+      '@typescript/analyze-trace': 0.10.1
+      '@typescript/vfs': 1.6.0(typescript@5.5.4)
+      arktype: 2.1.3
+      prettier: 3.4.2
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/code-frame@7.24.7':
     dependencies:
@@ -15215,6 +15321,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@prettier/sync@0.5.2(prettier@3.4.2)':
+    dependencies:
+      make-synchronized: 0.2.9
+      prettier: 3.4.2
+
   '@remix-run/dev@2.8.0(@remix-run/serve@2.8.0(typescript@5.5.4))(@types/node@20.9.5)(terser@5.26.0)(ts-node@10.9.1(@types/node@20.9.5)(typescript@5.5.4))(typescript@5.5.4)(vite@6.0.10(@types/node@20.9.5)(terser@5.26.0)(tsx@4.17.0))':
     dependencies:
       '@babel/core': 7.23.9
@@ -15988,6 +16099,24 @@ snapshots:
       '@typescript-eslint/types': 5.38.0
       eslint-visitor-keys: 3.3.0
 
+  '@typescript/analyze-trace@0.10.1':
+    dependencies:
+      chalk: 4.1.2
+      exit: 0.1.2
+      jsonparse: 1.3.1
+      jsonstream-next: 3.0.0
+      p-limit: 3.1.0
+      split2: 3.2.2
+      treeify: 1.1.0
+      yargs: 16.2.0
+
+  '@typescript/vfs@1.6.0(typescript@5.5.4)':
+    dependencies:
+      debug: 4.4.0(supports-color@9.2.3)
+      typescript: 5.5.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@vanilla-extract/babel-plugin-debug-ids@1.0.6':
     dependencies:
       '@babel/core': 7.23.9
@@ -16438,6 +16567,11 @@ snapshots:
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
+
+  arktype@2.1.3:
+    dependencies:
+      '@ark/schema': 0.43.3
+      '@ark/util': 0.43.3
 
   arr-diff@4.0.0: {}
 
@@ -17069,6 +17203,12 @@ snapshots:
   cli-width@2.2.1: {}
 
   client-only@0.0.1: {}
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   cliui@8.0.1:
     dependencies:
@@ -20126,6 +20266,13 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.10
 
+  jsonparse@1.3.1: {}
+
+  jsonstream-next@3.0.0:
+    dependencies:
+      jsonparse: 1.3.1
+      through2: 4.0.2
+
   jsonwebtoken@8.5.1:
     dependencies:
       jws: 3.2.2
@@ -20517,6 +20664,8 @@ snapshots:
       semver: 6.3.1
 
   make-error@1.3.6: {}
+
+  make-synchronized@0.2.9: {}
 
   makeerror@1.0.12:
     dependencies:
@@ -22356,6 +22505,8 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  prettier@3.4.2: {}
+
   pretty-error@4.0.0:
     dependencies:
       lodash: 4.17.21
@@ -23349,6 +23500,10 @@ snapshots:
     dependencies:
       through2: 2.0.5
 
+  split2@3.2.2:
+    dependencies:
+      readable-stream: 3.6.0
+
   sprintf-js@1.0.3: {}
 
   srcset@4.0.0: {}
@@ -23785,6 +23940,10 @@ snapshots:
       readable-stream: 2.3.7
       xtend: 4.0.2
 
+  through2@4.0.2:
+    dependencies:
+      readable-stream: 3.6.0
+
   through@2.3.8: {}
 
   thunky@1.1.0: {}
@@ -23880,6 +24039,8 @@ snapshots:
   tree-dump@1.0.2(tslib@2.5.0):
     dependencies:
       tslib: 2.5.0
+
+  treeify@1.1.0: {}
 
   trim-lines@1.1.3: {}
 
@@ -24964,7 +25125,19 @@ snapshots:
       camelcase: 5.3.1
       decamelize: 1.2.0
 
+  yargs-parser@20.2.9: {}
+
   yargs-parser@21.1.1: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.7.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,4 @@ packages:
   - 'site'
   - 'examples/*'
   - 'tests'
+  - 'benchmarks'


### PR DESCRIPTION
Fixes #1556.

Simplifying the CSS var function fallback string literal type from

```ts
`var(--${string}, ${string | number})`
```

to

```ts
`var(--${string}, ${string})`
```

drastically improves type-checking in certain cases. For example, when passing a template literal that interpolates a CSS variable into a `style` property multiple times:

```ts
// example.css.ts
import { style, createVar } from "@vanilla-extract/css";

const px = createVar();

export const mask = style({
  mask: `
    repeating-linear-gradient(45deg, #0005 0 calc(1 * ${px}), black calc(2 * ${px}) calc(3 * ${px}), #0005 calc(4 * ${px}) calc(5 * ${px})) no-repeat,
    repeating-linear-gradient(-45deg, #0005 0 calc(1 * ${px}), black calc(2 * ${px}) calc(3 * ${px}), #0005 calc(4 * ${px}) calc(5 * ${px})) no-repeat
  `,
});
```

This doesn't actually affect the values this type can accept because `${number}` is a subset of `${string}`, and therefore `${string | number}` === `${string}`.

With this change, a trivial app containing the above `example.css.ts` file has its type check time drop from ~2.8s to ~0.15s (along with much fewer type instantiations and lower memory usage).

<details>
  <summary>Before</summary>
<pre>
Files:                          54
Lines of Library:            38764
Lines of Definitions:        26605
Lines of TypeScript:            11
Lines of JavaScript:             0
Lines of JSON:                   0
Lines of Other:                  0
Identifiers:                 59814
Symbols:                     40105
Types:                       95560
Instantiations:             362610
Memory used:               625044K
Assignability cache size:   885751
Identity cache size:             0
Subtype cache size:              0
Strict subtype cache size:       0
I/O Read time:               0.03s
Parse time:                  0.14s
ResolveModule time:          0.03s
ResolveTypeReference time:   0.00s
ResolveLibrary time:         0.01s
Program time:                0.22s
Bind time:                   0.06s
Check time:                  2.83s
printTime time:              0.00s
Emit time:                   0.00s
Total time:                  3.11s
</pre>
</details>


<details>
  <summary>After</summary>
<pre>
Files:                         54
Lines of Library:           38764
Lines of Definitions:       26605
Lines of TypeScript:           11
Lines of JavaScript:            0
Lines of JSON:                  0
Lines of Other:                 0
Identifiers:                59814
Symbols:                    40105
Types:                       9032
Instantiations:             12412
Memory used:               91996K
Assignability cache size:   13325
Identity cache size:            0
Subtype cache size:             0
Strict subtype cache size:      0
I/O Read time:              0.02s
Parse time:                 0.15s
ResolveModule time:         0.03s
ResolveTypeReference time:  0.00s
ResolveLibrary time:        0.01s
Program time:               0.22s
Bind time:                  0.06s
Check time:                 0.15s
printTime time:             0.00s
Emit time:                  0.00s
Total time:                 0.43s
</pre>
</details>

## Benchmarks

I've created a `benchmarks` private package to add benchmarking scripts to. Currently the only script is one that benchmarks the number of instantiations between using a CSS var with a narrow type vs a broad (`string`) type.

Here are the results of the benchmark before and after making the change in this PR:

<details>
  <summary>Before</summary>
<pre>
🏌️  broad mask
⛳ Result: 8005 instantiations
🎯 Baseline: 8003 instantiations
📊 Delta: +0.02%

🏌️  narrow mask
⛳ Result: 362293 instantiations
🎯 Baseline: 8003 instantiations
📈 'narrow mask' exceeded baseline by 4426.96% (threshold is 20%).

❌ 'narrow mask' exceeded baseline by 4426.96% (threshold is 20%).
</pre>
</details>

<details>
  <summary>After</summary>
<pre>
🏌️  broad mask
⛳ Result: 8003 instantiations
🎯 Baseline: 8003 instantiations
📊 Delta: 0.00%

🏌️  narrow mask
⛳ Result: 12095 instantiations
🎯 Baseline: 8003 instantiations
📈 'narrow mask' exceeded baseline by 51.13% (threshold is 20%).

❌ 'narrow mask' exceeded baseline by 51.13% (threshold is 20%).
</pre>
</details>

Before the change in this PR, the narrow type resulted in ~360k instantiations while the broad type resulted in ~8k instantiations (44x difference). With this change, the narrow type now only creates ~12k instantiations (1.5x difference).
 