### PR TITLE
Add bun as a package manager option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,6 +40,7 @@ body:
         - npm
         - yarn
         - pnpm
+        - bun
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
I recently submitted [a new issue](https://github.com/vanilla-extract-css/vanilla-extract/issues/1636) relating to the bun runtime which has its own package manager. There was no option for bun in the template.

Template tested on my fork:

<img width="440" height="343" alt="2025-10-04T22:26:39-04:00" src="https://github.com/user-attachments/assets/43a7e96e-ee7b-4072-be3b-95150905ae96" />
