### PR TITLE
Convert `scripts` package to `type: "module"`

### DIFF
--- a/scripts/build-dts.ts
+++ b/scripts/build-dts.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs';
 import fs from 'fs/promises';
-import path from 'path';
+import path from 'node:path/posix';
 
 import glob from 'fast-glob';
 import { legacy, resolve } from 'resolve.exports';

--- a/scripts/build-dts.ts
+++ b/scripts/build-dts.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs';
 import fs from 'fs/promises';
-import path from 'node:path/posix';
+import path from 'path';
+import { pathToFileURL } from 'url';
 
 import glob from 'fast-glob';
 import { legacy, resolve } from 'resolve.exports';
@@ -98,9 +99,13 @@ const packages = await glob('packages/*', {
 const entryPaths: [string, string][] = [];
 
 for (const packageDir of packages) {
-  const pkg = await import(path.resolve(packageDir, 'package.json'), {
-    with: { type: 'json' },
-  });
+  const pkg = await import(
+    // oathToFileURL enables the result of `path.resolve` to work with `import()` on windows
+    pathToFileURL(path.resolve(packageDir, 'package.json')).toString(),
+    {
+      with: { type: 'json' },
+    }
+  );
 
   if (pkg.exports) {
     const pkgExports = Object.keys(pkg.exports);

--- a/scripts/copy-next-plugin.ts
+++ b/scripts/copy-next-plugin.ts
@@ -1,32 +1,30 @@
-import { glob } from 'fast-glob';
+import glob from 'fast-glob';
 import { existsSync } from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
 
 // We need to use distinct next plugins for each next fixutre
 // due to different next versions / mini-css-extract-plugin serializer registration
-(async () => {
-  const nextPluginDistDir = path.join(
-    __dirname,
-    '../packages/next-plugin/dist',
-  );
+const nextPluginDistDir = path.join(
+  import.meta.dirname,
+  '../packages/next-plugin/dist',
+);
 
-  if (!existsSync(nextPluginDistDir)) {
-    throw new Error('packages/next-plugin/dist is missing.');
-  }
+if (!existsSync(nextPluginDistDir)) {
+  throw new Error('packages/next-plugin/dist is missing.');
+}
 
-  const nextFixtureDirs = await glob('fixtures/next-*', {
-    onlyDirectories: true,
-    absolute: true,
+const nextFixtureDirs = await glob('fixtures/next-*', {
+  onlyDirectories: true,
+  absolute: true,
+});
+
+if (nextFixtureDirs.length === 0) {
+  throw new Error('No next fixtures found.');
+}
+
+for (const dir of nextFixtureDirs) {
+  await fs.cp(nextPluginDistDir, path.join(dir, 'next-plugin', 'dist'), {
+    recursive: true,
   });
-
-  if (nextFixtureDirs.length === 0) {
-    throw new Error('No next fixtures found.');
-  }
-
-  for (const dir of nextFixtureDirs) {
-    await fs.cp(nextPluginDistDir, path.join(dir, 'next-plugin', 'dist'), {
-      recursive: true,
-    });
-  }
-})();
+}

--- a/scripts/copy-next-plugin.ts
+++ b/scripts/copy-next-plugin.ts
@@ -1,14 +1,14 @@
 import glob from 'fast-glob';
 import { existsSync } from 'fs';
 import fs from 'fs/promises';
-import path from 'path';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // We need to use distinct next plugins for each next fixutre
 // due to different next versions / mini-css-extract-plugin serializer registration
-const nextPluginDistDir = path.join(
-  import.meta.dirname,
-  '../packages/next-plugin/dist',
-);
+const nextPluginDistDir = join(__dirname, '../packages/next-plugin/dist');
 
 if (!existsSync(nextPluginDistDir)) {
   throw new Error('packages/next-plugin/dist is missing.');
@@ -24,7 +24,7 @@ if (nextFixtureDirs.length === 0) {
 }
 
 for (const dir of nextFixtureDirs) {
-  await fs.cp(nextPluginDistDir, path.join(dir, 'next-plugin', 'dist'), {
+  await fs.cp(nextPluginDistDir, join(dir, 'next-plugin', 'dist'), {
     recursive: true,
   });
 }

--- a/scripts/copy-next-plugin.ts
+++ b/scripts/copy-next-plugin.ts
@@ -1,14 +1,14 @@
 import glob from 'fast-glob';
 import { existsSync } from 'fs';
 import fs from 'fs/promises';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import path from 'path';
 
 // We need to use distinct next plugins for each next fixutre
 // due to different next versions / mini-css-extract-plugin serializer registration
-const nextPluginDistDir = join(__dirname, '../packages/next-plugin/dist');
+const nextPluginDistDir = path.join(
+  import.meta.dirname,
+  '../packages/next-plugin/dist',
+);
 
 if (!existsSync(nextPluginDistDir)) {
   throw new Error('packages/next-plugin/dist is missing.');
@@ -24,7 +24,7 @@ if (nextFixtureDirs.length === 0) {
 }
 
 for (const dir of nextFixtureDirs) {
-  await fs.cp(nextPluginDistDir, join(dir, 'next-plugin', 'dist'), {
+  await fs.cp(nextPluginDistDir, path.join(dir, 'next-plugin', 'dist'), {
     recursive: true,
   });
 }

--- a/scripts/copy-readme-to-packages.ts
+++ b/scripts/copy-readme-to-packages.ts
@@ -3,17 +3,15 @@ import path from 'path';
 
 import glob from 'fast-glob';
 
-(async () => {
-  const packages = await glob('packages/*', {
-    onlyDirectories: true,
-    absolute: true,
-    ignore: ['packages/sprinkles', 'packages/integration'],
-  });
+const packages = await glob('packages/*', {
+  onlyDirectories: true,
+  absolute: true,
+  ignore: ['packages/sprinkles', 'packages/integration', 'packages/compiler'],
+});
 
-  for (const packageDir of packages) {
-    await fs.copyFile(
-      path.join(__dirname, '../README.md'),
-      path.join(packageDir, 'README.md'),
-    );
-  }
-})();
+for (const packageDir of packages) {
+  await fs.copyFile(
+    path.join(import.meta.dirname, '../README.md'),
+    path.join(packageDir, 'README.md'),
+  );
+}

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@vanilla-extract/scripts",
   "private": true,
+  "type": "module",
   "devDependencies": {
     "fast-glob": "^3.2.7",
     "resolve.exports": "^2.0.2",


### PR DESCRIPTION
Changes are primarily indentation related now that we don't need to use IIFEs and can instead use top-level `await`. Additionally, `packages/compiler` is now excluded from the copy READMEs script as currently that package is published with the top-level README.