### PR TITLE
Harden actions

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -1,22 +1,26 @@
 name: Deploy site
 
 on: push
+permissions: {}
 
 jobs:
   deploy-site:
     name: Deploy site
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'vanilla-extract-css'
     env:
       CI: true
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   release:
     name: Publish & Deploy
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.repository_owner == 'vanilla-extract-css'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -17,16 +17,17 @@ jobs:
       CI: true
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.VANILLA_EXTRACT_CI_GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
@@ -35,7 +36,7 @@ jobs:
         run: pnpm install
 
       - name: Create release PR or publish to npm
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           version: pnpm run version
           publish: pnpm release
@@ -44,7 +45,7 @@ jobs:
 
   snapshot:
     name: Publish snapshot version
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.repository_owner == 'vanilla-extract-css'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -52,16 +53,17 @@ jobs:
       CI: true
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: ${{ secrets.VANILLA_EXTRACT_CI_GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
@@ -70,7 +72,7 @@ jobs:
         run: pnpm install
 
       - name: Publish
-        uses: seek-oss/changesets-snapshot@v0
+        uses: seek-oss/changesets-snapshot@9063bfcb495100964ee0912c5bcb30c4c434c1b3 # v0.3.2
         with:
           pre-publish: pnpm prepare-release
         env:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,7 @@
 name: Validate
 
 on: [push, pull_request]
+permissions: {}
 
 jobs:
   test:
@@ -15,13 +16,15 @@ jobs:
       CI: true
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
           node-version-file: ${{ matrix.node == '' && '.nvmrc' || '' }}
@@ -50,13 +53,15 @@ jobs:
       CI: true
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
           node-version-file: ${{ matrix.node == '' && '.nvmrc' || '' }}
@@ -78,13 +83,15 @@ jobs:
       CI: true
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up PNPM
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'pnpm'
@@ -101,7 +108,7 @@ jobs:
       - name: Playwright tests
         run: pnpm test:playwright
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ failure() }}
         with:
           name: test-results


### PR DESCRIPTION
Fixed all issues found by [`zizmor`](https://docs.zizmor.sh/). Used [`pin-github-actions`](https://github.com/mheap/pin-github-action) to pin versions, but might end up configuring dependabot to do it regularly.

Also added a condition to the `deploy-site` and `release` workflows that stops them from running on forks. These are the workflows that get token access so are potential attack vectors, and forks don't even have access to these runs so they fail anyway, leading to email spam when a fork PR has lots of activity. Picked this up from [this blog post](https://bomb.sh/blog/one-repo-every-workflow/), and I might end up doing a similar build/publish split in the future.