### PR TITLE
[compiler] Inherit vite server watch options

### DIFF
--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -110,7 +110,7 @@ const createViteServer = async ({
     root,
     server: {
       hmr: false,
-      watch: enableFileWatcher ? undefined : null,
+      watch: enableFileWatcher ? viteConfig.server?.watch : null,
     },
     logLevel: 'silent',
     optimizeDeps: {


### PR DESCRIPTION
This fixes #1636 by inheriting the user's `server.watch` configuration, notably ignored watch patterns.

Does this break other use cases? No idea. Scrutiny required.