### PR TITLE
`vite`: Don't watch files or invalidate VE modules during SSR

### DIFF
--- a/.changeset/weak-boats-walk.md
+++ b/.changeset/weak-boats-walk.md
@@ -1,0 +1,7 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Don't watch files or invalidate VE modules during SSR
+
+Fixes a bug where a dependent of a Vanilla Extract module could be evaulated multiple times during `ssrLoadModule`, potentially causing bugs with singleton variables such as React context.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -183,7 +183,7 @@ export function vanillaExtractPlugin({
     closeWatcher() {
       return compiler?.close();
     },
-    async transform(code, id) {
+    async transform(code, id, options = {}) {
       const [validId] = id.split('?');
 
       if (!cssFileFilter.test(validId)) {
@@ -214,8 +214,8 @@ export function vanillaExtractPlugin({
           map: { mappings: '' },
         };
 
-        // We don't need to watch files in build mode
-        if (isBuild) {
+        // We don't need to watch files or invalidate modules in build mode or during SSR
+        if (isBuild || options.ssr) {
           return result;
         }
 


### PR DESCRIPTION
AFAICT, there's no good reason to watch files or invalidate modules during SSR. This was causing a bug in our SSG implementation that uses Vanilla Extract.

## Explanation

During `ssrLoadModule`, if 2 different modules import the same file, that file should ideally only be evaluated by Vite once. However we were observing the same file being evaluated twice. This file happened to contain a React context provider and consuming hook, so when the hook (imported in module X) tried to fetch the context configured on the provider (imported in module Y), they ended up referring to different context singletons.

It turns out that between these 2 evaluations of the same module, the module was being invalidated by the Vanilla Extract vite plugin. The invalidation wasn't directly being performed by the plugin, but rather by Vite as it invalidates importers up the dependency tree.

This invalidation behaviour is necessary for HMR, but I don't think it should be performed during `ssrLoadModule`, hence this fix.