### PR TITLE
Add container type `scroll-state` to type definitions

### DIFF
--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -12,7 +12,7 @@ export type Resolve<T> = {
 // https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries
 interface ContainerProperties {
   container?: string;
-  containerType?: 'size' | 'inline-size' | (string & {});
+  containerType?: 'size' | 'inline-size' | 'scroll-state' | (string & {});
   containerName?: string;
 }
 


### PR DESCRIPTION
Hello, there is a new container type for scroll state queries that is currently missing in the custom type definitions. More info: https://developer.mozilla.org/en-US/docs/Web/CSS/container-type

Cheers