### PR TITLE
fix(css): preserve empty string as a valid fallbackVar fallback

### DIFF
--- a/.changeset/fix-fallbackvar-empty-string.md
+++ b/.changeset/fix-fallbackvar-empty-string.md
@@ -1,0 +1,5 @@
+---
+"@vanilla-extract/css": patch
+---
+
+Fix `fallbackVar()` discarding empty string `""` as a valid CSS fallback value.

--- a/packages/css/src/vars.test.ts
+++ b/packages/css/src/vars.test.ts
@@ -45,6 +45,12 @@ describe('fallbackVar', () => {
     );
   });
 
+  it('supports an empty string as the final fallback', () => {
+    expect(fallbackVar('var(--foo-bar)', '')).toMatchInlineSnapshot(
+      `"var(--foo-bar, )"`,
+    );
+  });
+
   it('should throw with invalid vars', () => {
     expect(() => {
       fallbackVar('INVALID', '10px');

--- a/packages/css/src/vars.ts
+++ b/packages/css/src/vars.ts
@@ -106,10 +106,10 @@ export function assertVarName(
 export function fallbackVar(
   ...values: [string, ...Array<string>]
 ): CSSVarFunction {
-  let finalValue = '';
+  let finalValue: string | null = null;
 
   values.reverse().forEach((value) => {
-    if (finalValue === '') {
+    if (finalValue === null) {
       finalValue = String(value);
     } else {
       assertVarName(value);


### PR DESCRIPTION
## Problem

`fallbackVar('var(--foo)', '')` returns `'var(--foo)'` — the empty string fallback is silently discarded.

This breaks patterns where an empty CSS custom property fallback is intentional, e.g. when using Tailwind utility classes that rely on `var(--ring-color, )` producing a blank value rather than inheriting a default.

## Root cause

The implementation uses an empty string `''` as the sentinel to detect "not yet initialised":

```ts
let finalValue = '';

values.reverse().forEach((value) => {
  if (finalValue === '') {     // ← also true when the last value is ''
    finalValue = String(value);
  } else { ... }
});
```

When the last argument is `''`, the first loop iteration correctly sets `finalValue = ''`. But on the second iteration, `finalValue === ''` is still `true`, so the next variable is treated as the initialiser instead of being wrapped — the empty string fallback is lost.

## Fix

Switch the sentinel to `null`:

```ts
let finalValue: string | null = null;

values.reverse().forEach((value) => {
  if (finalValue === null) {   // unambiguously "not yet initialised"
    finalValue = String(value);
  } else { ... }
});
```

A test covering the empty-string case is included.

## Before / After

```ts
// Before
fallbackVar('var(--foo-bar)', '')  // => 'var(--foo-bar)'   ← wrong

// After
fallbackVar('var(--foo-bar)', '')  // => 'var(--foo-bar, )' ← correct
```