### PR TITLE
fix(vite-plugin): normalize absolute Vite ids on Windows

### DIFF
--- a/.changeset/chilly-bees-hug.md
+++ b/.changeset/chilly-bees-hug.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Normalize absolute Windows `@id/...` module ids before resolving virtual CSS files in Vite dev mode.

--- a/.changeset/chilly-bees-hug.md
+++ b/.changeset/chilly-bees-hug.md
@@ -2,4 +2,6 @@
 '@vanilla-extract/vite-plugin': patch
 ---
 
-Normalize absolute Windows `@id/...` module ids before resolving virtual CSS files in Vite dev mode.
+Fix `No CSS for file` error in Vite dev mode when virtual CSS modules are resolved through Vite's `@id/` id wrapper
+
+This was most commonly hit with workspace `.css.ts` imports in pnpm monorepos on Windows, where Vite produces ids shaped like `@id/C:/...`, but it can also occur on macOS/Linux. The plugin now unwraps these ids before resolving the virtual CSS file so they map to the correct compiler cache entry.

--- a/packages/vite-plugin/src/ids.test.ts
+++ b/packages/vite-plugin/src/ids.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAbsoluteId } from './ids';
+
+describe('getAbsoluteId', () => {
+  it('unwraps Windows absolute Vite ids', () => {
+    expect(
+      getAbsoluteId({
+        root: 'C:/Users/nit/projects/nettflater/apps/spkno',
+        filePath:
+          '@id/C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+      }),
+    ).toBe(
+      'C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+    );
+  });
+
+  it('unwraps Windows absolute Vite ids with a leading slash', () => {
+    expect(
+      getAbsoluteId({
+        root: 'C:/Users/nit/projects/nettflater/apps/spkno',
+        filePath:
+          '/@id/C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+      }),
+    ).toBe(
+      'C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+    );
+  });
+
+  it('keeps absolute monorepo paths outside the app root', () => {
+    expect(
+      getAbsoluteId({
+        root: '/Users/nit/projects/vanilla-extract/packages/vite-plugin',
+        filePath:
+          '/Users/nit/projects/vanilla-extract/packages/compiler/src/compiler.ts',
+      }),
+    ).toBe(
+      '/Users/nit/projects/vanilla-extract/packages/compiler/src/compiler.ts',
+    );
+  });
+
+  it('resolves SSR-style root-relative ids', () => {
+    expect(
+      getAbsoluteId({
+        root: '/Users/nit/projects/vanilla-extract/packages/vite-plugin',
+        filePath: '/app/styles.css.ts.vanilla.css',
+      }),
+    ).toBe(
+      '/Users/nit/projects/vanilla-extract/packages/vite-plugin/app/styles.css.ts.vanilla.css',
+    );
+  });
+});

--- a/packages/vite-plugin/src/ids.test.ts
+++ b/packages/vite-plugin/src/ids.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { getAbsoluteId } from './ids';
+
+describe('getAbsoluteId', () => {
+  it('unwraps Windows absolute Vite ids', () => {
+    expect(
+      getAbsoluteId({
+        root: 'C:/Users/nit/projects/nettflater/apps/spkno',
+        filePath:
+          '@id/C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+      }),
+    ).toBe(
+      'C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+    );
+  });
+
+  it('unwraps Windows absolute Vite ids with a leading slash', () => {
+    expect(
+      getAbsoluteId({
+        root: 'C:/Users/nit/projects/nettflater/apps/spkno',
+        filePath:
+          '/@id/C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+      }),
+    ).toBe(
+      'C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+    );
+  });
+
+  it('normalizes slash-prefixed Windows absolute ids after Vite resolution', () => {
+    expect(
+      getAbsoluteId({
+        root: '/Users/nit/projects/nettflater/apps/spkno',
+        filePath:
+          '/C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+      }),
+    ).toBe(
+      'C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+    );
+  });
+
+  it('normalizes slash-prefixed Windows absolute ids on non-C drives', () => {
+    expect(
+      getAbsoluteId({
+        root: '/Users/nit/projects/nettflater/apps/spkno',
+        filePath:
+          '/D:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+      }),
+    ).toBe(
+      'D:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+    );
+  });
+
+  it('keeps absolute monorepo paths outside the app root', () => {
+    expect(
+      getAbsoluteId({
+        root: '/Users/nit/projects/vanilla-extract/packages/vite-plugin',
+        filePath:
+          '/Users/nit/projects/vanilla-extract/packages/compiler/src/compiler.ts',
+      }),
+    ).toBe(
+      '/Users/nit/projects/vanilla-extract/packages/compiler/src/compiler.ts',
+    );
+  });
+
+  it('resolves SSR-style root-relative ids', () => {
+    expect(
+      getAbsoluteId({
+        root: '/Users/nit/projects/vanilla-extract/packages/vite-plugin',
+        filePath: '/app/styles.css.ts.vanilla.css',
+      }),
+    ).toBe(
+      '/Users/nit/projects/vanilla-extract/packages/vite-plugin/app/styles.css.ts.vanilla.css',
+    );
+  });
+});

--- a/packages/vite-plugin/src/ids.test.ts
+++ b/packages/vite-plugin/src/ids.test.ts
@@ -110,17 +110,18 @@ describe('getAbsoluteId', () => {
     ).toBe('/example-repo/apps/example-app/app/styles.css.ts.vanilla.css');
   });
 
-  it('is idempotent when applied to an already-resolved id', () => {
-    const root = 'C:/example-repo/apps/example-app';
-    const cases = [
-      '@id/C:/example-repo/packages/example-lib/src/styles.css.ts.vanilla.css',
-      '/app/styles.css.ts.vanilla.css',
-    ];
+  const cases = [
+    '@id/C:/example-repo/packages/example-lib/src/styles.css.ts.vanilla.css',
+    '/app/styles.css.ts.vanilla.css',
+  ];
 
-    for (const filePath of cases) {
+  it.each(cases)(
+    'is idempotent when applied to an already-resolved id',
+    (filePath) => {
+      const root = 'C:/example-repo/apps/example-app';
       const resolved = getAbsoluteId({ root, filePath });
 
       expect(getAbsoluteId({ root, filePath: resolved })).toBe(resolved);
-    }
-  });
+    },
+  );
 });

--- a/packages/vite-plugin/src/ids.test.ts
+++ b/packages/vite-plugin/src/ids.test.ts
@@ -6,71 +6,121 @@ describe('getAbsoluteId', () => {
   it('unwraps Windows absolute Vite ids', () => {
     expect(
       getAbsoluteId({
-        root: 'C:/Users/nit/projects/nettflater/apps/spkno',
+        root: 'C:/example-repo/apps/example-app',
         filePath:
-          '@id/C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+          '@id/C:/example-repo/packages/example-lib/src/styles.css.ts.vanilla.css',
       }),
     ).toBe(
-      'C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+      'C:/example-repo/packages/example-lib/src/styles.css.ts.vanilla.css',
     );
   });
 
   it('unwraps Windows absolute Vite ids with a leading slash', () => {
     expect(
       getAbsoluteId({
-        root: 'C:/Users/nit/projects/nettflater/apps/spkno',
+        root: 'C:/example-repo/apps/example-app',
         filePath:
-          '/@id/C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+          '/@id/C:/example-repo/packages/example-lib/src/styles.css.ts.vanilla.css',
       }),
     ).toBe(
-      'C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+      'C:/example-repo/packages/example-lib/src/styles.css.ts.vanilla.css',
     );
+  });
+
+  it('unwraps posix absolute Vite ids', () => {
+    expect(
+      getAbsoluteId({
+        root: '/example-repo/apps/example-app',
+        filePath:
+          '/@id//example-repo/packages/example-lib/src/styles.css.ts.vanilla.css',
+      }),
+    ).toBe('/example-repo/packages/example-lib/src/styles.css.ts.vanilla.css');
   });
 
   it('normalizes slash-prefixed Windows absolute ids after Vite resolution', () => {
     expect(
       getAbsoluteId({
-        root: '/Users/nit/projects/nettflater/apps/spkno',
+        root: '/example-repo/apps/example-app',
         filePath:
-          '/C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+          '/C:/example-repo/packages/example-lib/src/styles.css.ts.vanilla.css',
       }),
     ).toBe(
-      'C:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+      'C:/example-repo/packages/example-lib/src/styles.css.ts.vanilla.css',
     );
   });
 
   it('normalizes slash-prefixed Windows absolute ids on non-C drives', () => {
     expect(
       getAbsoluteId({
-        root: '/Users/nit/projects/nettflater/apps/spkno',
+        root: '/example-repo/apps/example-app',
         filePath:
-          '/D:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+          '/D:/example-repo/packages/example-lib/src/styles.css.ts.vanilla.css',
       }),
     ).toBe(
-      'D:/Users/nit/projects/nettflater/packages/shared/src/PortableText/block/block.css.ts.vanilla.css',
+      'D:/example-repo/packages/example-lib/src/styles.css.ts.vanilla.css',
     );
+  });
+
+  it('keeps plain Windows absolute paths inside the app root', () => {
+    expect(
+      getAbsoluteId({
+        root: 'C:/example-repo/apps/example-app',
+        filePath:
+          'C:/example-repo/apps/example-app/src/styles.css.ts.vanilla.css',
+      }),
+    ).toBe('C:/example-repo/apps/example-app/src/styles.css.ts.vanilla.css');
+  });
+
+  it('keeps plain posix absolute paths inside the app root', () => {
+    expect(
+      getAbsoluteId({
+        root: '/example-repo/apps/example-app',
+        filePath:
+          '/example-repo/apps/example-app/src/styles.css.ts.vanilla.css',
+      }),
+    ).toBe('/example-repo/apps/example-app/src/styles.css.ts.vanilla.css');
   });
 
   it('keeps absolute monorepo paths outside the app root', () => {
     expect(
       getAbsoluteId({
-        root: '/Users/nit/projects/vanilla-extract/packages/vite-plugin',
+        root: '/example-repo/apps/example-app',
         filePath:
-          '/Users/nit/projects/vanilla-extract/packages/compiler/src/compiler.ts',
+          '/example-repo/packages/example-lib/src/styles.css.ts.vanilla.css',
       }),
-    ).toBe(
-      '/Users/nit/projects/vanilla-extract/packages/compiler/src/compiler.ts',
-    );
+    ).toBe('/example-repo/packages/example-lib/src/styles.css.ts.vanilla.css');
+  });
+
+  it('keeps Windows monorepo paths on a different drive to the app root', () => {
+    expect(
+      getAbsoluteId({
+        root: 'C:/example-repo/apps/example-app',
+        filePath:
+          'D:/other-repo/packages/example-lib/src/styles.css.ts.vanilla.css',
+      }),
+    ).toBe('D:/other-repo/packages/example-lib/src/styles.css.ts.vanilla.css');
   });
 
   it('resolves SSR-style root-relative ids', () => {
     expect(
       getAbsoluteId({
-        root: '/Users/nit/projects/vanilla-extract/packages/vite-plugin',
+        root: '/example-repo/apps/example-app',
         filePath: '/app/styles.css.ts.vanilla.css',
       }),
-    ).toBe(
-      '/Users/nit/projects/vanilla-extract/packages/vite-plugin/app/styles.css.ts.vanilla.css',
-    );
+    ).toBe('/example-repo/apps/example-app/app/styles.css.ts.vanilla.css');
+  });
+
+  it('is idempotent when applied to an already-resolved id', () => {
+    const root = 'C:/example-repo/apps/example-app';
+    const cases = [
+      '@id/C:/example-repo/packages/example-lib/src/styles.css.ts.vanilla.css',
+      '/app/styles.css.ts.vanilla.css',
+    ];
+
+    for (const filePath of cases) {
+      const resolved = getAbsoluteId({ root, filePath });
+
+      expect(getAbsoluteId({ root, filePath: resolved })).toBe(resolved);
+    }
   });
 });

--- a/packages/vite-plugin/src/ids.ts
+++ b/packages/vite-plugin/src/ids.ts
@@ -1,0 +1,43 @@
+import path from 'path';
+
+import { normalizePath } from '@vanilla-extract/integration';
+
+const viteIdPrefix = /^\/?@id\//;
+const windowsAbsolutePathRegex =
+  /^(?:[a-zA-Z]:[/\\]|[/\\]{2}[^/\\]+[/\\][^/\\]+)/;
+
+const isWindowsAbsolutePath = (filePath: string) =>
+  windowsAbsolutePathRegex.test(filePath);
+
+const unwrapAbsoluteViteId = (id: string) => {
+  const unwrappedId = id.replace(viteIdPrefix, '');
+
+  return path.isAbsolute(unwrappedId) || isWindowsAbsolutePath(unwrappedId)
+    ? unwrappedId
+    : id;
+};
+
+export const getAbsoluteId = ({
+  filePath,
+  root,
+}: {
+  filePath: string;
+  root: string;
+}) => {
+  const resolvedId = unwrapAbsoluteViteId(filePath);
+
+  if (
+    isWindowsAbsolutePath(resolvedId) ||
+    resolvedId.startsWith(root) ||
+    // In monorepos the absolute path will be outside of root, so we check that they have the same
+    // root on the file system. Paths from Vite are always normalized, so we have to use the posix
+    // path separator.
+    (path.isAbsolute(resolvedId) &&
+      resolvedId.split(path.posix.sep)[1] === root.split(path.posix.sep)[1])
+  ) {
+    return normalizePath(resolvedId);
+  }
+
+  // In SSR mode we can have paths like /app/styles.css.ts
+  return normalizePath(path.join(root, resolvedId));
+};

--- a/packages/vite-plugin/src/ids.ts
+++ b/packages/vite-plugin/src/ids.ts
@@ -1,0 +1,44 @@
+import path from 'path';
+
+import { normalizePath } from '@vanilla-extract/integration';
+
+const viteIdPrefix = /^\/?@id\//;
+const windowsAbsolutePathRegex =
+  /^(?:[a-zA-Z]:[/\\]|[/\\]{2}[^/\\]+[/\\][^/\\]+)/;
+
+const isWindowsAbsolutePath = (filePath: string) =>
+  windowsAbsolutePathRegex.test(filePath);
+
+const unwrapAbsoluteViteId = (id: string) => {
+  const unwrappedId = id.replace(viteIdPrefix, '');
+  const normalizedId = unwrappedId.replace(/^\/([a-zA-Z]:[/\\])/, '$1');
+
+  return path.isAbsolute(normalizedId) || isWindowsAbsolutePath(normalizedId)
+    ? normalizedId
+    : id;
+};
+
+export const getAbsoluteId = ({
+  filePath,
+  root,
+}: {
+  filePath: string;
+  root: string;
+}) => {
+  const resolvedId = unwrapAbsoluteViteId(filePath);
+
+  if (
+    isWindowsAbsolutePath(resolvedId) ||
+    resolvedId.startsWith(root) ||
+    // In monorepos the absolute path will be outside of root, so we check that they have the same
+    // root on the file system. Paths from Vite are always normalized, so we have to use the posix
+    // path separator.
+    (path.isAbsolute(resolvedId) &&
+      resolvedId.split(path.posix.sep)[1] === root.split(path.posix.sep)[1])
+  ) {
+    return normalizePath(resolvedId);
+  }
+
+  // In SSR mode we can have paths like /app/styles.css.ts
+  return normalizePath(path.join(root, resolvedId));
+};

--- a/packages/vite-plugin/src/ids.ts
+++ b/packages/vite-plugin/src/ids.ts
@@ -1,21 +1,32 @@
-import path from 'path';
+import { posix } from 'path';
 
 import { normalizePath } from '@vanilla-extract/integration';
 
+// Vite wraps module ids that aren't valid browser import specifiers with
+// `/@id/` in dev mode. The leading slash is sometimes already stripped.
 const viteIdPrefix = /^\/?@id\//;
-const windowsAbsolutePathRegex =
-  /^(?:[a-zA-Z]:[/\\]|[/\\]{2}[^/\\]+[/\\][^/\\]+)/;
+// Vite emits posix separators and sometimes prefixes a Windows drive letter
+// with a slash, e.g. a resolved id like `/C:/...`.
+const slashPrefixedDrive = /^\/([a-zA-Z]:\/)/;
+// A Windows drive path (`C:/...`) is unambiguously a real absolute path
+// unlike a posix `/...` path, which may be an SSR root-relative id.
+const windowsAbsolutePathRegex = /^[a-zA-Z]:\//;
 
 const isWindowsAbsolutePath = (filePath: string) =>
   windowsAbsolutePathRegex.test(filePath);
 
-const unwrapAbsoluteViteId = (id: string) => {
-  const unwrappedId = id.replace(viteIdPrefix, '');
-  const normalizedId = unwrappedId.replace(/^\/([a-zA-Z]:[/\\])/, '$1');
+const isAbsolutePath = (filePath: string) =>
+  posix.isAbsolute(filePath) || isWindowsAbsolutePath(filePath);
 
-  return path.isAbsolute(normalizedId) || isWindowsAbsolutePath(normalizedId)
-    ? normalizedId
-    : id;
+// Strip Vite's `@id/` wrapper and any slash it prefixes onto a Windows drive.
+const unwrapViteId = (id: string) => {
+  const unwrapped = id
+    .replace(viteIdPrefix, '')
+    .replace(slashPrefixedDrive, '$1');
+
+  // If unwrapping didn't yield an absolute path, the `@id/` prefix wasn't a
+  // path wrapper, so keep the original id.
+  return isAbsolutePath(unwrapped) ? unwrapped : id;
 };
 
 export const getAbsoluteId = ({
@@ -25,20 +36,20 @@ export const getAbsoluteId = ({
   filePath: string;
   root: string;
 }) => {
-  const resolvedId = unwrapAbsoluteViteId(filePath);
+  const resolvedId = unwrapViteId(filePath);
 
   if (
+    // A Windows drive path is always a real absolute path.
     isWindowsAbsolutePath(resolvedId) ||
     resolvedId.startsWith(root) ||
-    // In monorepos the absolute path will be outside of root, so we check that they have the same
-    // root on the file system. Paths from Vite are always normalized, so we have to use the posix
-    // path separator.
-    (path.isAbsolute(resolvedId) &&
-      resolvedId.split(path.posix.sep)[1] === root.split(path.posix.sep)[1])
+    // In monorepos the absolute path is outside of `root`, so we check they
+    // share a filesystem root. Vite paths always use posix separators.
+    (posix.isAbsolute(resolvedId) &&
+      resolvedId.split(posix.sep)[1] === root.split(posix.sep)[1])
   ) {
     return normalizePath(resolvedId);
   }
 
-  // In SSR mode we can have paths like /app/styles.css.ts
-  return normalizePath(path.join(root, resolvedId));
+  // In SSR mode we can have root-relative paths like `/app/styles.css.ts`.
+  return normalizePath(posix.join(root, resolvedId));
 };

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,5 +1,3 @@
-import path from 'path';
-
 import type {
   Plugin,
   ResolvedConfig,
@@ -18,6 +16,7 @@ import {
   transform,
   normalizePath,
 } from '@vanilla-extract/integration';
+import { getAbsoluteId } from './ids';
 
 const PLUGIN_NAMESPACE = 'vite-plugin-vanilla-extract';
 const virtualExtCss = '.vanilla.css';
@@ -75,25 +74,6 @@ export function vanillaExtractPlugin({
 
   const getIdentOption = () =>
     identifiers ?? (config.mode === 'production' ? 'short' : 'debug');
-  const getAbsoluteId = (filePath: string) => {
-    let resolvedId = filePath;
-
-    if (
-      filePath.startsWith(config.root) ||
-      // In monorepos the absolute path will be outside of config.root, so we check that they have the same root on the file system
-      // Paths from vite are always normalized, so we have to use the posix path separator
-      (path.isAbsolute(filePath) &&
-        filePath.split(path.posix.sep)[1] ===
-          config.root.split(path.posix.sep)[1])
-    ) {
-      resolvedId = filePath;
-    } else {
-      // In SSR mode we can have paths like /app/styles.css.ts
-      resolvedId = path.join(config.root, filePath);
-    }
-
-    return normalizePath(resolvedId);
-  };
 
   /**
    * Custom invalidation function that takes a chain of importers to invalidate. If an importer is a
@@ -264,7 +244,10 @@ export function vanillaExtractPlugin({
           return null;
         }
 
-        const absoluteId = getAbsoluteId(validId);
+        const absoluteId = getAbsoluteId({
+          filePath: validId,
+          root: config.root,
+        });
 
         const { source, watchFiles } = await compiler.processVanillaFile(
           absoluteId,
@@ -321,7 +304,10 @@ export function vanillaExtractPlugin({
 
         if (!isVirtualId(validId)) return;
 
-        const absoluteId = getAbsoluteId(validId);
+        const absoluteId = getAbsoluteId({
+          filePath: validId,
+          root: config.root,
+        });
 
         if (
           // We should always have CSS for a file here.
@@ -338,7 +324,10 @@ export function vanillaExtractPlugin({
 
         if (!isVirtualId(validId) || !compiler) return;
 
-        const absoluteId = getAbsoluteId(validId);
+        const absoluteId = getAbsoluteId({
+          filePath: validId,
+          root: config.root,
+        });
 
         const { css } = compiler.getCssForFile(virtualIdToFileId(absoluteId));
 


### PR DESCRIPTION
Fixes #1717

## Summary

Fix a Windows dev-mode issue in `@vanilla-extract/vite-plugin` where Vite can resolve workspace virtual CSS modules as absolute `@id/...` ids, for example:

- `@id/C:/...`
- `/@id/C:/...`

Previously these ids could be treated as root-relative paths and joined with `config.root`, producing an invalid path and eventually causing `Error: No CSS for file: ...`.

This change:

- normalizes absolute Vite `@id/...` ids before resolving virtual CSS files
- preserves existing behavior for monorepo absolute paths outside `config.root`
- preserves existing SSR-style root-relative paths like `/app/styles.css.ts`
- adds tests covering the Windows `@id/C:/...` case and the existing path behaviors

## Testing

- `pnpm build`
- `pnpm test:unit -- packages/vite-plugin/src/ids.test.ts`
