### PR TITLE
Merge build options from viteConfig in compiler

### DIFF
--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -117,6 +117,7 @@ const createViteServer = async ({
         // Can be removed once https://github.com/vitejs/vite/pull/19247 is released.
         exclude: [/node_modules/],
       },
+      ...viteConfig.build,
     },
     ssr: {
       noExternal: true,


### PR DESCRIPTION
I was trying to update Remix's use of @vanilla-extract/integration (which is still at v6) and came across how the new compiler package now inlines small files into the resulting CSS. These dataurl strings broke the Remix [integration tests](https://github.com/remix-run/remix/blob/main/integration/vanilla-extract-test.ts), so I figured it was better to match the prior behavior.

To match the prior behavior, I need to pass the option `viteConfig.build.assetsInlineLimit: 0` into the compiler, but the `build` options were being ignored because the compiler is setting one of them.

So this patch is the minimum to get the option passed. I see that there have been earlier efforts to do a deep merge on the options (at least for the Vite plugin), but this is more narrow and is for the compiler.