### PR TITLE
Annotate return types to satisfy `isolatedDeclarations`

### DIFF
--- a/packages/css/src/adapter.ts
+++ b/packages/css/src/adapter.ts
@@ -22,13 +22,13 @@ const currentAdapter = () => {
 
 let hasConfiguredAdapter = false;
 
-export const setAdapterIfNotSet = (newAdapter: Adapter) => {
+export const setAdapterIfNotSet = (newAdapter: Adapter): void => {
   if (!hasConfiguredAdapter) {
     setAdapter(newAdapter);
   }
 };
 
-export const setAdapter = (newAdapter: Adapter) => {
+export const setAdapter = (newAdapter: Adapter): void => {
   if (!newAdapter) {
     throw new Error('No adapter provided when calling "setAdapter"');
   }
@@ -38,7 +38,7 @@ export const setAdapter = (newAdapter: Adapter) => {
   adapterStack.push(newAdapter);
 };
 
-export const removeAdapter = () => {
+export const removeAdapter = (): void => {
   adapterStack.pop();
 };
 

--- a/packages/css/src/conditionalRulesets.ts
+++ b/packages/css/src/conditionalRulesets.ts
@@ -12,6 +12,8 @@ type Condition = {
   children: ConditionalRuleset;
 };
 
+type RenderedConditionalRule = Record<string, Record<string, any>>;
+
 export class ConditionalRuleset {
   ruleset: Map<Query, Condition>;
 
@@ -27,7 +29,7 @@ export class ConditionalRuleset {
     this.precedenceLookup = new Map();
   }
 
-  findOrCreateCondition(conditionQuery: Query) {
+  findOrCreateCondition(conditionQuery: Query): Condition {
     let targetCondition = this.ruleset.get(conditionQuery);
 
     if (!targetCondition) {
@@ -43,7 +45,7 @@ export class ConditionalRuleset {
     return targetCondition;
   }
 
-  getConditionalRulesetByPath(conditionPath: Array<Query>) {
+  getConditionalRulesetByPath(conditionPath: Array<Query>): ConditionalRuleset {
     let currRuleset: ConditionalRuleset = this;
 
     for (const query of conditionPath) {
@@ -55,7 +57,11 @@ export class ConditionalRuleset {
     return currRuleset;
   }
 
-  addRule(rule: Rule, conditionQuery: Query, conditionPath: Array<Query>) {
+  addRule(
+    rule: Rule,
+    conditionQuery: Query,
+    conditionPath: Array<Query>,
+  ): void {
     const ruleset = this.getConditionalRulesetByPath(conditionPath);
     const targetCondition = ruleset.findOrCreateCondition(conditionQuery);
 
@@ -69,7 +75,7 @@ export class ConditionalRuleset {
   addConditionPrecedence(
     conditionPath: Array<Query>,
     conditionOrder: Array<Query>,
-  ) {
+  ): void {
     const ruleset = this.getConditionalRulesetByPath(conditionPath);
 
     for (let i = 0; i < conditionOrder.length; i++) {
@@ -86,7 +92,7 @@ export class ConditionalRuleset {
     }
   }
 
-  isCompatible(incomingRuleset: ConditionalRuleset) {
+  isCompatible(incomingRuleset: ConditionalRuleset): boolean {
     for (const [
       condition,
       orderPrecedence,
@@ -117,7 +123,7 @@ export class ConditionalRuleset {
     return true;
   }
 
-  merge(incomingRuleset: ConditionalRuleset) {
+  merge(incomingRuleset: ConditionalRuleset): void {
     // Merge rulesets into one array
     for (const { query, rules, children } of incomingRuleset.ruleset.values()) {
       const matchingCondition = this.ruleset.get(query);
@@ -150,7 +156,7 @@ export class ConditionalRuleset {
    *
    * @returns true if successful, false if the ruleset is incompatible
    */
-  mergeIfCompatible(incomingRuleset: ConditionalRuleset) {
+  mergeIfCompatible(incomingRuleset: ConditionalRuleset): boolean {
     if (!this.isCompatible(incomingRuleset)) {
       return false;
     }
@@ -160,7 +166,7 @@ export class ConditionalRuleset {
     return true;
   }
 
-  getSortedRuleset() {
+  getSortedRuleset(): Condition[] {
     const sortedRuleset: Array<Condition> = [];
 
     // Loop through all queries and add them to the sorted ruleset
@@ -189,11 +195,11 @@ export class ConditionalRuleset {
     return sortedRuleset;
   }
 
-  renderToArray() {
-    const arr: any = [];
+  renderToArray(): RenderedConditionalRule[] {
+    const arr: RenderedConditionalRule[] = [];
 
     for (const { query, rules, children } of this.getSortedRuleset()) {
-      const selectors: any = {};
+      const selectors: Record<string, any> = {};
 
       for (const rule of rules) {
         selectors[rule.selector] = {

--- a/packages/css/src/container.ts
+++ b/packages/css/src/container.ts
@@ -2,5 +2,5 @@ import { generateIdentifier } from './identifier';
 
 // createContainer is used for local scoping of CSS containers
 // For now it is mostly just an alias of generateIdentifier
-export const createContainer = (debugId?: string) =>
+export const createContainer = (debugId?: string): string =>
   generateIdentifier(debugId);

--- a/packages/css/src/fileScope.ts
+++ b/packages/css/src/fileScope.ts
@@ -6,7 +6,7 @@ let refCounter = 0;
 
 const fileScopes: Array<FileScope> = [];
 
-export function setFileScope(filePath: string, packageName?: string) {
+export function setFileScope(filePath: string, packageName?: string): void {
   refCounter = 0;
   const fileScope = {
     filePath,
@@ -16,13 +16,13 @@ export function setFileScope(filePath: string, packageName?: string) {
   onBeginFileScope(fileScope);
 }
 
-export function endFileScope() {
+export function endFileScope(): void {
   onEndFileScope(getFileScope());
   refCounter = 0;
   fileScopes.splice(0, 1);
 }
 
-export function hasFileScope() {
+export function hasFileScope(): boolean {
   return fileScopes.length > 0;
 }
 
@@ -41,6 +41,6 @@ export function getFileScope(): FileScope {
   return fileScopes[0];
 }
 
-export function getAndIncrementRefCounter() {
+export function getAndIncrementRefCounter(): number {
   return refCounter++;
 }

--- a/packages/css/src/functionSerializer.ts
+++ b/packages/css/src/functionSerializer.ts
@@ -16,7 +16,7 @@ interface SerializerConfig {
 export function addFunctionSerializer<Target extends object>(
   target: Target,
   recipe: SerializerConfig,
-) {
+): Target {
   // TODO: Update to "__function_serializer__" in future.
   // __recipe__ is the backwards compatible name
   Object.defineProperty(target, '__recipe__', {

--- a/packages/css/src/getDebugFileName.ts
+++ b/packages/css/src/getDebugFileName.ts
@@ -56,7 +56,7 @@ const memoizedGetDebugFileName = () => {
     max: 500,
   });
 
-  return (path: string) => {
+  return (path: string): string => {
     const cachedResult = cache.get(path);
 
     if (cachedResult) {
@@ -70,4 +70,5 @@ const memoizedGetDebugFileName = () => {
   };
 };
 
-export const getDebugFileName = memoizedGetDebugFileName();
+export const getDebugFileName: (path: string) => string =
+  memoizedGetDebugFileName();

--- a/packages/css/src/injectStyles.ts
+++ b/packages/css/src/injectStyles.ts
@@ -6,7 +6,7 @@ interface InjectStylesOptions {
   fileScope: FileScope;
   css: string;
 }
-export const injectStyles = ({ fileScope, css }: InjectStylesOptions) => {
+export const injectStyles = ({ fileScope, css }: InjectStylesOptions): void => {
   const fileScopeId = fileScope.packageName
     ? [fileScope.packageName, fileScope.filePath].join('/')
     : fileScope.filePath;

--- a/packages/css/src/recipe.ts
+++ b/packages/css/src/recipe.ts
@@ -1,6 +1,8 @@
 import { addFunctionSerializer } from './functionSerializer';
 
-/**
- * @deprecated Use 'addFunctionSerializer' from '@vanilla-extract/css/functionSerializer'
- */
-export const addRecipe = addFunctionSerializer;
+export {
+  /**
+   * @deprecated Use 'addFunctionSerializer' from '@vanilla-extract/css/functionSerializer'
+   */
+  addFunctionSerializer as addRecipe,
+};

--- a/packages/css/src/style.ts
+++ b/packages/css/src/style.ts
@@ -67,7 +67,7 @@ function composedStyle(rules: Array<StyleRule | ClassNames>, debugId?: string) {
   return result;
 }
 
-export function style(rule: ComplexStyleRule, debugId?: string) {
+export function style(rule: ComplexStyleRule, debugId?: string): string {
   if (Array.isArray(rule)) {
     return composedStyle(rule, debugId);
   }
@@ -83,20 +83,20 @@ export function style(rule: ComplexStyleRule, debugId?: string) {
 /**
  * @deprecated The same functionality is now provided by the 'style' function when you pass it an array
  */
-export function composeStyles(...classNames: Array<ClassNames>) {
+export function composeStyles(...classNames: Array<ClassNames>): string {
   const compose = hasFileScope() ? composedStyle : dudupeAndJoinClassList;
 
   return compose(classNames);
 }
 
-export function globalStyle(selector: string, rule: GlobalStyleRule) {
+export function globalStyle(selector: string, rule: GlobalStyleRule): void {
   appendCss({ type: 'global', selector, rule }, getFileScope());
 }
 
 export function fontFace(
   rule: FontFaceRule | FontFaceRule[],
   debugId?: string,
-) {
+): string {
   const fontFamily = `"${cssesc(generateIdentifier(debugId), {
     quotes: 'double',
   })}"`;
@@ -124,7 +124,7 @@ export function fontFace(
 export function globalFontFace(
   fontFamily: string,
   rule: FontFaceRule | FontFaceRule[],
-) {
+): void {
   const rules = Array.isArray(rule) ? rule : [rule];
 
   for (const singleRule of rules) {
@@ -135,7 +135,7 @@ export function globalFontFace(
   }
 }
 
-export function keyframes(rule: CSSKeyframes, debugId?: string) {
+export function keyframes(rule: CSSKeyframes, debugId?: string): string {
   const name = cssesc(generateIdentifier(debugId), {
     isIdentifier: true,
   });
@@ -145,7 +145,7 @@ export function keyframes(rule: CSSKeyframes, debugId?: string) {
   return name;
 }
 
-export function globalKeyframes(name: string, rule: CSSKeyframes) {
+export function globalKeyframes(name: string, rule: CSSKeyframes): void {
   appendCss({ type: 'keyframes', name, rule }, getFileScope());
 }
 

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -639,7 +639,7 @@ class Stylesheet {
   }
 }
 
-function renderCss(v: any, indent: string = '') {
+function renderCss(v: Record<string, any>, indent: string = '') {
   const rules: Array<string> = [];
 
   for (const key of Object.keys(v)) {
@@ -679,7 +679,7 @@ export function transformCss({
   localClassNames,
   cssObjs,
   composedClassLists,
-}: TransformCSSParams) {
+}: TransformCSSParams): string[] {
   const stylesheet = new Stylesheet(localClassNames, composedClassLists);
 
   for (const root of cssObjs) {

--- a/packages/css/src/utils.ts
+++ b/packages/css/src/utils.ts
@@ -5,7 +5,7 @@ type BasicObj = { [key: string]: any };
 export function forEach<Input extends BasicObj>(
   obj: Input | undefined,
   fn: <Key extends keyof Input>(value: Input[Key], key: string) => void,
-) {
+): void {
   for (const key in obj) {
     fn(obj[key], key);
   }

--- a/packages/css/src/validateContract.ts
+++ b/packages/css/src/validateContract.ts
@@ -4,7 +4,13 @@ import pc from 'picocolors';
 
 const normaliseObject = (obj: Contract) => walkObject(obj, () => '');
 
-export function validateContract(contract: any, tokens: any) {
+export function validateContract(
+  contract: any,
+  tokens: any,
+): {
+  valid: boolean;
+  diffString: string;
+} {
   const theDiff = diff(normaliseObject(contract), normaliseObject(tokens));
   const valid = Object.keys(theDiff).length === 0;
 

--- a/packages/css/src/validateMediaQuery.ts
+++ b/packages/css/src/validateMediaQuery.ts
@@ -12,7 +12,7 @@ const createMediaQueryError = (mediaQuery: string, msg: string) =>
   `,
   );
 
-export const validateMediaQuery = (mediaQuery: string) => {
+export const validateMediaQuery = (mediaQuery: string): void => {
   // Empty queries will start with '@media '
   if (mediaQuery === '@media ') {
     throw createMediaQueryError(mediaQuery, 'Query is empty');

--- a/packages/css/src/validateSelector.ts
+++ b/packages/css/src/validateSelector.ts
@@ -7,7 +7,10 @@ function escapeRegex(string: string) {
   return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
-export const validateSelector = (selector: string, targetClassName: string) => {
+export const validateSelector = (
+  selector: string,
+  targetClassName: string,
+): void => {
   const replaceTarget = () => {
     const targetRegex = new RegExp(
       `.${escapeRegex(cssesc(targetClassName, { isIdentifier: true }))}`,

--- a/packages/css/src/viewTransition.ts
+++ b/packages/css/src/viewTransition.ts
@@ -2,5 +2,5 @@ import { generateIdentifier } from './identifier';
 
 // createViewTransition is used for locally scoping CSS view transitions
 // For now it is mostly just an alias of generateIdentifier
-export const createViewTransition = (debugId?: string) =>
+export const createViewTransition = (debugId?: string): string =>
   generateIdentifier(debugId);

--- a/packages/integration/src/addFileScope.ts
+++ b/packages/integration/src/addFileScope.ts
@@ -4,7 +4,7 @@ import dedent from 'dedent';
 
 // Inlined from @rollup/pluginutils
 // https://github.com/rollup/plugins/blob/33174f956304ab4aad4bbaba656f627c31679dc5/packages/pluginutils/src/normalizePath.ts#L5-L7
-export const normalizePath = (filename: string) =>
+export const normalizePath = (filename: string): string =>
   filename.split(win32.sep).join(posix.sep);
 
 interface AddFileScopeParams {
@@ -20,7 +20,7 @@ export function addFileScope({
   rootPath,
   packageName,
   globalAdapterIdentifier,
-}: AddFileScopeParams) {
+}: AddFileScopeParams): string {
   // Encode windows file paths as posix
   const normalizedPath = normalizePath(relative(rootPath, filePath));
 

--- a/packages/integration/src/compile.ts
+++ b/packages/integration/src/compile.ts
@@ -57,7 +57,10 @@ export async function compile({
   identOption,
   cwd = process.cwd(),
   esbuildOptions,
-}: CompileOptions) {
+}: CompileOptions): Promise<{
+  source: string;
+  watchFiles: string[];
+}> {
   const result = await esbuild({
     entryPoints: [filePath],
     metafile: true,

--- a/packages/integration/src/filters.ts
+++ b/packages/integration/src/filters.ts
@@ -1,4 +1,4 @@
 // Vite adds a "?used" to CSS files it detects, this isn't relevant for
 // .css.ts files but it's added anyway so we need to allow for it in the file match
-export const cssFileFilter = /\.css\.(js|cjs|mjs|jsx|ts|tsx)(\?used)?$/;
-export const virtualCssFileFilter = /\.vanilla\.css\?source=.*$/;
+export const cssFileFilter: RegExp = /\.css\.(js|cjs|mjs|jsx|ts|tsx)(\?used)?$/;
+export const virtualCssFileFilter: RegExp = /\.vanilla\.css\?source=.*$/;

--- a/packages/integration/src/hash.ts
+++ b/packages/integration/src/hash.ts
@@ -1,4 +1,4 @@
 import crypto from 'crypto';
 
-export const hash = (value: string) =>
+export const hash = (value: string): string =>
   crypto.createHash('md5').update(value).digest('hex');

--- a/packages/integration/src/processVanillaFile.ts
+++ b/packages/integration/src/processVanillaFile.ts
@@ -69,7 +69,7 @@ export async function processVanillaFile({
   outputCss = true,
   identOption = process.env.NODE_ENV === 'production' ? 'short' : 'debug',
   serializeVirtualCssPath,
-}: ProcessVanillaFileOptions) {
+}: ProcessVanillaFileOptions): Promise<string> {
   type Css = Parameters<Adapter['appendCss']>[0];
   type Composition = Parameters<Adapter['registerComposition']>[0];
 
@@ -336,7 +336,7 @@ export function serializeVanillaModule(
   cssImports: Array<string>,
   exports: Record<string, unknown>,
   unusedCompositionRegex: RegExp | null,
-) {
+): string {
   const functionSerializationImports = new Set<string>();
   const exportLookup = new Map(
     Object.entries(exports).map(([key, value]) => [

--- a/packages/integration/src/serialize.ts
+++ b/packages/integration/src/serialize.ts
@@ -8,7 +8,7 @@ const unzip = promisify(gunzip);
 const compressionThreshold = 1000;
 const compressionFlag = '#';
 
-export async function serializeCss(source: string) {
+export async function serializeCss(source: string): Promise<string> {
   if (source.length > compressionThreshold) {
     const compressedSource = await zip(source);
 
@@ -18,7 +18,7 @@ export async function serializeCss(source: string) {
   return Buffer.from(source, 'utf-8').toString('base64');
 }
 
-export async function deserializeCss(source: string) {
+export async function deserializeCss(source: string): Promise<string> {
   if (source.indexOf(compressionFlag) > -1) {
     const decompressedSource = await unzip(
       Buffer.from(source.replace(compressionFlag, ''), 'base64'),

--- a/packages/integration/src/virtualFile.ts
+++ b/packages/integration/src/virtualFile.ts
@@ -1,6 +1,9 @@
 import { deserializeCss } from './serialize';
 
-export async function getSourceFromVirtualCssFile(id: string) {
+export async function getSourceFromVirtualCssFile(id: string): Promise<{
+  fileName: string;
+  source: string;
+}> {
   const match = id.match(/^(?<fileName>.*)\?source=(?<source>.*)$/);
 
   if (!match || !match.groups) {

--- a/packages/parcel-transformer/src/index.ts
+++ b/packages/parcel-transformer/src/index.ts
@@ -1,7 +1,7 @@
 import { Transformer } from '@parcel/plugin';
 import { compile, processVanillaFile } from '@vanilla-extract/integration';
 
-export default new Transformer({
+const vanillaExtractParcelTransformer: Transformer<unknown> = new Transformer({
   async transform({ asset, options }) {
     const identOption = options.mode === 'development' ? 'debug' : 'short';
     const { source, watchFiles } = await compile({
@@ -50,3 +50,5 @@ export default new Transformer({
     return [asset, ...css];
   },
 });
+
+export default vanillaExtractParcelTransformer;

--- a/packages/private/src/get.ts
+++ b/packages/private/src/get.ts
@@ -1,4 +1,4 @@
-export function get(obj: any, path: Array<string>) {
+export function get(obj: any, path: Array<string>): any {
   let result = obj;
 
   for (const key of path) {

--- a/packages/private/src/getVarName.ts
+++ b/packages/private/src/getVarName.ts
@@ -1,4 +1,4 @@
-export function getVarName(variable: string) {
+export function getVarName(variable: string): string {
   const matches = variable.match(/^var\((.*)\)$/);
 
   if (matches) {

--- a/packages/sprinkles/src/createRuntimeSprinkles.ts
+++ b/packages/sprinkles/src/createRuntimeSprinkles.ts
@@ -12,5 +12,7 @@ export const createSprinkles = <
   ...args: Args
 ): SprinklesFn<Args> => internalCreateSprinkles(composeStyles)(...args);
 
-/** @deprecated - Use `createSprinkles` */
-export const createAtomsFn = createSprinkles;
+export {
+  /** @deprecated - Use `createSprinkles` */
+  createSprinkles as createAtomsFn,
+};

--- a/packages/sprinkles/src/index.ts
+++ b/packages/sprinkles/src/index.ts
@@ -374,8 +374,9 @@ export function createSprinkles<
   });
 }
 
-/** @deprecated - Use `defineProperties` */
-export const createAtomicStyles = defineProperties;
-
-/** @deprecated - Use `createSprinkles` */
-export const createAtomsFn = createSprinkles;
+export {
+  /** @deprecated - Use `defineProperties` */
+  defineProperties as createAtomicStyles,
+  /** @deprecated - Use `createSprinkles` */
+  createSprinkles as createAtomsFn,
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -19,7 +19,7 @@ const multiply = (...operands: Array<Operand>) =>
 const divide = (...operands: Array<Operand>) =>
   `calc(${toExpression('/', ...operands)})`;
 
-const negate = (x: Operand) => multiply(x, -1);
+const negate = (x: Operand): string => multiply(x, -1);
 
 type CalcChain = {
   add: (...operands: Array<Operand>) => CalcChain;

--- a/packages/webpack-plugin/src/compiler.ts
+++ b/packages/webpack-plugin/src/compiler.ts
@@ -20,13 +20,16 @@ export class ChildCompiler {
     this.externals = externals;
   }
 
-  isChildCompiler(name: string | undefined) {
+  isChildCompiler(name: string | undefined): boolean {
     return (
       typeof name === 'string' && name.startsWith('vanilla-extract-compiler')
     );
   }
 
-  async getCompiledSource(loader: LoaderContext) {
+  async getCompiledSource(loader: LoaderContext): Promise<{
+    source: string;
+    dependencies: string[];
+  }> {
     const { source, fileDependencies, contextDependencies } =
       await compileVanillaSource(loader, this.externals);
 
@@ -60,7 +63,7 @@ function getRootCompilation(loader: LoaderContext) {
 // https://github.com/webpack/webpack/blob/87660921808566ef3b8796f8df61bd79fc026108/lib/TemplatedPathPlugin.js#L19
 const templateStringRegexp = /\[([\w:]+)\]/g;
 
-export const escapeWebpackTemplateString = (s: string) =>
+export const escapeWebpackTemplateString = (s: string): string =>
   s.replaceAll(templateStringRegexp, '[\\$1\\]');
 
 function compileVanillaSource(

--- a/packages/webpack-plugin/src/index.ts
+++ b/packages/webpack-plugin/src/index.ts
@@ -2,7 +2,7 @@ import type { Compiler } from 'webpack';
 import { AbstractVanillaExtractPlugin } from './plugin';
 
 export class VanillaExtractPlugin extends AbstractVanillaExtractPlugin {
-  apply(compiler: Compiler) {
+  apply(compiler: Compiler): void {
     this.inject(compiler, 'virtualFileLoader');
   }
 }

--- a/packages/webpack-plugin/src/loader.ts
+++ b/packages/webpack-plugin/src/loader.ts
@@ -46,7 +46,7 @@ const defaultIdentifierOption = (
 ): IdentifierOption =>
   identifiers ?? (mode === 'production' ? 'short' : 'debug');
 
-export default function (this: LoaderContext, source: string) {
+export default function (this: LoaderContext, source: string): void {
   const { identifiers } = loaderUtils.getOptions(this) as InternalLoaderOptions;
 
   const { name } = getPackageInfo(this.rootContext);
@@ -68,7 +68,7 @@ export default function (this: LoaderContext, source: string) {
     });
 }
 
-export function pitch(this: LoaderContext) {
+export function pitch(this: LoaderContext): void {
   const { childCompiler, outputCss, identifiers, virtualLoader } =
     loaderUtils.getOptions(this) as InternalLoaderOptions;
 

--- a/packages/webpack-plugin/src/logger.ts
+++ b/packages/webpack-plugin/src/logger.ts
@@ -1,9 +1,9 @@
 import createDebug from 'debug';
 import pc from 'picocolors';
 
-export const formatResourcePath = (i: string) =>
+export const formatResourcePath = (i: string): string =>
   pc.blue(`"${i.replace(/.*\//, '')}"`);
 
 createDebug.formatters.r = (r: string) => formatResourcePath(r);
 
-export const debug = createDebug;
+export const debug: typeof createDebug = createDebug;

--- a/packages/webpack-plugin/src/next.ts
+++ b/packages/webpack-plugin/src/next.ts
@@ -10,9 +10,9 @@ const virtualNextFileLoader = require.resolve(
 );
 
 export class VanillaExtractPlugin extends AbstractVanillaExtractPlugin {
-  static loader = virtualNextFileLoader;
+  static loader: string = virtualNextFileLoader;
 
-  apply(compiler: Compiler) {
+  apply(compiler: Compiler): void {
     this.inject(compiler, 'virtualNextFileLoader');
   }
 }

--- a/packages/webpack-plugin/src/plugin.ts
+++ b/packages/webpack-plugin/src/plugin.ts
@@ -88,7 +88,7 @@ export abstract class AbstractVanillaExtractPlugin {
   protected inject(
     compiler: Compiler,
     virtualLoader: 'virtualFileLoader' | 'virtualNextFileLoader',
-  ) {
+  ): void {
     const compat = createCompat(
       Boolean(compiler.webpack && compiler.webpack.version),
     );

--- a/packages/webpack-plugin/src/virtualFileLoader.ts
+++ b/packages/webpack-plugin/src/virtualFileLoader.ts
@@ -2,7 +2,7 @@ import { deserializeCss } from '@vanilla-extract/integration';
 // @ts-expect-error
 import { getOptions } from 'loader-utils';
 
-export default function (this: any) {
+export default function (this: any): void {
   const { source } = getOptions(this);
   const callback = this.async();
 

--- a/packages/webpack-plugin/src/virtualNextFileLoader.ts
+++ b/packages/webpack-plugin/src/virtualNextFileLoader.ts
@@ -1,6 +1,6 @@
 import { deserializeCss } from '@vanilla-extract/integration';
 
-export default function (this: any) {
+export default function (this: any): void {
   const callback = this.async();
   const resourceQuery = this.resourceQuery.slice(1);
 


### PR DESCRIPTION
> [!NOTE]
> This PR doesn't actually configure `isolatedDeclarations`

[`isolatedDeclarations`](https://www.typescriptlang.org/tsconfig/#isolatedDeclarations) helps tooling generate declaration files _much_ faster. Practically this means public API must explicitly define return types there's no need to infer types with the TypeScript compiler.

The effect of this is _much_ faster bundling. On a branch I have that migrates the repo to use `tsdown` for bundling, without `isoldatedDeclarations`, a full build takes ~25s. _With_ `isolatedDeclarations`, that drops to ~2s.

There's still a tricky type annotation that's required to full enable `isolatedDeclarations` in the repo, and I want to refactor our tsconfig setup to use project references too.