### PR TITLE
Conditionally run snapshot release, actually make OIDC publishing work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     name: Publish & Deploy
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     env:
       CI: true
     steps:
@@ -44,6 +46,8 @@ jobs:
     name: Publish snapshot version
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     env:
       CI: true
     steps:


### PR DESCRIPTION
Hotfix for #1669: forgot to add a condition to the snapshot release job and the thing that actually makes OIDC publishing work.