### PR TITLE
docs: fix typos and broken link

### DIFF
--- a/site/docs/global-api/create-global-theme.md
+++ b/site/docs/global-api/create-global-theme.md
@@ -25,7 +25,7 @@ export const vars = createGlobalTheme(':root', {
 
 All theme values must be provided or it’s a type error.
 
-Importing this stylesheet as a side effect to include the styles in your CSS bundle.
+Import this stylesheet as a side effect to include the styles in your CSS bundle.
 
 ```ts
 // app.ts

--- a/site/docs/overview/styling.md
+++ b/site/docs/overview/styling.md
@@ -191,10 +191,10 @@ import { style } from '@vanilla-extract/css';
 
 const invalid = style({
   selectors: {
-    // ❌ ERROR: Targetting `a[href]`
+    // ❌ ERROR: Targeting `a[href]`
     '& a[href]': {...},
 
-    // ❌ ERROR: Targetting `.otherClass`
+    // ❌ ERROR: Targeting `.otherClass`
     '& ~ div > .otherClass': {...}
   }
 });
@@ -210,7 +210,7 @@ import { style } from '@vanilla-extract/css';
 export const child = style({});
 export const parent = style({
   selectors: {
-    // ❌ ERROR: Targetting `child` from `parent`
+    // ❌ ERROR: Targeting `child` from `parent`
     [`& ${child}`]: {...}
   }
 });

--- a/site/docs/overview/theming.md
+++ b/site/docs/overview/theming.md
@@ -243,7 +243,7 @@ export const container = style({
 This pattern opens up a lot of interesting possibilities. Type-safe runtime theming without the need for runtime creation and injection of CSS.
 
 [createtheme]: /documentation/api/create-theme/
-[createthemecontract]: /documentation/api/create-theme/
+[createthemecontract]: /documentation/api/create-theme-contract/
 [assigninlinevars]: /documentation/packages/dynamic/#assigninlinevars
 [createvar]: /documentation/api/create-var
 [tiny]: https://bundlephobia.com/package/@vanilla-extract/dynamic


### PR DESCRIPTION
## Summary

- Fix `Targetting` → `Targeting` (3 occurrences in `site/docs/overview/styling.md`)
- Fix broken link for `createThemeContract` in `site/docs/overview/theming.md` — was pointing to `/documentation/api/create-theme/` instead of `/documentation/api/create-theme-contract/`
- Fix sentence fragment `Importing this stylesheet...` → `Import this stylesheet...` in `site/docs/global-api/create-global-theme.md`