### PR TITLE
createSprinkles.ts

### DIFF
--- a/packagespackages/sprinkles/src/createSprinkles.ts
+++ b/packagespackages/sprinkles/src/createSprinkles.ts
@@ -1,0 +1,29 @@
+import { createRuntimeFn } from './runtime/createRuntimeFn';
+import { mergeProperties } from './mergeProperties';
+import type { AtomicProperties, SprinklesFn } from './types';
+
+/**
+ * Creates a Sprinkles function from multiple property definitions.
+ * This version includes a check to prevent duplicate property names across multiple defineProperties configs.
+ */
+export function createSprinkles(
+  ...configs: Array<AtomicProperties>
+): SprinklesFn {
+  // 👇 Added logic to track duplicate property names
+  const usedProperties = new Set<string>();
+
+  for (const config of configs) {
+    for (const property of Object.keys(config.properties)) {
+      if (usedProperties.has(property)) {
+        throw new Error(
+          `Duplicate property "${property}" found in multiple defineProperties() calls. Please ensure all properties are uniquely defined.`
+        );
+      }
+      usedProperties.add(property);
+    }
+  }
+
+  const merged = mergeProperties(...configs);
+
+  return createRuntimeFn(merged);
+}


### PR DESCRIPTION
This pull request fixes [#590](https://github.com/vanilla-extract-css/vanilla-extract/issues/590) by adding a check in the createSprinkles function to detect and throw an error when the same property is defined in multiple defineProperties() configs.

Currently, passing duplicate properties (like "margin") from multiple configs causes an unhandled error. This PR ensures the error is:

Caught early

Clearly explained to the user

Prevents unexpected runtime behavior

✅ Changes Made
Added a Set to track used property names

Throw an explicit error on duplicates in createSprinkles.ts

Added a unit test in createSprinkles.test.ts to verify this behavior

🔗 Issue
Closes #590

