### PR TITLE
docs(rollup): Replace table with list

### DIFF
--- a/site/docs/integrations/rollup.md
+++ b/site/docs/integrations/rollup.md
@@ -112,7 +112,5 @@ vanillaExtractPlugin({
 });
 ```
 
-| Option        | Type      | Default        | Description                                                                                                                       |
-| :------------ | :-------- | :------------- | :-------------------------------------------------------------------------------------------------------------------------------- |
-| **name**      | `string`  | `'bundle.css'` | Name the bundled CSS. [output.assetFilenames](https://rollupjs.org/configuration-options/#output-assetfilenames) can affect this. |
-| **sourcemap** | `boolean` | `false`        | Set to `true` to also output `.css.map` file.                                                                                     |
+- `name`: Default `'bundle.css'`. Name the bundled CSS. [`output.assetFilenames`](https://rollupjs.org/configuration-options/#output-assetfilenames) can affect this.
+- `sourcemap`: Default `false`. Set to `true` to also output `.css.map` file.


### PR DESCRIPTION
We don't have any styles for rendering tables, so currently the table at the bottom of the rollup docs looks like a mess:

<img width="997" height="372" alt="image" src="https://github.com/user-attachments/assets/1deffd1e-c332-40c2-91b4-7b3647cd6fbd" />

This PR replaces the table with a list, at least for now until proper table styles are written:

<img width="1339" height="262" alt="image" src="https://github.com/user-attachments/assets/059f4fd5-a34c-4c60-9e56-f0704f27f9d6" />