### PR TITLE
Implement `enableDevCache` option in Vite plugin

### DIFF
--- a/.changeset/forty-clocks-leave.md
+++ b/.changeset/forty-clocks-leave.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': minor
+---
+
+Implement an `enableDevCache` option in the Vite plugin which helps alleviate dev server performance issues in large projects caused by redundant `.vanilla.css` file loading

--- a/site/docs/integrations/vite.md
+++ b/site/docs/integrations/vite.md
@@ -60,3 +60,23 @@ vanillaExtractPlugin({
 ```
 
 Each integration will set a default value based on the configuration options passed to the bundler.
+
+### enableDevCache
+
+This option can help mitigate dev mode [performance issues](https://github.com/vanilla-extract-css/vanilla-extract/issues/1488) in large projects, especially those using `sprinkles` or other common `.css.ts` imports. It ensures that `.vanilla.css` virtual files are only invalidated and re-fetched when their contents have actually change. This is accomplished by creating a map of `.css.ts` file paths to MD5 hashes of their content.
+
+The trade-offs for this option include more filesystem operations and potentially higher memory usage in the plugin.
+
+```js
+// vite.config.js
+
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+
+export default {
+  plugins: [
+    vanillaExtractPlugin({
+      enableDevCache: true
+    })
+  ]
+};
+```


### PR DESCRIPTION
Addresses issue #1488 

This PR implements an `enableDevCache` option in `@vanilla-extract/vite-plugin` which helps alleviate dev server performance issues in large projects caused by redundant `.vanilla.css` file loading.

I made this an option rather than a default because there is an obvious trade-off here: adding these filesystem and hashing operations incurs cost, so the default / `false` setting is likely faster in small projects.  But in large projects, this seems worthwhile.

It cut my cold start load times by about 25%. I think the performance improvement would've been bigger if I hadn't already added sprinkles and recipes runtime imports to `optimizeDeps.include`- they were causing some HMR churn on startup so it made the duplicate imports more costly.