### PR TITLE
Update TypeScript to 5.8.3, modernize tsconfig

### DIFF
--- a/benchmarks/package.json
+++ b/benchmarks/package.json
@@ -8,6 +8,6 @@
     "@arktype/attest": "^0.43.3",
     "@vanilla-extract/css": "workspace:*",
     "tsx": "^4.17.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.8.3"
   }
 }

--- a/fixtures/thirdparty/src/styles.css.ts
+++ b/fixtures/thirdparty/src/styles.css.ts
@@ -5,7 +5,6 @@ export {
   depColor,
   depdepBlock,
   depdepColor,
-  // @ts-expect-error no types
 } from '@fixtures/thirdparty-dep';
 
 const color = createVar();

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "prettier": "^2.8.8",
     "tsx": "^4.17.0",
-    "typescript": "^5.5.4",
+    "typescript": "^5.8.3",
     "vitest": "^3.0.2"
   },
   "preconstruct": {

--- a/packages/babel-plugin-debug-ids/src/index.ts
+++ b/packages/babel-plugin-debug-ids/src/index.ts
@@ -1,4 +1,9 @@
-import { types as t, PluginObj, PluginPass, NodePath } from '@babel/core';
+import {
+  types as t,
+  type PluginObj,
+  type PluginPass,
+  type NodePath,
+} from '@babel/core';
 
 const packageIdentifiers = new Set([
   '@vanilla-extract/css',

--- a/packages/css/src/validateContract.ts
+++ b/packages/css/src/validateContract.ts
@@ -1,4 +1,4 @@
-import { Contract, walkObject } from '@vanilla-extract/private';
+import { type Contract, walkObject } from '@vanilla-extract/private';
 import { diff } from 'deep-object-diff';
 import pc from 'picocolors';
 

--- a/packages/css/src/vars.ts
+++ b/packages/css/src/vars.ts
@@ -3,17 +3,17 @@ import type { AtRule } from 'csstype';
 import {
   get,
   walkObject,
-  Contract,
-  MapLeafNodes,
-  CSSVarFunction,
+  type Contract,
+  type MapLeafNodes,
+  type CSSVarFunction,
 } from '@vanilla-extract/private';
 import cssesc from 'cssesc';
 
-import { Tokens, NullableTokens, ThemeVars } from './types';
+import type { Tokens, NullableTokens, ThemeVars } from './types';
 import { validateContract } from './validateContract';
 import { getFileScope } from './fileScope';
 import { generateIdentifier } from './identifier';
-import { PropertySyntax } from './types';
+import type { PropertySyntax } from './types';
 import { appendCss } from './adapter';
 
 type VarDeclaration =

--- a/packages/dynamic/src/assignInlineVars.ts
+++ b/packages/dynamic/src/assignInlineVars.ts
@@ -2,8 +2,8 @@ import {
   walkObject,
   get,
   getVarName,
-  Contract,
-  MapLeafNodes,
+  type Contract,
+  type MapLeafNodes,
 } from '@vanilla-extract/private';
 
 type Styles = { [cssVarName: string]: string };

--- a/packages/dynamic/src/setElementVars.ts
+++ b/packages/dynamic/src/setElementVars.ts
@@ -2,8 +2,8 @@ import {
   get,
   walkObject,
   getVarName,
-  Contract,
-  MapLeafNodes,
+  type Contract,
+  type MapLeafNodes,
 } from '@vanilla-extract/private';
 
 function setVar(element: HTMLElement, variable: string, value: string) {

--- a/packages/esbuild-plugin-next/src/index.ts
+++ b/packages/esbuild-plugin-next/src/index.ts
@@ -7,7 +7,7 @@ import {
 import {
   cssFileFilter,
   vanillaExtractTransformPlugin,
-  IdentifierOption,
+  type IdentifierOption,
 } from '@vanilla-extract/integration';
 import type { Plugin } from 'esbuild';
 

--- a/packages/esbuild-plugin/src/index.ts
+++ b/packages/esbuild-plugin/src/index.ts
@@ -7,8 +7,8 @@ import {
   getSourceFromVirtualCssFile,
   compile,
   vanillaExtractTransformPlugin,
-  IdentifierOption,
-  CompileOptions,
+  type IdentifierOption,
+  type CompileOptions,
 } from '@vanilla-extract/integration';
 import type { Plugin } from 'esbuild';
 
@@ -70,7 +70,7 @@ export function vanillaExtractPlugin({
       );
 
       build.onLoad({ filter: cssFileFilter }, async ({ path }) => {
-        const combinedEsbuildOptions = { ...esbuildOptions } ?? {};
+        const combinedEsbuildOptions = { ...esbuildOptions };
         const identOption =
           identifiers ?? (build.initialOptions.minify ? 'short' : 'debug');
 

--- a/packages/integration/src/compile.ts
+++ b/packages/integration/src/compile.ts
@@ -3,8 +3,8 @@ import { promises as fs } from 'fs';
 
 import {
   build as esbuild,
-  Plugin,
-  BuildOptions as EsbuildOptions,
+  type Plugin,
+  type BuildOptions as EsbuildOptions,
 } from 'esbuild';
 
 import type { IdentifierOption } from './types';

--- a/packages/integration/src/processVanillaFile.ts
+++ b/packages/integration/src/processVanillaFile.ts
@@ -1,4 +1,4 @@
-import { FileScope, Adapter } from '@vanilla-extract/css';
+import type { FileScope, Adapter } from '@vanilla-extract/css';
 import { transformCss } from '@vanilla-extract/css/transformCss';
 import evalCode from 'eval';
 import { stringify } from 'javascript-stringify';

--- a/packages/integration/src/types.ts
+++ b/packages/integration/src/types.ts
@@ -1,3 +1,3 @@
-import { Adapter } from '@vanilla-extract/css';
+import type { Adapter } from '@vanilla-extract/css';
 
 export type IdentifierOption = ReturnType<Adapter['getIdentOption']>;

--- a/packages/private/src/walkObject.ts
+++ b/packages/private/src/walkObject.ts
@@ -1,4 +1,4 @@
-import { MapLeafNodes } from './types';
+import type { MapLeafNodes } from './types';
 
 type Primitive = string | number | null | undefined;
 

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -3,10 +3,10 @@ import {
   cssFileFilter,
   processVanillaFile,
   compile,
-  IdentifierOption,
+  type IdentifierOption,
   getSourceFromVirtualCssFile,
   virtualCssFileFilter,
-  CompileOptions,
+  type CompileOptions,
 } from '@vanilla-extract/integration';
 import { posix } from 'path';
 

--- a/packages/rollup-plugin/test/rollup-plugin.test.ts
+++ b/packages/rollup-plugin/test/rollup-plugin.test.ts
@@ -1,4 +1,4 @@
-import { rollup, OutputOptions } from 'rollup';
+import { rollup, type OutputOptions } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
 import json from '@rollup/plugin-json';
 import path from 'path';

--- a/packages/sprinkles/src/createRuntimeSprinkles.ts
+++ b/packages/sprinkles/src/createRuntimeSprinkles.ts
@@ -1,8 +1,8 @@
 import {
   createSprinkles as internalCreateSprinkles,
-  SprinklesFn,
+  type SprinklesFn,
 } from './createSprinkles';
-import { SprinklesProperties } from './types';
+import type { SprinklesProperties } from './types';
 
 const composeStyles = (classList: string) => classList;
 

--- a/packages/sprinkles/src/createSprinkles.ts
+++ b/packages/sprinkles/src/createSprinkles.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   ResponsiveArrayByMaxLength,
   ConditionalPropertyValue,
   SprinklesProperties,

--- a/packages/sprinkles/src/createUtils.ts
+++ b/packages/sprinkles/src/createUtils.ts
@@ -1,5 +1,5 @@
 import { addRecipe } from '@vanilla-extract/css/recipe';
-import {
+import type {
   ResponsiveArrayByMaxLength,
   RequiredResponsiveArrayByMaxLength,
 } from './types';

--- a/packages/sprinkles/src/index.ts
+++ b/packages/sprinkles/src/index.ts
@@ -1,17 +1,17 @@
 import {
   style,
   composeStyles,
-  CSSProperties,
-  StyleRule,
+  type CSSProperties,
+  type StyleRule,
 } from '@vanilla-extract/css';
 import { addRecipe } from '@vanilla-extract/css/recipe';
 import { hasFileScope } from '@vanilla-extract/css/fileScope';
 
 import {
-  SprinklesFn,
+  type SprinklesFn,
   createSprinkles as internalCreateSprinkles,
 } from './createSprinkles';
-import { SprinklesProperties, ResponsiveArrayConfig } from './types';
+import type { SprinklesProperties, ResponsiveArrayConfig } from './types';
 
 export { createNormalizeValueFn, createMapValueFn } from './createUtils';
 export type { ConditionalValue, RequiredConditionalValue } from './createUtils';

--- a/packages/webpack-plugin/src/loader.ts
+++ b/packages/webpack-plugin/src/loader.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import loaderUtils from 'loader-utils';
 import {
   getPackageInfo,
-  IdentifierOption,
+  type IdentifierOption,
   processVanillaFile,
   serializeCss,
   transform,

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -1,8 +1,11 @@
-import { cssFileFilter, IdentifierOption } from '@vanilla-extract/integration';
+import {
+  cssFileFilter,
+  type IdentifierOption,
+} from '@vanilla-extract/integration';
 import type { Compiler, RuleSetRule } from 'webpack';
 
 import { ChildCompiler } from './compiler';
-import createCompat, { WebpackCompat } from './compat';
+import createCompat, { type WebpackCompat } from './compat';
 
 const pluginName = 'VanillaExtractPlugin';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 2.8.2
       '@testing-library/jest-dom':
         specifier: ^6.4.2
-        version: 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4)))(vitest@3.0.2(@types/node@22.15.3)(jsdom@20.0.3)(terser@5.26.0)(tsx@4.17.0))
+        version: 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3)))(vitest@3.0.2(@types/node@22.15.3)(jsdom@20.0.3)(terser@5.26.0)(tsx@4.17.0))
       '@types/jest':
         specifier: ^29.5.12
         version: 29.5.12
@@ -55,7 +55,7 @@ importers:
         version: 7.0.3
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))
+        version: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))
       jest-environment-jsdom:
         specifier: ^29.7.0
         version: 29.7.0
@@ -66,8 +66,8 @@ importers:
         specifier: ^4.17.0
         version: 4.17.0
       typescript:
-        specifier: ^5.5.4
-        version: 5.5.4
+        specifier: ^5.8.3
+        version: 5.8.3
       vitest:
         specifier: ^3.0.2
         version: 3.0.2(@types/node@22.15.3)(jsdom@20.0.3)(terser@5.26.0)(tsx@4.17.0)
@@ -76,7 +76,7 @@ importers:
     dependencies:
       '@arktype/attest':
         specifier: ^0.43.3
-        version: 0.43.3(typescript@5.5.4)
+        version: 0.43.3(typescript@5.8.3)
       '@vanilla-extract/css':
         specifier: workspace:*
         version: link:../packages/css
@@ -84,8 +84,8 @@ importers:
         specifier: ^4.17.0
         version: 4.17.0
       typescript:
-        specifier: ^5.5.4
-        version: 5.5.4
+        specifier: ^5.8.3
+        version: 5.8.3
 
   examples/next:
     dependencies:
@@ -113,13 +113,13 @@ importers:
     dependencies:
       '@remix-run/node':
         specifier: ^2.8.0
-        version: 2.8.0(typescript@5.5.4)
+        version: 2.8.0(typescript@5.8.3)
       '@remix-run/react':
         specifier: ^2.8.0
-        version: 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4)
+        version: 2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.8.3)
       '@remix-run/serve':
         specifier: ^2.8.0
-        version: 2.8.0(typescript@5.5.4)
+        version: 2.8.0(typescript@5.8.3)
       '@vanilla-extract/css':
         specifier: workspace:*
         version: link:../../packages/css
@@ -135,7 +135,7 @@ importers:
     devDependencies:
       '@remix-run/dev':
         specifier: ^2.8.0
-        version: 2.8.0(@remix-run/serve@2.8.0(typescript@5.5.4))(@types/node@22.15.3)(terser@5.26.0)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))(typescript@5.5.4)(vite@6.0.10(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0))
+        version: 2.8.0(@remix-run/serve@2.8.0(typescript@5.8.3))(@types/node@22.15.3)(terser@5.26.0)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))(typescript@5.8.3)(vite@6.0.10(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0))
       '@types/react':
         specifier: ^18.2.55
         version: 18.2.55
@@ -189,7 +189,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       tailwindcss:
         specifier: ^2.1.2
-        version: 2.2.19(autoprefixer@10.4.17(postcss@8.5.1))(postcss@8.5.1)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))
+        version: 2.2.19(autoprefixer@10.4.17(postcss@8.5.1))(postcss@8.5.1)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))
       webpack:
         specifier: ^5.90.0
         version: 5.90.0(webpack-cli@5.1.4)
@@ -636,7 +636,7 @@ importers:
         version: 4.30.1
       rollup-plugin-dts:
         specifier: ^6.1.1
-        version: 6.1.1(rollup@4.30.1)(typescript@5.5.4)
+        version: 6.1.1(rollup@4.30.1)(typescript@5.8.3)
       rollup-plugin-node-externals:
         specifier: ^7.1.3
         version: 7.1.3(rollup@4.30.1)
@@ -941,7 +941,7 @@ importers:
         version: 10.0.0
       '@testing-library/jest-dom':
         specifier: ^6.4.2
-        version: 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4)))(vitest@3.0.2(@types/node@22.15.3)(jsdom@20.0.3)(terser@5.26.0)(tsx@4.17.0))
+        version: 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3)))(vitest@3.0.2(@types/node@22.15.3)(jsdom@20.0.3)(terser@5.26.0)(tsx@4.17.0))
       '@vanilla-extract-private/test-helpers':
         specifier: workspace:*
         version: link:../test-helpers
@@ -968,7 +968,7 @@ importers:
         version: link:../packages/sprinkles
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.5.4)(vite@6.0.10(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0))
+        version: 5.1.4(typescript@5.8.3)(vite@6.0.10(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0))
 
 packages:
 
@@ -11247,8 +11247,8 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  typescript@5.5.4:
-    resolution: {integrity: sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -12134,16 +12134,16 @@ snapshots:
 
   '@ark/util@0.43.3': {}
 
-  '@arktype/attest@0.43.3(typescript@5.5.4)':
+  '@arktype/attest@0.43.3(typescript@5.8.3)':
     dependencies:
       '@ark/fs': 0.43.3
       '@ark/util': 0.43.3
       '@prettier/sync': 0.5.2(prettier@3.4.2)
       '@typescript/analyze-trace': 0.10.1
-      '@typescript/vfs': 1.6.0(typescript@5.5.4)
+      '@typescript/vfs': 1.6.0(typescript@5.8.3)
       arktype: 2.1.3
       prettier: 3.4.2
-      typescript: 5.5.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13665,7 +13665,7 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))':
+  '@jest/core@29.7.0(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -13679,7 +13679,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))
+      jest-config: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -15333,7 +15333,7 @@ snapshots:
       make-synchronized: 0.2.9
       prettier: 3.4.2
 
-  '@remix-run/dev@2.8.0(@remix-run/serve@2.8.0(typescript@5.5.4))(@types/node@22.15.3)(terser@5.26.0)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))(typescript@5.5.4)(vite@6.0.10(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0))':
+  '@remix-run/dev@2.8.0(@remix-run/serve@2.8.0(typescript@5.8.3))(@types/node@22.15.3)(terser@5.26.0)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))(typescript@5.8.3)(vite@6.0.10(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0))':
     dependencies:
       '@babel/core': 7.23.9
       '@babel/generator': 7.23.6
@@ -15345,9 +15345,9 @@ snapshots:
       '@babel/types': 7.23.9
       '@mdx-js/mdx': 2.3.0
       '@npmcli/package-json': 4.0.1
-      '@remix-run/node': 2.8.0(typescript@5.5.4)
+      '@remix-run/node': 2.8.0(typescript@5.8.3)
       '@remix-run/router': 1.15.2
-      '@remix-run/server-runtime': 2.8.0(typescript@5.5.4)
+      '@remix-run/server-runtime': 2.8.0(typescript@5.8.3)
       '@types/mdx': 2.0.11
       '@vanilla-extract/integration': 6.5.0(@types/node@22.15.3)(terser@5.26.0)
       arg: 5.0.2
@@ -15376,7 +15376,7 @@ snapshots:
       pidtree: 0.6.0
       postcss: 8.5.1
       postcss-discard-duplicates: 5.1.0(postcss@8.5.1)
-      postcss-load-config: 4.0.2(postcss@8.5.1)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))
+      postcss-load-config: 4.0.2(postcss@8.5.1)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))
       postcss-modules: 6.0.0(postcss@8.5.1)
       prettier: 2.8.8
       pretty-ms: 7.0.1
@@ -15389,8 +15389,8 @@ snapshots:
       tsconfig-paths: 4.2.0
       ws: 7.5.6
     optionalDependencies:
-      '@remix-run/serve': 2.8.0(typescript@5.5.4)
-      typescript: 5.5.4
+      '@remix-run/serve': 2.8.0(typescript@5.8.3)
+      typescript: 5.8.3
       vite: 6.0.10(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0)
     transitivePeerDependencies:
       - '@types/node'
@@ -15408,16 +15408,16 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@remix-run/express@2.8.0(express@4.18.2)(typescript@5.5.4)':
+  '@remix-run/express@2.8.0(express@4.18.2)(typescript@5.8.3)':
     dependencies:
-      '@remix-run/node': 2.8.0(typescript@5.5.4)
+      '@remix-run/node': 2.8.0(typescript@5.8.3)
       express: 4.18.2
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.8.3
 
-  '@remix-run/node@2.8.0(typescript@5.5.4)':
+  '@remix-run/node@2.8.0(typescript@5.8.3)':
     dependencies:
-      '@remix-run/server-runtime': 2.8.0(typescript@5.5.4)
+      '@remix-run/server-runtime': 2.8.0(typescript@5.8.3)
       '@remix-run/web-fetch': 4.4.2
       '@remix-run/web-file': 3.1.0
       '@remix-run/web-stream': 1.1.0
@@ -15426,25 +15426,25 @@ snapshots:
       source-map-support: 0.5.21
       stream-slice: 0.1.2
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.8.3
 
-  '@remix-run/react@2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.5.4)':
+  '@remix-run/react@2.8.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(typescript@5.8.3)':
     dependencies:
       '@remix-run/router': 1.15.2
-      '@remix-run/server-runtime': 2.8.0(typescript@5.5.4)
+      '@remix-run/server-runtime': 2.8.0(typescript@5.8.3)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-router: 6.22.2(react@18.2.0)
       react-router-dom: 6.22.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.8.3
 
   '@remix-run/router@1.15.2': {}
 
-  '@remix-run/serve@2.8.0(typescript@5.5.4)':
+  '@remix-run/serve@2.8.0(typescript@5.8.3)':
     dependencies:
-      '@remix-run/express': 2.8.0(express@4.18.2)(typescript@5.5.4)
-      '@remix-run/node': 2.8.0(typescript@5.5.4)
+      '@remix-run/express': 2.8.0(express@4.18.2)(typescript@5.8.3)
+      '@remix-run/node': 2.8.0(typescript@5.8.3)
       chokidar: 3.6.0
       compression: 1.7.4
       express: 4.18.2
@@ -15455,7 +15455,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@remix-run/server-runtime@2.8.0(typescript@5.5.4)':
+  '@remix-run/server-runtime@2.8.0(typescript@5.8.3)':
     dependencies:
       '@remix-run/router': 1.15.2
       '@types/cookie': 0.6.0
@@ -15464,7 +15464,7 @@ snapshots:
       set-cookie-parser: 2.6.0
       source-map: 0.7.3
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.8.3
 
   '@remix-run/web-blob@3.1.0':
     dependencies:
@@ -15694,7 +15694,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4)))(vitest@3.0.2(@types/node@22.15.3)(jsdom@20.0.3)(terser@5.26.0)(tsx@4.17.0))':
+  '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3)))(vitest@3.0.2(@types/node@22.15.3)(jsdom@20.0.3)(terser@5.26.0)(tsx@4.17.0))':
     dependencies:
       '@adobe/css-tools': 4.3.3
       '@babel/runtime': 7.23.9
@@ -15707,7 +15707,7 @@ snapshots:
     optionalDependencies:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.12
-      jest: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))
+      jest: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))
       vitest: 3.0.2(@types/node@22.15.3)(jsdom@20.0.3)(terser@5.26.0)(tsx@4.17.0)
 
   '@tootallnate/once@2.0.0': {}
@@ -16121,10 +16121,10 @@ snapshots:
       treeify: 1.1.0
       yargs: 16.2.0
 
-  '@typescript/vfs@1.6.0(typescript@5.5.4)':
+  '@typescript/vfs@1.6.0(typescript@5.8.3)':
     dependencies:
       debug: 4.4.0(supports-color@9.2.3)
-      typescript: 5.5.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -17466,13 +17466,13 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 3.6.0
 
-  create-jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4)):
+  create-jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.10
-      jest-config: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))
+      jest-config: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -19850,16 +19850,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4)):
+  jest-cli@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))
+      '@jest/core': 29.7.0(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))
+      create-jest: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))
       exit: 0.1.2
       import-local: 3.0.3
-      jest-config: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))
+      jest-config: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -19869,7 +19869,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4)):
+  jest-config@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3)):
     dependencies:
       '@babel/core': 7.23.9
       '@jest/test-sequencer': 29.7.0
@@ -19895,7 +19895,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.15.3
-      ts-node: 10.9.1(@types/node@22.15.3)(typescript@5.5.4)
+      ts-node: 10.9.1(@types/node@22.15.3)(typescript@5.8.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -20164,12 +20164,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4)):
+  jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))
+      '@jest/core': 29.7.0(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))
       '@jest/types': 29.6.3
       import-local: 3.0.3
-      jest-cli: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))
+      jest-cli: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22255,21 +22255,21 @@ snapshots:
     optionalDependencies:
       ts-node: 10.9.1(@types/node@16.11.10)(typescript@4.9.4)
 
-  postcss-load-config@3.1.0(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4)):
+  postcss-load-config@3.1.0(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3)):
     dependencies:
       import-cwd: 3.0.0
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
-      ts-node: 10.9.1(@types/node@22.15.3)(typescript@5.5.4)
+      ts-node: 10.9.1(@types/node@22.15.3)(typescript@5.8.3)
 
-  postcss-load-config@4.0.2(postcss@8.5.1)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4)):
+  postcss-load-config@4.0.2(postcss@8.5.1)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3)):
     dependencies:
       lilconfig: 3.1.0
       yaml: 2.3.4
     optionalDependencies:
       postcss: 8.5.1
-      ts-node: 10.9.1(@types/node@22.15.3)(typescript@5.5.4)
+      ts-node: 10.9.1(@types/node@22.15.3)(typescript@5.8.3)
 
   postcss-merge-longhand@5.1.7(postcss@8.5.1):
     dependencies:
@@ -23079,11 +23079,11 @@ snapshots:
     dependencies:
       glob: 10.3.10
 
-  rollup-plugin-dts@6.1.1(rollup@4.30.1)(typescript@5.5.4):
+  rollup-plugin-dts@6.1.1(rollup@4.30.1)(typescript@5.8.3):
     dependencies:
       magic-string: 0.30.17
       rollup: 4.30.1
-      typescript: 5.5.4
+      typescript: 5.8.3
     optionalDependencies:
       '@babel/code-frame': 7.24.7
 
@@ -23775,7 +23775,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@2.2.19(autoprefixer@10.4.17(postcss@8.5.1))(postcss@8.5.1)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4)):
+  tailwindcss@2.2.19(autoprefixer@10.4.17(postcss@8.5.1))(postcss@8.5.1)(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3)):
     dependencies:
       arg: 5.0.2
       autoprefixer: 10.4.17(postcss@8.5.1)
@@ -23801,7 +23801,7 @@ snapshots:
       object-hash: 2.2.0
       postcss: 8.5.1
       postcss-js: 3.0.3
-      postcss-load-config: 3.1.0(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4))
+      postcss-load-config: 3.1.0(ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3))
       postcss-nested: 5.0.6(postcss@8.5.1)
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
@@ -24063,7 +24063,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.1(@types/node@22.15.3)(typescript@5.5.4):
+  ts-node@10.9.1(@types/node@22.15.3)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.8
@@ -24077,14 +24077,14 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.5.4
+      typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
 
-  tsconfck@3.1.4(typescript@5.5.4):
+  tsconfck@3.1.4(typescript@5.8.3):
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.8.3
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -24143,7 +24143,7 @@ snapshots:
 
   typescript@4.9.4: {}
 
-  typescript@5.5.4: {}
+  typescript@5.8.3: {}
 
   typographic-apostrophes-for-possessive-plurals@1.0.5: {}
 
@@ -24576,11 +24576,11 @@ snapshots:
       - rollup
       - supports-color
 
-  vite-tsconfig-paths@5.1.4(typescript@5.5.4)(vite@6.0.10(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.0.10(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0)):
     dependencies:
       debug: 4.4.0(supports-color@9.2.3)
       globrex: 0.1.2
-      tsconfck: 3.1.4(typescript@5.5.4)
+      tsconfck: 3.1.4(typescript@5.8.3)
     optionalDependencies:
       vite: 6.0.10(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0)
     transitivePeerDependencies:

--- a/site/src/Blockquote/Blockquote.tsx
+++ b/site/src/Blockquote/Blockquote.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { Box } from '../system';
 import * as styles from './Blockquote.css';
 

--- a/site/src/Code/CompiledCode.css.ts
+++ b/site/src/Code/CompiledCode.css.ts
@@ -1,4 +1,9 @@
-import { createVar, fallbackVar, style, StyleRule } from '@vanilla-extract/css';
+import {
+  createVar,
+  fallbackVar,
+  style,
+  type StyleRule,
+} from '@vanilla-extract/css';
 import { calc } from '@vanilla-extract/css-utils';
 import { darkMode, sprinkles } from '../system/styles/sprinkles.css';
 import { vars } from '../themes.css';

--- a/site/src/Code/ErrorHighlighter.tsx
+++ b/site/src/Code/ErrorHighlighter.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, ReactNode } from 'react';
+import { useRef, useEffect, type ReactNode } from 'react';
 import * as styles from './ErrorHighlighter.css';
 
 export interface CodeProps {

--- a/site/src/ColorModeToggle/ColorModeToggle.tsx
+++ b/site/src/ColorModeToggle/ColorModeToggle.tsx
@@ -3,7 +3,7 @@ import {
   useState,
   createContext,
   useContext,
-  ReactNode,
+  type ReactNode,
 } from 'react';
 import { Box } from '../system';
 import * as styles from './ColorModeToggle.css';

--- a/site/src/HomePage/HomePage.tsx
+++ b/site/src/HomePage/HomePage.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 import dedent from 'dedent';
 import { Box, Stack, ContentBlock, Columns, ButtonLink } from '../system';
 import { Heading } from '../Typography/Heading';

--- a/site/src/InlineCode/InlineCode.tsx
+++ b/site/src/InlineCode/InlineCode.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { Box } from '../system';
 import * as styles from './InlineCode.css';
 

--- a/site/src/SearchInput/SearchInput.tsx
+++ b/site/src/SearchInput/SearchInput.tsx
@@ -1,6 +1,6 @@
 import { DocSearch } from '@docsearch/react';
 import '@docsearch/css';
-import { ComponentProps } from 'react';
+import type { ComponentProps } from 'react';
 
 import './SearchInput.css';
 

--- a/site/src/Tweet/Tweet.tsx
+++ b/site/src/Tweet/Tweet.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { Box, Stack } from '../system';
 import Link from '../Typography/Link';
 import Text from '../Typography/Text';

--- a/site/src/Typography/Heading.tsx
+++ b/site/src/Typography/Heading.tsx
@@ -1,9 +1,9 @@
-import { ElementType, ReactNode } from 'react';
+import type { ElementType, ReactNode } from 'react';
 import classnames from 'classnames';
 
 import * as styles from './typography.css';
 import { Box } from '../system';
-import { sprinkles, Sprinkles } from '../system/styles/sprinkles.css';
+import { sprinkles, type Sprinkles } from '../system/styles/sprinkles.css';
 
 export type HeadingLevel = keyof typeof styles.heading;
 

--- a/site/src/Typography/Link.tsx
+++ b/site/src/Typography/Link.tsx
@@ -1,7 +1,7 @@
-import { Link, LinkProps } from 'react-router-dom';
+import { Link, type LinkProps } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
 import classnames from 'classnames';
-import { TextProps, useTextStyles } from './Text';
+import { type TextProps, useTextStyles } from './Text';
 import * as styles from './Link.css';
 import { sprinkles } from '../system/styles/sprinkles.css';
 

--- a/site/src/Typography/Text.tsx
+++ b/site/src/Typography/Text.tsx
@@ -1,8 +1,8 @@
-import { ReactNode, ElementType } from 'react';
+import type { ReactNode, ElementType } from 'react';
 import classnames from 'classnames';
 import { Box } from '../system';
 import * as styles from './typography.css';
-import { sprinkles, Sprinkles } from '../system/styles/sprinkles.css';
+import { sprinkles, type Sprinkles } from '../system/styles/sprinkles.css';
 
 const colorMap = {
   neutral: { lightMode: 'coolGray700', darkMode: 'gray100' },

--- a/site/src/mdx-components.tsx
+++ b/site/src/mdx-components.tsx
@@ -1,8 +1,8 @@
 import {
-  ReactNode,
-  ComponentProps,
-  AllHTMLAttributes,
-  ElementType,
+  type ReactNode,
+  type ComponentProps,
+  type AllHTMLAttributes,
+  type ElementType,
   createElement,
   Children,
 } from 'react';
@@ -12,10 +12,10 @@ import { Box } from './system';
 import InlineCode from './InlineCode/InlineCode';
 import Link from './Typography/Link';
 import Blockquote from './Blockquote/Blockquote';
-import { HeadingLevel, useHeadingStyles } from './Typography/Heading';
+import { type HeadingLevel, useHeadingStyles } from './Typography/Heading';
 import Divider from './Divider/Divider';
-import { CompiledCode, CompiledCodeProps } from './Code/CompiledCode';
-import { BoxProps } from './system/Box/Box';
+import { CompiledCode, type CompiledCodeProps } from './Code/CompiledCode';
+import { type BoxProps } from './system/Box/Box';
 import { sprinkles } from './system/styles/sprinkles.css';
 import { vars } from './themes.css';
 import * as styles from './mdx-components.css';

--- a/site/src/render.tsx
+++ b/site/src/render.tsx
@@ -3,7 +3,7 @@ import { renderToString } from 'react-dom/server';
 import { StaticRouter } from 'react-router-dom/server';
 import { HeadProvider } from 'react-head';
 import App from './App';
-import { StatsCompilation } from 'webpack';
+import type { StatsCompilation } from 'webpack';
 import { darkMode, lightMode } from './system/styles/sprinkles.css';
 import { themeKey } from './ColorModeToggle/ColorModeToggle';
 

--- a/site/src/system/Box/Box.tsx
+++ b/site/src/system/Box/Box.tsx
@@ -1,7 +1,7 @@
-import { createElement, AllHTMLAttributes, ElementType } from 'react';
+import { createElement, type AllHTMLAttributes, type ElementType } from 'react';
 import classnames from 'classnames';
 import * as resetStyles from '../styles/reset.css';
-import { sprinkles, Sprinkles } from '../styles/sprinkles.css';
+import { sprinkles, type Sprinkles } from '../styles/sprinkles.css';
 
 export interface BoxProps
   extends Omit<

--- a/site/src/system/ButtonLink/ButtonLink.tsx
+++ b/site/src/system/ButtonLink/ButtonLink.tsx
@@ -1,6 +1,6 @@
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import classnames from 'classnames';
-import { Link, NavLinkProps } from 'react-router-dom';
+import { Link, type NavLinkProps } from 'react-router-dom';
 import { HashLink } from 'react-router-hash-link';
 import { Box } from '..';
 import * as styles from './ButtonLink.css';

--- a/site/src/system/Columns/Columns.tsx
+++ b/site/src/system/Columns/Columns.tsx
@@ -1,9 +1,9 @@
-import { Children, ReactNode } from 'react';
+import { Children, type ReactNode } from 'react';
 import { Box } from '../Box/Box';
 import {
   mapResponsiveValue,
-  ResponsiveValue,
-  Space,
+  type ResponsiveValue,
+  type Space,
 } from '../styles/sprinkles.css';
 
 interface Props {

--- a/site/src/system/ContentBlock/ContentBlock.tsx
+++ b/site/src/system/ContentBlock/ContentBlock.tsx
@@ -1,7 +1,7 @@
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 import { Box } from '../';
 import * as styles from './ContentBlock.css';
-import { BoxProps } from '../Box/Box';
+import type { BoxProps } from '../Box/Box';
 
 export const ContentBlock = ({
   children,

--- a/site/src/system/Stack/Stack.tsx
+++ b/site/src/system/Stack/Stack.tsx
@@ -1,7 +1,10 @@
-import { Children, ReactNode } from 'react';
+import { Children, type ReactNode } from 'react';
 import { Box } from '../';
-import { BoxProps } from '../Box/Box';
-import { mapResponsiveValue, ResponsiveValue } from '../styles/sprinkles.css';
+import type { BoxProps } from '../Box/Box';
+import {
+  mapResponsiveValue,
+  type ResponsiveValue,
+} from '../styles/sprinkles.css';
 
 const alignToFlexAlign = {
   left: 'flex-start',

--- a/site/src/system/styles/sprinkles.css.ts
+++ b/site/src/system/styles/sprinkles.css.ts
@@ -4,7 +4,7 @@ import {
   createSprinkles,
   createMapValueFn,
   createNormalizeValueFn,
-  ConditionalValue,
+  type ConditionalValue,
 } from '@vanilla-extract/sprinkles';
 import { calc } from '@vanilla-extract/css-utils';
 import { breakpoints } from '../../themeUtils';

--- a/site/src/themeUtils.ts
+++ b/site/src/themeUtils.ts
@@ -1,7 +1,7 @@
 import omit from 'lodash/omit';
 import isEqual from 'lodash/isEqual';
-import { StyleRule } from '@vanilla-extract/css';
-import { Properties } from 'csstype';
+import type { StyleRule } from '@vanilla-extract/css';
+import type { Properties } from 'csstype';
 import mapValues from 'lodash/mapValues';
 
 export const breakpoints = {

--- a/site/src/themes.css.ts
+++ b/site/src/themes.css.ts
@@ -2,7 +2,7 @@ import { createGlobalTheme } from '@vanilla-extract/css';
 import colors from 'tailwindcss/colors';
 import { precomputeValues } from '@capsizecss/vanilla-extract';
 
-import { Breakpoint } from './themeUtils';
+import type { Breakpoint } from './themeUtils';
 
 const grid = 4;
 const px = (value: string | number) => `${value}px`;

--- a/test-helpers/src/startFixture/esbuild.ts
+++ b/test-helpers/src/startFixture/esbuild.ts
@@ -5,7 +5,7 @@ import { vanillaExtractPlugin } from '@vanilla-extract/esbuild-plugin';
 import { vanillaExtractPlugin as vanillaExtractPluginNext } from '@vanilla-extract/esbuild-plugin-next';
 import * as esbuild from 'esbuild';
 
-import { TestServer } from './types';
+import type { TestServer } from './types';
 
 export interface EsbuildFixtureOptions {
   type: 'esbuild' | 'esbuild-runtime' | 'esbuild-next' | 'esbuild-next-runtime';

--- a/test-helpers/src/startFixture/index.ts
+++ b/test-helpers/src/startFixture/index.ts
@@ -1,12 +1,12 @@
 import portfinder from 'portfinder';
 
-import { startWebpackFixture, WebpackFixtureOptions } from './webpack';
-import { startEsbuildFixture, EsbuildFixtureOptions } from './esbuild';
-import { startViteFixture, ViteFixtureOptions } from './vite';
-import { startParcelFixture, ParcelFixtureOptions } from './parcel';
-import { NextFixtureOptions, startNextFixture } from './next';
+import { startWebpackFixture, type WebpackFixtureOptions } from './webpack';
+import { startEsbuildFixture, type EsbuildFixtureOptions } from './esbuild';
+import { startViteFixture, type ViteFixtureOptions } from './vite';
+import { startParcelFixture, type ParcelFixtureOptions } from './parcel';
+import { type NextFixtureOptions, startNextFixture } from './next';
 
-import { TestServer } from './types';
+import type { TestServer } from './types';
 
 export * from './types';
 

--- a/test-helpers/src/startFixture/next.ts
+++ b/test-helpers/src/startFixture/next.ts
@@ -6,7 +6,7 @@ import { existsSync } from 'fs';
 import { Server as _Server, createServer } from 'http';
 import path from 'path';
 
-import { TestServer } from './types';
+import type { TestServer } from './types';
 import { serveAssets } from './vite';
 
 type Server = _Server & {

--- a/test-helpers/src/startFixture/parcel.ts
+++ b/test-helpers/src/startFixture/parcel.ts
@@ -2,7 +2,7 @@ import path from 'path';
 
 import { Parcel } from '@parcel/core';
 
-import { TestServer } from './types';
+import type { TestServer } from './types';
 
 export interface ParcelFixtureOptions {
   type: 'parcel';

--- a/test-helpers/src/startFixture/types.ts
+++ b/test-helpers/src/startFixture/types.ts
@@ -1,8 +1,8 @@
-import { EsbuildFixtureOptions } from './esbuild';
-import { NextFixtureOptions } from './next';
-import { ParcelFixtureOptions } from './parcel';
-import { ViteFixtureOptions } from './vite';
-import { WebpackFixtureOptions } from './webpack';
+import type { EsbuildFixtureOptions } from './esbuild';
+import type { NextFixtureOptions } from './next';
+import type { ParcelFixtureOptions } from './parcel';
+import type { ViteFixtureOptions } from './vite';
+import type { WebpackFixtureOptions } from './webpack';
 
 type BuildType =
   | WebpackFixtureOptions['type']

--- a/test-helpers/src/startFixture/vite.ts
+++ b/test-helpers/src/startFixture/vite.ts
@@ -6,7 +6,7 @@ import handler from 'serve-handler';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import inspect from 'vite-plugin-inspect';
 
-import { TestServer } from './types';
+import type { TestServer } from './types';
 
 export const serveAssets = ({ port, dir }: { port: number; dir: string }) =>
   new Promise<() => Promise<void>>((resolve) => {

--- a/test-helpers/src/startFixture/webpack.ts
+++ b/test-helpers/src/startFixture/webpack.ts
@@ -1,12 +1,12 @@
 import { VanillaExtractPlugin } from '@vanilla-extract/webpack-plugin';
 import WDS from 'webpack-dev-server';
-import webpack, { Configuration } from 'webpack';
+import webpack, { type Configuration } from 'webpack';
 import webpackMerge from 'webpack-merge';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 
 import { stylesheetName } from '../getStylesheet';
-import { TestServer } from './types';
+import type { TestServer } from './types';
 
 export const getTestNodes = (fixture: string) =>
   require(`@fixtures/${fixture}/test-nodes.json`);

--- a/tests/e2e/features.playwright.ts
+++ b/tests/e2e/features.playwright.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import {
   getStylesheet,
   startFixture,
-  TestServer,
+  type TestServer,
 } from '@vanilla-extract-private/test-helpers';
 
 import test from './fixture';

--- a/tests/e2e/fixtures-next-development.playwright.ts
+++ b/tests/e2e/fixtures-next-development.playwright.ts
@@ -1,7 +1,7 @@
 import {
   nextFixtures,
   startFixture,
-  TestServer,
+  type TestServer,
 } from '@vanilla-extract-private/test-helpers';
 import { expect } from '@playwright/test';
 

--- a/tests/e2e/fixtures-next-production.playwright.ts
+++ b/tests/e2e/fixtures-next-production.playwright.ts
@@ -1,7 +1,7 @@
 import {
   nextFixtures,
   startFixture,
-  TestServer,
+  type TestServer,
 } from '@vanilla-extract-private/test-helpers';
 import { expect } from '@playwright/test';
 

--- a/tests/e2e/layers.playwright.ts
+++ b/tests/e2e/layers.playwright.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import {
   getStylesheet,
   startFixture,
-  TestServer,
+  type TestServer,
 } from '@vanilla-extract-private/test-helpers';
 
 import test from './fixture';

--- a/tests/e2e/low-level.playwright.ts
+++ b/tests/e2e/low-level.playwright.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import {
   getStylesheet,
   startFixture,
-  TestServer,
+  type TestServer,
 } from '@vanilla-extract-private/test-helpers';
 
 import test from './fixture';

--- a/tests/e2e/recipes.playwright.ts
+++ b/tests/e2e/recipes.playwright.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import {
   getStylesheet,
   startFixture,
-  TestServer,
+  type TestServer,
 } from '@vanilla-extract-private/test-helpers';
 
 import test from './fixture';

--- a/tests/e2e/sprinkles.playwright.ts
+++ b/tests/e2e/sprinkles.playwright.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import {
   getStylesheet,
   startFixture,
-  TestServer,
+  type TestServer,
 } from '@vanilla-extract-private/test-helpers';
 
 import test from './fixture';

--- a/tests/e2e/template-string-paths.playwright.ts
+++ b/tests/e2e/template-string-paths.playwright.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import {
   getStylesheet,
   startFixture,
-  TestServer,
+  type TestServer,
 } from '@vanilla-extract-private/test-helpers';
 
 import test from './fixture';

--- a/tests/e2e/themed.playwright.ts
+++ b/tests/e2e/themed.playwright.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import {
   getStylesheet,
   startFixture,
-  TestServer,
+  type TestServer,
 } from '@vanilla-extract-private/test-helpers';
 
 import test from './fixture';

--- a/tests/e2e/thirdparty.playwright.ts
+++ b/tests/e2e/thirdparty.playwright.ts
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import {
   getStylesheet,
   startFixture,
-  TestServer,
+  type TestServer,
 } from '@vanilla-extract-private/test-helpers';
 
 import test from './fixture';

--- a/tests/recipes/recipes-type-tests.ts
+++ b/tests/recipes/recipes-type-tests.ts
@@ -1,7 +1,7 @@
 /*
     This file is for validating types, it is not designed to be executed
 */
-import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
+import { recipe, type RecipeVariants } from '@vanilla-extract/recipes';
 
 // @ts-expect-error Unused args
 const noop = (...args: Array<any>) => {};

--- a/tests/sprinkles/sprinkles-type-tests.ts
+++ b/tests/sprinkles/sprinkles-type-tests.ts
@@ -5,8 +5,8 @@ import {
   defineProperties,
   createMapValueFn,
   createNormalizeValueFn,
-  ConditionalValue,
-  RequiredConditionalValue,
+  type ConditionalValue,
+  type RequiredConditionalValue,
 } from '@vanilla-extract/sprinkles';
 import { createSprinkles } from '@vanilla-extract/sprinkles';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,22 +1,23 @@
 {
   "compilerOptions": {
-    "target": "ESNEXT" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
-    "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    "lib": ["es2021", "dom"],
+    "target": "ES2022",
+    "module": "Preserve", // Vanilla Extract is bundled with preconstruct (effectively Rollup)
+    "lib": ["ES2023", "dom", "dom.iterable"], // ES2023 aligns with Node 22, and we need DOM APIs for fixtures and the docs site
     "noEmit": true,
     "noImplicitAny": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "strict": true /* Enable all strict type-checking options. */,
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
-    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "bundler", // Again, bundling handles module resolution
     "jsx": "react-jsx",
     "allowJs": true,
     "incremental": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
+    "moduleDetection": "force",
     "isolatedModules": true,
-    "downlevelIteration": true
+    "verbatimModuleSyntax": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Modernized tsconfig to utilize newer, bundler-specific configuration options such as `module: "preserve"` and `moduleResolution: "bundler"`.

Additionally enabled `verbatimModuleSyntax` to enforce that we use type-only imports where appropriate.

These config changes do not affect published package artifacts.