### PR TITLE
ci(.github/workflows): replace 'pnpm i' with 'pnpm install'

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -22,7 +22,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm i
+        run: pnpm install
 
       - name: Build packages
         run: pnpm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm i
+        run: pnpm install
 
       - name: Create release PR or publish to npm
         uses: changesets/action@v1

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -26,7 +26,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm i
+        run: pnpm install
 
       - name: Publish
         uses: seek-oss/changesets-snapshot@v0

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,7 +28,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm i
+        run: pnpm install
 
       - name: Build
         run: pnpm build && node ./site/makeDocsManifest
@@ -63,7 +63,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm i
+        run: pnpm install
 
       - name: Build
         run: pnpm build
@@ -89,7 +89,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Install Dependencies
-        run: pnpm i
+        run: pnpm install
 
       - name: Install Browsers
         run: pnpm playwright install chromium


### PR DESCRIPTION
* Since `vanilla-extract` is an official open source library, I replaced the alias command `pnpm i` with the full command `pnpm install` for clarify.