### PR TITLE
Set `expandDirectories: false` when using `tinyglobby` to more accurately reflect `fast-glob` behaviour

### DIFF
--- a/scripts/build-dts.ts
+++ b/scripts/build-dts.ts
@@ -94,6 +94,7 @@ async function removePreconstructDeclarations(
 const packages = await glob('packages/*', {
   onlyDirectories: true,
   absolute: true,
+  expandDirectories: false,
 });
 
 const entryPaths: [string, string][] = [];

--- a/scripts/copy-next-plugin.ts
+++ b/scripts/copy-next-plugin.ts
@@ -17,6 +17,7 @@ if (!existsSync(nextPluginDistDir)) {
 const nextFixtureDirs = await glob('fixtures/next-*', {
   onlyDirectories: true,
   absolute: true,
+  expandDirectories: false,
 });
 
 if (nextFixtureDirs.length === 0) {

--- a/scripts/copy-readme-to-packages.ts
+++ b/scripts/copy-readme-to-packages.ts
@@ -7,6 +7,7 @@ const packages = await glob('packages/*', {
   onlyDirectories: true,
   absolute: true,
   ignore: ['packages/sprinkles', 'packages/integration', 'packages/compiler'],
+  expandDirectories: false,
 });
 
 for (const packageDir of packages) {


### PR DESCRIPTION
As per [recommendation](https://github.com/SuperchupuDev/tinyglobby/issues/127#issuecomment-2957770469) from the `tinyglobby` maintainer.