### PR TITLE
`docs`: Highlight CSS

### DIFF
--- a/site/src/Code/SyntaxHighlighter.tsx
+++ b/site/src/Code/SyntaxHighlighter.tsx
@@ -4,8 +4,11 @@ import { PrismLight as SyntaxHighlighter } from 'react-syntax-highlighter/dist/e
 import tsx from 'react-syntax-highlighter/dist/esm/languages/prism/tsx';
 // @ts-expect-error
 import ts from 'react-syntax-highlighter/dist/esm/languages/prism/typescript';
+// @ts-expect-error
+import css from 'react-syntax-highlighter/dist/esm/languages/prism/css';
 SyntaxHighlighter.registerLanguage('tsx', tsx);
 SyntaxHighlighter.registerLanguage('ts', ts);
+SyntaxHighlighter.registerLanguage('css', css);
 
 import { Box } from '../system';
 import Text from '../Typography/Text';


### PR DESCRIPTION
I swear CSS used to be highlighted, but the syntax highlighter has never had CSS configured explicitly. Maybe CSS used to be on by default, but then changed in a lockfile update?

- [Before](https://changeset-release-master--vanilla-extract-css.netlify.app/documentation/api/style/) (draft site deploy so it's a permalink, rather than pointing to prod)
- [After](https://docs-css-highlighting--vanilla-extract-css.netlify.app/documentation/api/style/)