### PR TITLE
Allow `packageInfo` to be undefined

### DIFF
--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -148,7 +148,7 @@ const createViteServer = async ({
               source: code,
               rootPath: root,
               filePath: id,
-              packageName: pkg.name,
+              packageName: pkg?.name,
               identOption: identifiers,
               globalAdapterIdentifier,
             });

--- a/packages/integration/src/addFileScope.ts
+++ b/packages/integration/src/addFileScope.ts
@@ -11,7 +11,7 @@ interface AddFileScopeParams {
   source: string;
   filePath: string;
   rootPath: string;
-  packageName: string;
+  packageName?: string;
   globalAdapterIdentifier?: string;
 }
 export function addFileScope({
@@ -29,20 +29,26 @@ export function addFileScope({
   if (source.includes('@vanilla-extract/css/fileScope')) {
     source = source.replace(
       /setFileScope\(((\n|.)*?)\)/,
-      `setFileScope("${normalizedPath}", "${packageName}")`,
+      `setFileScope("${normalizedPath}"${
+        packageName ? `, "${packageName}"` : ''
+      })`,
     );
   } else {
     if (hasESM && !isMixed) {
       source = dedent(`
         import { setFileScope, endFileScope } from "@vanilla-extract/css/fileScope";
-        setFileScope("${normalizedPath}", "${packageName}");
+        setFileScope("${normalizedPath}"${
+          packageName ? `, "${packageName}"` : ''
+        });
         ${source}
         endFileScope();
       `);
     } else {
       source = dedent(`
         const __vanilla_filescope__ = require("@vanilla-extract/css/fileScope");
-        __vanilla_filescope__.setFileScope("${normalizedPath}", "${packageName}");
+        __vanilla_filescope__.setFileScope("${normalizedPath}"${
+          packageName ? `, "${packageName}"` : ''
+        });
         ${source}
         __vanilla_filescope__.endFileScope();
       `);

--- a/packages/integration/src/compile.ts
+++ b/packages/integration/src/compile.ts
@@ -29,7 +29,7 @@ export const vanillaExtractTransformPlugin = ({
         source: originalSource,
         filePath: path,
         rootPath: build.initialOptions.absWorkingDir!,
-        packageName: packageInfo.name,
+        packageName: packageInfo?.name,
         identOption:
           identOption ?? (build.initialOptions.minify ? 'short' : 'debug'),
       });

--- a/packages/integration/src/packageInfo.ts
+++ b/packages/integration/src/packageInfo.ts
@@ -8,7 +8,7 @@ export interface PackageInfo {
   dirname: string;
 }
 
-function getClosestPackageInfo(directory: string) {
+function getClosestPackageInfo(directory: string): PackageInfo | undefined {
   const packageJsonPath = findUp.sync('package.json', {
     cwd: directory,
   });
@@ -26,7 +26,7 @@ function getClosestPackageInfo(directory: string) {
 
 const packageInfoCache = new Map<string, PackageInfo>();
 
-export function getPackageInfo(cwd?: string | null): PackageInfo {
+export function getPackageInfo(cwd?: string | null): PackageInfo | undefined {
   const resolvedCwd = cwd ?? process.cwd();
   const cachedValue = packageInfoCache.get(resolvedCwd);
 
@@ -43,9 +43,7 @@ export function getPackageInfo(cwd?: string | null): PackageInfo {
   }
 
   if (!packageInfo || !packageInfo.name) {
-    throw new Error(
-      `Couldn't find parent package.json with a name field from '${resolvedCwd}'`,
-    );
+    return undefined;
   }
 
   packageInfoCache.set(resolvedCwd, packageInfo);

--- a/packages/integration/src/transform.ts
+++ b/packages/integration/src/transform.ts
@@ -10,7 +10,7 @@ interface TransformParams {
   source: string;
   filePath: string;
   rootPath: string;
-  packageName: string;
+  packageName?: string;
   identOption: IdentifierOption;
   globalAdapterIdentifier?: string;
 }

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -65,7 +65,7 @@ export function vanillaExtractPlugin({
   let config: ResolvedConfig;
   let configEnv: ConfigEnv;
   let server: ViteDevServer;
-  let packageName: string;
+  let packageName: string | undefined;
   let compiler: Compiler | undefined;
   const vitePromise = import('vite');
 
@@ -127,7 +127,7 @@ export function vanillaExtractPlugin({
     },
     async configResolved(_resolvedConfig) {
       config = _resolvedConfig;
-      packageName = getPackageInfo(config.root).name;
+      packageName = getPackageInfo(config.root)?.name;
     },
     async buildStart() {
       // Ensure we re-use the compiler instance between builds, e.g. in watch mode


### PR DESCRIPTION
Fixes #1563.

IIRC, the name is only relevant for packages that publish to npm (#20).
This PR relaxes that requirement.