### PR TITLE
Remove unnecessary intersections

### DIFF
--- a/.changeset/warm-seahorses-taste.md
+++ b/.changeset/warm-seahorses-taste.md
@@ -2,4 +2,4 @@
 '@vanilla-extract/css': patch
 ---
 
-Remove unnecessary intersections
+Remove unnecessary intersections in a few types

--- a/.changeset/warm-seahorses-taste.md
+++ b/.changeset/warm-seahorses-taste.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': patch
+---
+
+Remove unnecessary intersections

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -62,18 +62,16 @@ interface AllQueries<StyleType>
 export type WithQueries<StyleType> = StyleType & AllQueries<StyleType>;
 
 interface SelectorMap {
-  [selector: string]: CSSPropertiesWithVars &
-    WithQueries<CSSPropertiesWithVars>;
+  [selector: string]: WithQueries<CSSPropertiesWithVars>;
 }
 
 export interface StyleWithSelectors extends CSSPropertiesAndPseudos {
   selectors?: SelectorMap;
 }
 
-export type StyleRule = StyleWithSelectors & WithQueries<StyleWithSelectors>;
+export type StyleRule = WithQueries<StyleWithSelectors>;
 
-export type GlobalStyleRule = CSSPropertiesWithVars &
-  WithQueries<CSSPropertiesWithVars>;
+export type GlobalStyleRule = WithQueries<CSSPropertiesWithVars>;
 
 export type GlobalFontFaceRule = Omit<AtRule.FontFaceFallback, 'src'> &
   Required<Pick<AtRule.FontFaceFallback, 'src'>>;


### PR DESCRIPTION
Types that uses `WithQueries<StyleType>` are defined like `StyleType & WithQueries<StyleType>`, for example:
https://github.com/vanilla-extract-css/vanilla-extract/blob/221f07f83844a238604a00e4c2d3c75eb7f087ba/packages/css/src/types.ts#L73
while `WithQueries<StyleType>` is defined as:
https://github.com/vanilla-extract-css/vanilla-extract/blob/221f07f83844a238604a00e4c2d3c75eb7f087ba/packages/css/src/types.ts#L62
Additional `StyleType &` is unnecessary, as `StyleType & WithQueries<StyleType>` is `StyleType & StyleType & AllQueries<StyleType>`.
