### PR TITLE
Remove buggy `--no-bail` flag to prevent false-negative lints

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:clean-next": "pnpm --filter=@fixtures/next-* run '/^clean.*/'",
     "test:build-next": "node scripts/copy-next-plugin.ts && pnpm --filter=@fixtures/next-* run '/^build.*/'",
     "format": "oxlint --fix && prettier --write .",
-    "lint": "pnpm run --no-bail '/^lint:.*/'",
+    "lint": "pnpm run '/^lint:.*/'",
     "lint:manypkg": "manypkg check",
     "lint:prettier": "prettier --cache --check .",
     "lint:tsc": "tsc",


### PR DESCRIPTION
Noticed that CI was _not_ failing in #1720 despite `prettier` flagging unformatted files. This is because [pnpm's `--no-bail` flag is buggy](https://github.com/pnpm/pnpm/issues/8013).

The downside to removing it is that the first error encountered by the `lint` script will kill it immediately, but it's better than false-negatives.