### PR TITLE
set up pkg.pr.new to install unreleased versions from github

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,30 @@
+name: Prerelease
+
+on: [push, pull_request]
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up PNPM
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm prepare-release
+
+      - name: Publish preview
+        run: pnpm dlx pkg-pr-new publish './packages/*'


### PR DESCRIPTION
when working on #1639 I found it very difficult to test out versions of the plugin in real projects

solutions I explored:
- you could clone the repository and install via a link, but this only works locally and can't really be committed.
- pnpm will let you install from github, but it doesn't support rewriting the workspace protocol on the fly
- `gitpkg` also lets you install from github, but similarly don't support rewriting the workspace protocol
- in theory, you *could* add the entire vanilla extract repository as a submodule, but that's incredibly difficult to manage
- you can clone and build using `gitpick` but this can cause issues across different computers if you want to actually deploy anything with the prerelease version, and it's also not very stable for development. it also breaks resolving for packages that assume they are installed in the working directory.

https://pkg.pr.new/ solves all of these by building the package normally in github actions.

It generates links you can use to install any version that was previously built:
```json
"pnpm": {
  "overrides": {
    "@vanilla-extract/compiler": "https://pkg.pr.new/RJWadley/vanilla-extract/@vanilla-extract/compiler@c1d4a88",
    "@vanilla-extract/css": "https://pkg.pr.new/RJWadley/vanilla-extract/@vanilla-extract/css@c1d4a88",
    "@vanilla-extract/integration": "https://pkg.pr.new/RJWadley/vanilla-extract/@vanilla-extract/integration@c1d4a88",
    "@vanilla-extract/next-plugin": "https://pkg.pr.new/RJWadley/vanilla-extract/@vanilla-extract/next-plugin@c1d4a88",
    "@vanilla-extract/turbopack-plugin": "https://pkg.pr.new/RJWadley/vanilla-extract/@vanilla-extract/turbopack-plugin@c1d4a88",
    "@vanilla-extract/webpack-plugin": "https://pkg.pr.new/RJWadley/vanilla-extract/@vanilla-extract/webpack-plugin@c1d4a88"
  },
}
```


> [!NOTE]  
> A maintainer will need to install the [GitHub application](https://github.com/apps/pkg-pr-new) on this repository
