### PR TITLE
fix: include content in css sourcemap when extracting

### DIFF
--- a/.changeset/breezy-poets-matter.md
+++ b/.changeset/breezy-poets-matter.md
@@ -2,4 +2,4 @@
 '@vanilla-extract/rollup-plugin': patch
 ---
 
-include content in css sourcemap when extracting
+Include content in CSS sourcemap when bundling with the `extract` option

--- a/.changeset/breezy-poets-matter.md
+++ b/.changeset/breezy-poets-matter.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/rollup-plugin': patch
+---
+
+include content in css sourcemap when extracting

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -174,7 +174,9 @@ export function vanillaExtractPlugin({
           type: 'asset',
           name: sourcemapName,
           originalFileName: sourcemapName,
-          source: bundle.generateMap({ file: name }).toString(),
+          source: bundle
+            .generateMap({ file: name, includeContent: true })
+            .toString(),
         });
       }
     },


### PR DESCRIPTION
Hi 👋 

Without source map contents included [(which is the default behavior of rollup sourcemaps)](https://rollupjs.org/configuration-options/#output-sourcemapexcludesources) it makes them less useful. 

For example if you explore [the `app.css` and `app.css.map`](https://github.com/user-attachments/files/21537058/before.zip) for the `fixtures/react-library-example` workspace on [https://evanw.github.io/source-map-visualization] the mappings lead to empty files:
<img width="1212" height="1022" alt="image" src="https://github.com/user-attachments/assets/d545af6f-014e-41b6-8958-c56b419b8d75" />

[With this PR the mappings now preserve the CSS that were initially omitted](https://github.com/user-attachments/files/21537218/after.zip):

<img width="1218" height="1024" alt="image" src="https://github.com/user-attachments/assets/4db7ce19-719a-4603-a240-a964f13ec145" />

Richer sourcemaps are especially useful when vanilla extract is the first step, and later on `lightningcss`, `cssnano` or `postcss` is operating on the extracted CSS asset. In those scenarios it's helpful to know what the CSS looked like before it was optimized and possibly deduped 😌 

Thanks so much for #1604 and #1616 btw. At Sanity we've decided to move away entirely from `styled-components`; `vanilla-extract` is shaping up to become its replacement. Since our tooling is leaning heavily on `rollup`, with the long term goal of moving to `rolldown`, these recent improvements were helpful and appreciated ❤ 