### PR TITLE
fix: processVanillaFile fileScopes race

### DIFF
--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -27,6 +27,7 @@
     "mlly": "^1.4.2"
   },
   "devDependencies": {
-    "@types/babel__core": "^7.20.5"
+    "@types/babel__core": "^7.20.5",
+    "@fixtures/sprinkles": "workspace:*"
   }
 }

--- a/packages/integration/src/processVanillaFile.test.ts
+++ b/packages/integration/src/processVanillaFile.test.ts
@@ -1,4 +1,7 @@
-import { serializeVanillaModule } from './processVanillaFile';
+import {
+  processVanillaFile,
+  serializeVanillaModule,
+} from './processVanillaFile';
 
 describe('serializeVanillaModule', () => {
   test('with plain object exports', () => {
@@ -231,5 +234,49 @@ describe('serializeVanillaModule', () => {
       export var reReExport = reExport;
       export var otherComplexExport = reExport;"
     `);
+  });
+});
+
+describe('processVanillaFile', () => {
+  jest.useFakeTimers();
+  test('should process vanilla file with correct promise order', async () => {
+    const serializeVirtualCssPath1 = jest.fn(
+      ({ source }) =>
+        new Promise<string>((resolve) => {
+          setTimeout(() => resolve(source), 1);
+        }),
+    );
+    const serializeVirtualCssPath2 = jest.fn(({ source }) =>
+      Promise.resolve(source),
+    );
+
+    const [result] = await Promise.all([
+      processVanillaFile({
+        source: `
+        const __vanilla_filescope__ = require("@vanilla-extract/css/fileScope");
+        const { style, globalStyle } = require('@vanilla-extract/css'); 
+        __vanilla_filescope__.setFileScope("dependency.css.ts", "test");
+        exports.x = style({ color: 'blue' });
+        __vanilla_filescope__.endFileScope();
+        __vanilla_filescope__.setFileScope("style1.css.ts", "test");
+        exports.y = style([exports.x]);
+        globalStyle('body ' + exports.y, { color: 'red' });
+        __vanilla_filescope__.endFileScope();
+      `,
+        filePath: require.resolve('@fixtures/sprinkles'),
+        serializeVirtualCssPath: serializeVirtualCssPath1,
+      }),
+      processVanillaFile({
+        source: `
+        const __vanilla_filescope__ = require("@vanilla-extract/css/fileScope");
+        __vanilla_filescope__.setFileScope("style2.css.ts", "test");
+        __vanilla_filescope__.endFileScope();
+      `,
+        filePath: require.resolve('@fixtures/sprinkles'),
+        serializeVirtualCssPath: serializeVirtualCssPath2,
+      }),
+      jest.runAllTimersAsync(),
+    ]);
+    expect(result).toMatch(/.*export var y = .*style1.*/);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -508,6 +508,9 @@ importers:
         specifier: ^1.4.2
         version: 1.4.2
     devDependencies:
+      '@fixtures/sprinkles':
+        specifier: workspace:^
+        version: link:../../fixtures/sprinkles
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5


### PR DESCRIPTION
## Problem
`processVanillaFile` (1) awaits while serializing css for each fileScope. For a file with multiple fileScopes (which happens when one `.css.ts` file imports another), it will yield to the event loop before calling `transformCss` on the next fileScope.

If the integration is handling multiple files concurrently, it could yield to another `processVanillaFile` (2).

Since all `processVanillaFile` calls share one [adapaterStack](https://github.com/vanilla-extract-css/vanilla-extract/blob/9241939b9c8f44b78bd6cc6285e5f6c41b6dfd62/packages/css/src/adapter.ts#L13), (2) could push its adapter onto the stack and then yield back to (1) while (2) is awaiting serialization.

If this happens, [currentAdapter](https://github.com/vanilla-extract-css/vanilla-extract/blob/9241939b9c8f44b78bd6cc6285e5f6c41b6dfd62/packages/css/src/adapter.ts#L15) will point to the adapter of (2) for the `transformCss` of the next fileScope in (1).

This causes the `markCompositionUsed` called by `transformCss` to update the wrong adapter. `unusedCompositions` of (1) would then include an identifier that was actually used. The identifier is then stripped and any selectors that referenced it will not work. 

The new test in `processVanillaFile.test.ts` fails without this change.

## Solution
Add the scoped adapter to the stack before calling functions that use it (`evalCode` and `transformCss`) and remove the adapter before any awaits. This way `currentAdapter` will always point to the relevant adapter.

## Context
Pretty sure this is what's going on here: https://github.com/vanilla-extract-css/vanilla-extract/issues/654