### PR TITLE
Use pnpm v10, move pnpm config to `pnpm-workspace.yaml`, remove `volta` config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
-strict-peer-dependencies=false
 registry=https://registry.npmjs.org/

--- a/package.json
+++ b/package.json
@@ -67,9 +67,5 @@
   "manypkg": {
     "workspaceProtocol": "require"
   },
-  "packageManager": "pnpm@9.2.0",
-  "pnpm": {},
-  "volta": {
-    "node": "20.9.0"
-  }
+  "packageManager": "pnpm@10.10.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
-prefer-workspace-packages: true
+preferWorkspacePackages: true
 packages:
   - 'packages/*'
   - 'test-helpers'


### PR DESCRIPTION
- `strict-peer-dependencies` has defaulted to `false` in PNPM for a while now, so the explicit config has been removed
- `volta` is effectively unmaintained, `corepack` (or more generics tool that use `corepack` like `asdf` or `mise`) is likely going to be recommendation going forward
- `prefer-workspace-packages` should've been in `.npmrc`, but it's now available in camel case in `pnpm-workspace.yaml`. It wasn't doing anything before, but even now I don't think it affects much, we're already using the workspace protocol for package references.