### PR TITLE
Merge Vite server config with existing settings

### DIFF
--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -109,6 +109,7 @@ const createViteServer = async ({
     configFile: false,
     root,
     server: {
+      ...(viteConfig.server ?? {}),
       hmr: false,
       watch: enableFileWatcher ? undefined : null,
     },


### PR DESCRIPTION
Trying to launch a vite server with `middlewareMode` doesn't get propagated to the compiler vite server.

Without middlewareMode, the vite server directly handles `SIGTERM` and immediately exits the process. This breaks the parent server behavior (such as Fastify graceful shutdown)