### PR TITLE
feat: Skip already compiled code in vite plugin

### DIFF
--- a/packages/integration/src/filters.ts
+++ b/packages/integration/src/filters.ts
@@ -1,4 +1,30 @@
-// Vite adds a "?used" to CSS files it detects, this isn't relevant for
-// .css.ts files but it's added anyway so we need to allow for it in the file match
 export const cssFileFilter: RegExp = /\.css\.(js|cjs|mjs|jsx|ts|tsx)(\?used)?$/;
 export const virtualCssFileFilter: RegExp = /\.vanilla\.css\?source=.*$/;
+
+const COMPILED_CSS_PATTERN = /\.vanilla(-[a-zA-Z0-9_-]+)?\.css['"]/;
+const VANILLA_EXTRACT_FAMILLY = /@vanilla-extract/;
+
+interface IsSourceVanillaFileContext {
+  code: string;
+}
+
+export function isSourceVanillaFile(
+  filePath: string,
+  context: IsSourceVanillaFileContext,
+): boolean {
+  if (!cssFileFilter.test(filePath)) {
+    return false;
+  }
+
+  if (context.code) {
+    if (COMPILED_CSS_PATTERN.test(context.code)) {
+      return false;
+    }
+
+    if (!VANILLA_EXTRACT_FAMILLY.test(context.code)) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/integration/src/index.ts
+++ b/packages/integration/src/index.ts
@@ -15,5 +15,9 @@ export { hash } from './hash';
 export { addFileScope, normalizePath } from './addFileScope';
 export { serializeCss, deserializeCss } from './serialize';
 export { transformSync, transform } from './transform';
-export { cssFileFilter, virtualCssFileFilter } from './filters';
+export {
+  cssFileFilter,
+  virtualCssFileFilter,
+  isSourceVanillaFile,
+} from './filters';
 export type { IdentifierOption } from './types';

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -16,6 +16,7 @@ import {
   getPackageInfo,
   transform,
   normalizePath,
+  isSourceVanillaFile,
 } from '@vanilla-extract/integration';
 
 const PLUGIN_NAMESPACE = 'vite-plugin-vanilla-extract';
@@ -213,7 +214,11 @@ export function vanillaExtractPlugin({
       async transform(code, id, options = {}) {
         const [validId] = id.split('?');
 
-        if (!cssFileFilter.test(validId)) {
+        if (
+          !isSourceVanillaFile(validId, {
+            code,
+          })
+        ) {
           return null;
         }
 
@@ -289,9 +294,12 @@ export function vanillaExtractPlugin({
 
         const absoluteId = getAbsoluteId(validId);
 
-        const { css } = compiler.getCssForFile(virtualIdToFileId(absoluteId));
-
-        return css;
+        try {
+          const { css } = compiler.getCssForFile(virtualIdToFileId(absoluteId));
+          return css;
+        } catch {
+          return null; // pass through
+        }
       },
     },
   ];


### PR DESCRIPTION
## Problem

The Vite plugin currently processes all `.css.{ts,js,tsx,jsx}` files based solely on file extension, without distinguishing between source files and already-compiled output.

This causes issues in monorepo setups where:

1. Package A (e.g., design system) builds its vanilla-extract files
2. Package B (e.g., application) imports from Package A
3. Vite plugin tries to reprocess the already-compiled files from Package A's
4. This fails because the VE compiler cannot process already-compiled files

## Solution

Add a simple check in the `transform` hook to detect already-compiled vanilla-extract files by looking for the signature pattern: `import` statements containing `.vanilla.css`

**Key pattern:**
```js
// Compiled file (should skip)
import './button.css.ts.vanilla.css';

or 

import './button.css.ts.vanilla-somehash.css'
```


## Why Not Other Approaches?

### Path-Based Filtering

Q: Since the Vite plugin has access to A's file path during build, why not filter based on path?

A: Path-based filtering would block use-cases where someone intentionally want to transpile Package A's source code during Package B's build (e.g., in monorepo development mode with direct source imports).

Content-based detection only skips files that are already compiled, preserving flexibility for different monorepo workflows.

## Renaming Output Files (as suggested in #1568)

**Q:** Why not use rollup's `assetFileNames` option to rename compiled files (e.g., `.styles.mjs` instead of `.css.mjs`) to avoid the `.css.{js,ts}` pattern matching?

**A:** While this workaround can avoid the immediate issue, it doesn't address the root cause: **the plugin attempting to reprocess already-compiled files**.

This PR aims to fix the fundamental problem rather than working around it.

The file renaming approach remains valid as a temporary workaround, but this fix ensures the plugin correctly handles all scenarios by default.