### PR TITLE
fix: support deno packages

### DIFF
--- a/.changeset/wicked-dragons-melt.md
+++ b/.changeset/wicked-dragons-melt.md
@@ -1,0 +1,7 @@
+---
+'@vanilla-extract/integration': patch
+---
+
+Support Deno projects without a `package.json` file.
+
+When Deno is detected, we'll first check for `deno.json` or `deno.jsonc` before falling back to `package.json`.

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -24,6 +24,7 @@
     "eval": "0.1.8",
     "find-up": "^5.0.0",
     "javascript-stringify": "^2.0.1",
+    "json5": "^2.2.3",
     "mlly": "^1.4.2"
   },
   "devDependencies": {

--- a/packages/integration/src/packageInfo.ts
+++ b/packages/integration/src/packageInfo.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-
+import json5 from 'json5';
+import fs from 'node:fs';
 import findUp from 'find-up';
 
 export interface PackageInfo {
@@ -8,7 +9,7 @@ export interface PackageInfo {
   dirname: string;
 }
 
-function getClosestPackageInfo(directory: string) {
+function getClosestPackageInfo(directory: string): PackageInfo | undefined {
   const packageJsonPath = findUp.sync('package.json', {
     cwd: directory,
   });
@@ -24,6 +25,23 @@ function getClosestPackageInfo(directory: string) {
   }
 }
 
+function getClosestDenoJson(directory: string): PackageInfo | undefined {
+  const denoJsonPath = findUp.sync(['deno.json', 'deno.jsonc'], {
+    cwd: directory,
+  });
+
+  if (denoJsonPath) {
+    const { name } = json5.parse(fs.readFileSync(denoJsonPath, 'utf-8'));
+
+    return {
+      name,
+      path: denoJsonPath,
+      dirname: path.dirname(denoJsonPath),
+    };
+  }
+}
+
+const isDeno = typeof process.versions.deno === 'string';
 const packageInfoCache = new Map<string, PackageInfo>();
 
 export function getPackageInfo(cwd?: string | null): PackageInfo {
@@ -34,15 +52,34 @@ export function getPackageInfo(cwd?: string | null): PackageInfo {
     return cachedValue;
   }
 
-  let packageInfo = getClosestPackageInfo(resolvedCwd);
+  let packageInfo: PackageInfo | undefined;
 
-  while (packageInfo && !packageInfo.name) {
-    packageInfo = getClosestPackageInfo(
-      path.resolve(packageInfo.dirname, '..'),
-    );
+  // Deno projects don't necessarily have a package.json
+  if (isDeno) {
+    packageInfo = getClosestDenoJson(resolvedCwd);
+
+    // No need to look further as nested deno.json files is not supported
+    // in Deno without being a workspace member. If they are a workspace
+    // member, they are expected to have the `name` field anyway.
+  }
+
+  if (!packageInfo) {
+    packageInfo = getClosestPackageInfo(resolvedCwd);
+
+    while (packageInfo && !packageInfo.name) {
+      packageInfo = getClosestPackageInfo(
+        path.resolve(packageInfo.dirname, '..'),
+      );
+    }
   }
 
   if (!packageInfo || !packageInfo.name) {
+    if (isDeno) {
+      throw new Error(
+        `Couldn't find parent deno.json, deno.jsonc or package.json with a name field from '${resolvedCwd}'`,
+      );
+    }
+
     throw new Error(
       `Couldn't find parent package.json with a name field from '${resolvedCwd}'`,
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -526,6 +526,9 @@ importers:
       javascript-stringify:
         specifier: ^2.0.1
         version: 2.1.0
+      json5:
+        specifier: ^2.2.3
+        version: 2.2.3
       mlly:
         specifier: ^1.4.2
         version: 1.4.2


### PR DESCRIPTION
This PR adds support for Deno projects which don't necessarily have a `package.json`. When a Deno environment is detect it will check for `deno.json` or `deno.jsonc` first before falling back to `package.json`.

Fixes https://github.com/denoland/fresh/issues/3392