### PR TITLE
Update vite-node to v3.2.2

### DIFF
--- a/.changeset/old-dragons-sort.md
+++ b/.changeset/old-dragons-sort.md
@@ -1,0 +1,5 @@
+---
+"@vanilla-extract/compiler": patch
+---
+
+Update `vite-node` dependency to `^3.2.2`

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -27,6 +27,6 @@
     "@vanilla-extract/css": "workspace:^",
     "@vanilla-extract/integration": "workspace:^",
     "vite": "^5.0.0 || ^6.0.0",
-    "vite-node": "^3.0.4"
+    "vite-node": "^3.2.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -396,8 +396,8 @@ importers:
         specifier: ^5.0.0 || ^6.0.0
         version: 6.0.10(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0)
       vite-node:
-        specifier: ^3.0.4
-        version: 3.0.4(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0)
+        specifier: ^3.2.2
+        version: 3.2.2(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0)
 
   packages/css:
     dependencies:
@@ -5813,6 +5813,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decache@4.6.1:
     resolution: {integrity: sha512-ohApBM8u9ygepJCjgBrEZSSxPjc0T/PJkD+uNyxXPkqudyUpdXpwJYp0VISm2WrPVzASU6DZyIi6BWdyw7uJ2Q==}
 
@@ -6228,6 +6237,9 @@ packages:
 
   es-module-lexer@1.6.0:
     resolution: {integrity: sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
   es6-promisify@6.1.1:
     resolution: {integrity: sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg==}
@@ -9415,6 +9427,9 @@ packages:
   pathe@2.0.2:
     resolution: {integrity: sha512-15Ztpk+nov8DR524R4BF7uEuzESgzUEAV4Ah7CUMNGXdE5ELuvxElxGXndBl32vMSsWa1jpNf22Z+Er3sKwq+w==}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
@@ -11588,8 +11603,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite-node@3.0.4:
-    resolution: {integrity: sha512-7JZKEzcYV2Nx3u6rlvN8qdo3QV7Fxyt6hx+CCKz9fbWxdX5IvUOmTWEAxMrWxaiSf7CKGLJQ5rFu8prb/jBjOA==}
+  vite-node@3.2.2:
+    resolution: {integrity: sha512-Xj/jovjZvDXOq2FgLXu8NsY4uHUMWtzVmMC2LkCu9HWdr9Qu1Is5sanX3Z4jOFKdohfaWDnEJWp9pRP0vVpAcA==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
@@ -17677,6 +17692,10 @@ snapshots:
     optionalDependencies:
       supports-color: 9.2.3
 
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
   decache@4.6.1:
     dependencies:
       callsite: 1.0.0
@@ -18068,6 +18087,8 @@ snapshots:
       stackframe: 1.3.4
 
   es-module-lexer@1.6.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es6-promisify@6.1.1: {}
 
@@ -22143,6 +22164,8 @@ snapshots:
 
   pathe@2.0.2: {}
 
+  pathe@2.0.3: {}
+
   pathval@2.0.0: {}
 
   peek-stream@1.1.3:
@@ -24561,12 +24584,12 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.0.4(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0):
+  vite-node@3.2.2(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0(supports-color@9.2.3)
-      es-module-lexer: 1.6.0
-      pathe: 2.0.2
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
       vite: 6.0.10(@types/node@22.15.3)(terser@5.26.0)(tsx@4.17.0)
     transitivePeerDependencies:
       - '@types/node'


### PR DESCRIPTION
Vite 7 (currently in beta) includes a small breaking change that affects vite-node. Because of that, currently the plugin cannot be used with Vite 7.

This PR updates vite-node to v3.2.2 so that the plugin can be used with Vite 7. vite-node 3.2 is compatible with Vite 5 and Vite 6 so this change should not affect older versions.
It's still a beta version, but merging this PR will help keeping the ecosystem-ci green and helps us find any regression faster (it was caught indirectly via waku).
