### PR TITLE
Fix styled system link in sprinkles documentation

### DIFF
--- a/site/docs/packages/sprinkles.md
+++ b/site/docs/packages/sprinkles.md
@@ -795,7 +795,7 @@ const e: ResponsiveAlign = { desktop: 'center' };
 ```
 
 [tailwind]: https://tailwindcss.com
-[styled system]: https://styled-system.com
+[styled system]: https://github.com/styled-system/styled-system
 [support container queries]: https://caniuse.com/css-container-queries
 [container query syntax]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries
 [layer]: https://developer.mozilla.org/en-US/docs/Web/CSS/@layer


### PR DESCRIPTION
Updated the styled system link to point to its GitHub repository.

The styled system domain has been taken over by a casino advertisement.

<img width="3813" height="2034" alt="image" src="https://github.com/user-attachments/assets/c46d84f5-d58b-49e7-b064-8b729ac6e14a" />
