### PR TITLE
omit rule-less variants from classMap

### DIFF
--- a/packages/css/src/style.ts
+++ b/packages/css/src/style.ts
@@ -168,6 +168,7 @@ export function styleVariants(...args: any[]) {
 
     const classMap: Record<string | number, string> = {};
     for (const key in data) {
+      if (!Object.keys(data[key]).length) continue;
       classMap[key] = style(
         mapData(data[key], key),
         debugId ? `${debugId}_${key}` : key,


### PR DESCRIPTION
This PR prevents `styleVariants` from generating class names for 'empty' variants. As discussed in #1580 this can be helpful for using as conditions for `compoundVariants`.

Not sure if you'd classify it a bug, or if it's a change you want to make; but it addresses the issue I found, so have made this PR for your consideration.