### PR TITLE
Update github action versions

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           token: ${{ secrets.VANILLA_EXTRACT_CI_GITHUB_TOKEN }}
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -58,7 +58,7 @@ jobs:
           token: ${{ secrets.VANILLA_EXTRACT_CI_GITHUB_TOKEN }}
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
Fixes warnings about deprecated node v20 actions. [Example](https://github.com/vanilla-extract-css/vanilla-extract/actions/runs/23679773019).