### PR TITLE
Update code font to use MonoLisa

### DIFF
--- a/.changeset/blue-turkeys-cough.md
+++ b/.changeset/blue-turkeys-cough.md
@@ -1,0 +1,5 @@
+---
+"site": patch
+---
+
+Update code font to use `MonoLisa` instead of `ml` to align with MonoLisa API changes

--- a/site/src/themes.css.ts
+++ b/site/src/themes.css.ts
@@ -161,7 +161,7 @@ export const vars = createGlobalTheme(':root', {
     heading:
       '"DM Sans", "Helvetica Neue", HelveticaNeue, Helvetica, sans-serif',
     body: '-apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", HelveticaNeue, Helvetica, Arial, sans-serif',
-    code: 'ml, "Roboto Mono", Menlo, monospace',
+    code: 'MonoLisa, "Roboto Mono", Menlo, monospace',
   },
   grid: px(grid),
   spacing: {


### PR DESCRIPTION
This should fix code blocks font display. I did required adjustments on the API / backend to serve it correctly (allowed the domain). In the future, I think it would be better to switch to static woff files. I can do a follow up PR for that.