### PR TITLE
fix(webpack-plugin): fix 'require is not defined' error in Node 24

### DIFF
--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -7,6 +7,10 @@ import type { Compiler, RuleSetRule } from 'webpack';
 import { ChildCompiler } from './compiler';
 import createCompat, { type WebpackCompat } from './compat';
 
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
 const pluginName = 'VanillaExtractPlugin';
 
 function markCSSFilesAsSideEffects(compiler: Compiler, compat: WebpackCompat) {


### PR DESCRIPTION
The webpack plugin was failing when used with Storybook in Node.js 24 environments due to ESM module resolution. Node.js attempts to execute the code as ESM where 'require' is not defined (reference: storybookjs/storybook#31434).

This fix addresses the compatibility issue by properly handling module imports in ESM contexts.

The solution ensures consistent behavior across both CommonJS and ESM module systems.