### PR TITLE
Vendor `cssesc` dependency

### DIFF
--- a/.changeset/eight-tigers-poke.md
+++ b/.changeset/eight-tigers-poke.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': patch
+---
+
+Replace `cssesc` dependency with vendored version

--- a/.changeset/hot-geese-end.md
+++ b/.changeset/hot-geese-end.md
@@ -1,0 +1,7 @@
+---
+'@vanilla-extract/compiler': minor
+---
+
+Don't mark `cssesc` dependency as `external`
+
+`cssesc` has been vendored into the `@vanilla-extract/css` package due to its lack of ESM support

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -130,11 +130,6 @@ const createViteServer = async ({
     },
     ssr: {
       noExternal: true,
-      // `cssesc` is CJS-only, so we need to mark it as external as Vite's transform pipeline
-      // can't handle CJS during dev-time.
-      // See https://github.com/withastro/astro/blob/0879cc2ce7e15a2e7330c68d6667d9a2edea52ab/packages/astro/src/core/create-vite.ts#L86
-      // and https://github.com/withastro/astro/issues/11395
-      external: ['cssesc'],
     },
     plugins: [
       {

--- a/packages/css/package.json
+++ b/packages/css/package.json
@@ -121,7 +121,6 @@
     "@emotion/hash": "^0.9.0",
     "@vanilla-extract/private": "workspace:^",
     "css-what": "^6.1.0",
-    "cssesc": "^3.0.0",
     "csstype": "^3.2.3",
     "dedent": "^1.5.3",
     "deep-object-diff": "^1.1.9",
@@ -130,8 +129,5 @@
     "media-query-parser": "^2.0.2",
     "modern-ahocorasick": "^1.0.0",
     "picocolors": "^1.0.0"
-  },
-  "devDependencies": {
-    "@types/cssesc": "^3.0.0"
   }
 }

--- a/packages/css/src/cssesc.ts
+++ b/packages/css/src/cssesc.ts
@@ -1,0 +1,104 @@
+/* eslint-disable regexp/control-character-escape */
+/* eslint-disable no-control-regex */
+/* eslint-disable regexp/no-optional-assertion */
+/* eslint-disable regexp/no-useless-escape */
+/* eslint-disable regexp/no-obscure-range */
+// ESM vendored version of cssesc: https://github.com/mathiasbynens/cssesc/blob/cb894eb42f27c8d3cd793f16afe35b3ab38000a1/cssesc.js
+// See https://github.com/vanilla-extract-css/vanilla-extract/pull/1710
+
+const regexAnySingleEscape = /[ -,\.\/:-@\[-\^`\{-~]/;
+const regexSingleEscape = /[ -,\.\/:-@\[\]\^`\{-~]/;
+const regexExcessiveSpaces =
+  /(^|\\+)?(\\[A-F0-9]{1,6})\x20(?![a-fA-F0-9\x20])/g;
+
+interface Options {
+  escapeEverything: boolean;
+  isIdentifier: boolean;
+  quotes: 'single' | 'double';
+  wrap: boolean;
+}
+
+const DEFAULT_OPTIONS: Options = {
+  escapeEverything: false,
+  isIdentifier: false,
+  quotes: 'single',
+  wrap: false,
+};
+
+export function cssesc(string: string, options: Partial<Options> = {}) {
+  options = { ...DEFAULT_OPTIONS, ...options };
+  const quote = options.quotes === 'double' ? '"' : "'";
+  const { isIdentifier } = options;
+
+  const firstChar = string.charAt(0);
+  let output = '';
+  let counter = 0;
+  const length = string.length;
+  while (counter < length) {
+    const character = string.charAt(counter++);
+    let codePoint = character.charCodeAt(0);
+    let value: string;
+    // If it’s not a printable ASCII character…
+    if (codePoint < 0x20 || codePoint > 0x7e) {
+      if (codePoint >= 0xd800 && codePoint <= 0xdbff && counter < length) {
+        // It’s a high surrogate, and there is a next character.
+        const extra = string.charCodeAt(counter++);
+        if ((extra & 0xfc00) === 0xdc00) {
+          // next character is low surrogate
+          codePoint = ((codePoint & 0x3ff) << 10) + (extra & 0x3ff) + 0x10000;
+        } else {
+          // It’s an unmatched surrogate; only append this code unit, in case
+          // the next code unit is the high surrogate of a surrogate pair.
+          counter--;
+        }
+      }
+      value = '\\' + codePoint.toString(16).toUpperCase() + ' ';
+    } else {
+      if (options.escapeEverything) {
+        if (regexAnySingleEscape.test(character)) {
+          value = '\\' + character;
+        } else {
+          value = '\\' + codePoint.toString(16).toUpperCase() + ' ';
+        }
+      } else if (/[\t\n\f\r\x0B]/.test(character)) {
+        value = '\\' + codePoint.toString(16).toUpperCase() + ' ';
+      } else if (
+        character === '\\' ||
+        (!isIdentifier &&
+          ((character === '"' && quote === character) ||
+            (character === "'" && quote === character))) ||
+        (isIdentifier && regexSingleEscape.test(character))
+      ) {
+        value = '\\' + character;
+      } else {
+        value = character;
+      }
+    }
+    output += value;
+  }
+
+  if (isIdentifier) {
+    if (/^-[-\d]/.test(output)) {
+      output = '\\-' + output.slice(1);
+    } else if (/\d/.test(firstChar)) {
+      output = '\\3' + firstChar + ' ' + output.slice(1);
+    }
+  }
+
+  // Remove spaces after `\HEX` escapes that are not followed by a hex digit,
+  // since they’re redundant. Note that this is only possible if the escape
+  // sequence isn’t preceded by an odd number of backslashes.
+  output = output.replace(regexExcessiveSpaces, function ($0, $1, $2) {
+    if ($1 && $1.length % 2) {
+      // It’s not safe to remove the space, so don’t.
+      return $0;
+    }
+    // Strip the space.
+    return ($1 || '') + $2;
+  });
+
+  if (!isIdentifier && options.wrap) {
+    return quote + output + quote;
+  }
+  return output;
+}

--- a/packages/css/src/style.ts
+++ b/packages/css/src/style.ts
@@ -1,4 +1,3 @@
-import cssesc from 'cssesc';
 import dedent from 'dedent';
 import deepmerge from 'deepmerge';
 
@@ -19,6 +18,7 @@ import {
 import { getFileScope, hasFileScope } from './fileScope';
 import { generateIdentifier } from './identifier';
 import { dedupeAndJoinClassList } from './utils';
+import { cssesc } from './cssesc';
 
 function composedStyle(rules: Array<StyleRule | ClassNames>, debugId?: string) {
   const className = generateIdentifier(debugId);

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -1,5 +1,4 @@
 import { getVarName } from '@vanilla-extract/private';
-import cssesc from 'cssesc';
 import AhoCorasick from 'modern-ahocorasick';
 
 import type {
@@ -21,6 +20,7 @@ import { validateSelector } from './validateSelector';
 import { ConditionalRuleset } from './conditionalRulesets';
 import { simplePseudos, simplePseudoLookup } from './simplePseudos';
 import { validateMediaQuery } from './validateMediaQuery';
+import { cssesc } from './cssesc';
 
 const DECLARATION = '__DECLARATION';
 

--- a/packages/css/src/validateSelector.ts
+++ b/packages/css/src/validateSelector.ts
@@ -1,6 +1,6 @@
 import { parse } from 'css-what';
-import cssesc from 'cssesc';
 import dedent from 'dedent';
+import { cssesc } from './cssesc';
 
 // https://stackoverflow.com/questions/3561493/is-there-a-regexp-escape-function-in-javascript
 function escapeRegex(string: string) {

--- a/packages/css/src/vars.ts
+++ b/packages/css/src/vars.ts
@@ -7,7 +7,6 @@ import {
   type MapLeafNodes,
   type CSSVarFunction,
 } from '@vanilla-extract/private';
-import cssesc from 'cssesc';
 
 import type { Tokens, NullableTokens, ThemeVars } from './types';
 import { validateContract } from './validateContract';
@@ -15,6 +14,7 @@ import { getFileScope } from './fileScope';
 import { generateIdentifier } from './identifier';
 import type { PropertySyntax } from './types';
 import { appendCss } from './adapter';
+import { cssesc } from './cssesc';
 
 type VarDeclaration =
   | {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,9 +408,6 @@ importers:
       css-what:
         specifier: ^6.1.0
         version: 6.1.0
-      cssesc:
-        specifier: ^3.0.0
-        version: 3.0.0
       csstype:
         specifier: ^3.2.3
         version: 3.2.3
@@ -435,10 +432,6 @@ importers:
       picocolors:
         specifier: ^1.0.0
         version: 1.1.1
-    devDependencies:
-      '@types/cssesc':
-        specifier: ^3.0.0
-        version: 3.0.0
 
   packages/dynamic:
     dependencies:
@@ -4137,9 +4130,6 @@ packages:
 
   '@types/connect@3.4.35':
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==}
-
-  '@types/cssesc@3.0.0':
-    resolution: {integrity: sha512-4mBnOrTpVKn+tYzlnMO7cwDkDa6wlQ2bBXW+79/6ahMd36GF216kxWYxgz+S4d5Ev1ByFbnQbPGxV4P5BSL8MA==}
 
   '@types/debug@4.1.7':
     resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
@@ -14588,8 +14578,6 @@ snapshots:
   '@types/connect@3.4.35':
     dependencies:
       '@types/node': 22.15.3
-
-  '@types/cssesc@3.0.0': {}
 
   '@types/debug@4.1.7':
     dependencies:


### PR DESCRIPTION
Vendoring for much the same reason astro did it in https://github.com/withastro/astro/pull/15669: lack of ESM-compatibility can result in errors, specifically in bundlers that use the VE compiler.