### PR TITLE
Fix runtime behavior to match the type definition

### DIFF
--- a/packages/css/src/style.ts
+++ b/packages/css/src/style.ts
@@ -27,7 +27,11 @@ function composedStyle(rules: Array<StyleRule | ClassNames>, debugId?: string) {
   const classList = [];
   const styleRules = [];
 
-  for (const rule of rules) {
+  // `flat(Infinity)` fails to compile because of TS2589
+  const flattenedRules = rules.flat(Infinity as 20) as Array<
+    StyleRule | string
+  >;
+  for (const rule of flattenedRules) {
     if (typeof rule === 'string') {
       classList.push(rule);
     } else {


### PR DESCRIPTION
Currently, the definition of `ClassNames` is recursive:
https://github.com/vanilla-extract-css/vanilla-extract/blob/221f07f83844a238604a00e4c2d3c75eb7f087ba/packages/css/src/types.ts#L166
But it is not handled correctly on:
https://github.com/vanilla-extract-css/vanilla-extract/blob/221f07f83844a238604a00e4c2d3c75eb7f087ba/packages/css/src/style.ts#L30-L36
This PR fixes this mismatch.