### PR TITLE
`vite`: Disable the compiler's file watcher during builds

### DIFF
--- a/.changeset/kind-chicken-battle.md
+++ b/.changeset/kind-chicken-battle.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Disable the compiler's file watcher during builds

--- a/.changeset/wet-swans-rush.md
+++ b/.changeset/wet-swans-rush.md
@@ -1,0 +1,17 @@
+---
+'@vanilla-extract/compiler': minor
+---
+
+`createCompiler`: Add `enableFileWatcher` option
+
+By default, the compiler sets up its own file watcher.
+This option allows you to disable it if necessary, such as during a production build.
+
+**EXAMPLE USAGE**:
+
+```ts
+const compiler = createCompiler({
+  root: process.cwd(),
+  enableFileWatcher: false
+});
+```

--- a/test-helpers/src/startFixture/esbuild.ts
+++ b/test-helpers/src/startFixture/esbuild.ts
@@ -12,6 +12,7 @@ export interface EsbuildFixtureOptions {
   mode?: 'development' | 'production';
   port: number;
 }
+
 export const startEsbuildFixture = async (
   fixtureName: string,
   { type, mode = 'development', port = 3000 }: EsbuildFixtureOptions,
@@ -48,7 +49,16 @@ export const startEsbuildFixture = async (
     outdir,
   });
 
+  await ctx.watch();
+
   const server = await ctx.serve({ servedir: outdir, port });
+
+  const esbuildLiveReloadScript = `
+    <script type="module">
+      new EventSource('/esbuild').addEventListener('change', () =>
+      location.reload(),
+      );
+    </script>`;
 
   await fs.writeFile(
     path.join(outdir, 'index.html'),
@@ -58,6 +68,7 @@ export const startEsbuildFixture = async (
       <meta charset="utf-8">
       <title>esbuild - ${fixtureName}</title>
       <link rel="stylesheet" type="text/css" href="index.css" />
+      ${mode !== 'production' ? esbuildLiveReloadScript : ''}
       </head>
     <body>
       <script src="index.js"></script>


### PR DESCRIPTION
Closes #1327.

Both the parent vite dev server and the compiler can have independent file watchers configured. During a build, the compiler doesn't need to watch files, so a new `enableFileWatcher` option has been exposed on `createCompiler`. The vite plugin sets this to `false` during a non-watched build.

I tried exposing a module invalidation method on a the compiler so that the parent vite server can invalidate it based on events from its watcher. This would lets us permanently disable the compiler's watcher in the vite plugin. However I couldn't get it to work. It resulted in HMR not working at all, and even a page refresh wouldn't update CSS :shrug:.

I've also modified how we run `esbuild` fixtures to take advantage of the documented [live reload](https://esbuild.github.io/api/#live-reload) functionality.