### PR TITLE
fix(vite-plugin): await compiler creation in transform to fix race with concurrently-emitted entries

### DIFF
--- a/.changeset/vite-plugin-compiler-race.md
+++ b/.changeset/vite-plugin-compiler-race.md
@@ -1,0 +1,9 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Fix a race condition that could leave `.css.ts` files untransformed
+
+The compiler is created in `buildStart`, and `transform` previously bailed out (`return null`) if it ran before the compiler was ready. When another plugin emits an additional entry whose module graph is transformed concurrently (e.g. a module federation plugin exposing a module as its own chunk), a `transform` for a `.css.ts` could run before `buildStart` finished creating the compiler, leaving the file untransformed and producing runtime `style()` calls that throw `Styles were unable to be assigned to a file`.
+
+Compiler creation is now memoized and awaited from `transform`, so it no longer depends on `buildStart` having already resolved.

--- a/.changeset/vite-plugin-compiler-race.md
+++ b/.changeset/vite-plugin-compiler-race.md
@@ -2,8 +2,6 @@
 '@vanilla-extract/vite-plugin': patch
 ---
 
-Fix a race condition that could leave `.css.ts` files untransformed
+Fixed an issue where `.css.ts` files could be left untransformed
 
-The compiler is created in `buildStart`, and `transform` previously bailed out (`return null`) if it ran before the compiler was ready. When another plugin emits an additional entry whose module graph is transformed concurrently (e.g. a module federation plugin exposing a module as its own chunk), a `transform` for a `.css.ts` could run before `buildStart` finished creating the compiler, leaving the file untransformed and producing runtime `style()` calls that throw `Styles were unable to be assigned to a file`.
-
-Compiler creation is now memoized and awaited from `transform`, so it no longer depends on `buildStart` having already resolved.
+This was most commonly hit when using module federation plugins that expose modules as their own chunks, resulting in untransformed runtime `style()` calls throwing `Styles were unable to be assigned to a file`.

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -67,6 +67,7 @@ export function vanillaExtractPlugin({
   let server: ViteDevServer;
   let packageName: string;
   let compiler: Compiler | undefined;
+  let compilerReady: Promise<void> | undefined;
   let isBuild: boolean;
   const vitePromise = import('vite');
 
@@ -111,6 +112,65 @@ export function vanillaExtractPlugin({
         }
       }
     }
+  };
+
+  /**
+   * Lazily creates the compiler, memoizing the initialization promise.
+   *
+   * `buildStart` kicks this off eagerly, but `transform` also awaits it. This
+   * matters because `transform` can run before `buildStart` has finished
+   * creating the compiler when another plugin emits an additional entry whose
+   * module graph is transformed concurrently (e.g. a module federation plugin
+   * exposing a module as its own chunk). Without awaiting, `transform` would
+   * bail and leave the `.css.ts` untransformed, producing runtime `style()`
+   * calls that throw "Styles were unable to be assigned to a file".
+   */
+  const ensureCompiler = () => {
+    if (unstable_mode === 'transform') {
+      return Promise.resolve();
+    }
+
+    compilerReady ??= (async () => {
+      const { loadConfigFromFile } = await vitePromise;
+
+      let configForViteCompiler: UserConfig | undefined;
+
+      // The user has a vite config file
+      if (config.configFile) {
+        const configFile = await loadConfigFromFile(
+          {
+            command: config.command,
+            mode: config.mode,
+            isSsrBuild: configEnv.isSsrBuild,
+          },
+          config.configFile,
+        );
+
+        configForViteCompiler = configFile?.config;
+      }
+      // The user is using a vite-based framework that has a custom config file
+      else {
+        configForViteCompiler = config.inlineConfig;
+      }
+
+      const viteConfig = {
+        ...configForViteCompiler,
+        plugins: configForViteCompiler?.plugins
+          ?.flat()
+          .filter(isPluginObject)
+          .filter(withUserPluginFilter({ mode: config.mode, pluginFilter })),
+      };
+
+      compiler = createCompiler({
+        root: config.root,
+        identifiers: getIdentOption(),
+        cssImportSpecifier: fileIdToVirtualId,
+        viteConfig,
+        enableFileWatcher: !isBuild,
+      });
+    })();
+
+    return compilerReady;
   };
 
   return [
@@ -166,47 +226,7 @@ export function vanillaExtractPlugin({
       },
       async buildStart() {
         // Ensure we re-use the compiler instance between builds, e.g. in watch mode
-        if (unstable_mode !== 'transform' && !compiler) {
-          const { loadConfigFromFile } = await vitePromise;
-
-          let configForViteCompiler: UserConfig | undefined;
-
-          // The user has a vite config file
-          if (config.configFile) {
-            const configFile = await loadConfigFromFile(
-              {
-                command: config.command,
-                mode: config.mode,
-                isSsrBuild: configEnv.isSsrBuild,
-              },
-              config.configFile,
-            );
-
-            configForViteCompiler = configFile?.config;
-          }
-          // The user is using a vite-based framework that has a custom config file
-          else {
-            configForViteCompiler = config.inlineConfig;
-          }
-
-          const viteConfig = {
-            ...configForViteCompiler,
-            plugins: configForViteCompiler?.plugins
-              ?.flat()
-              .filter(isPluginObject)
-              .filter(
-                withUserPluginFilter({ mode: config.mode, pluginFilter }),
-              ),
-          };
-
-          compiler = createCompiler({
-            root: config.root,
-            identifiers: getIdentOption(),
-            cssImportSpecifier: fileIdToVirtualId,
-            viteConfig,
-            enableFileWatcher: !isBuild,
-          });
-        }
+        await ensureCompiler();
       },
       buildEnd() {
         // When using the rollup watcher, we don't want to close the compiler after every build.
@@ -238,6 +258,15 @@ export function vanillaExtractPlugin({
             packageName,
             identOption,
           });
+        }
+
+        // `transform` can run before `buildStart` has finished creating the
+        // compiler (e.g. when another plugin emits an additional entry whose
+        // module graph is transformed concurrently). Await the memoized
+        // initialization rather than bailing, which would leave this `.css.ts`
+        // untransformed.
+        if (!compiler) {
+          await ensureCompiler();
         }
 
         if (!compiler) {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -114,6 +114,46 @@ export function vanillaExtractPlugin({
     }
   };
 
+  const initializeCompiler = async () => {
+    const { loadConfigFromFile } = await vitePromise;
+
+    let configForViteCompiler: UserConfig | undefined;
+
+    // The user has a vite config file
+    if (config.configFile) {
+      const configFile = await loadConfigFromFile(
+        {
+          command: config.command,
+          mode: config.mode,
+          isSsrBuild: configEnv.isSsrBuild,
+        },
+        config.configFile,
+      );
+
+      configForViteCompiler = configFile?.config;
+    }
+    // The user is using a vite-based framework that has a custom config file
+    else {
+      configForViteCompiler = config.inlineConfig;
+    }
+
+    const viteConfig = {
+      ...configForViteCompiler,
+      plugins: configForViteCompiler?.plugins
+        ?.flat()
+        .filter(isPluginObject)
+        .filter(withUserPluginFilter({ mode: config.mode, pluginFilter })),
+    };
+
+    compiler = createCompiler({
+      root: config.root,
+      identifiers: getIdentOption(),
+      cssImportSpecifier: fileIdToVirtualId,
+      viteConfig,
+      enableFileWatcher: !isBuild,
+    });
+  };
+
   /**
    * Lazily creates the compiler, memoizing the initialization promise.
    *
@@ -130,46 +170,7 @@ export function vanillaExtractPlugin({
       return Promise.resolve();
     }
 
-    compilerReady ??= (async () => {
-      const { loadConfigFromFile } = await vitePromise;
-
-      let configForViteCompiler: UserConfig | undefined;
-
-      // The user has a vite config file
-      if (config.configFile) {
-        const configFile = await loadConfigFromFile(
-          {
-            command: config.command,
-            mode: config.mode,
-            isSsrBuild: configEnv.isSsrBuild,
-          },
-          config.configFile,
-        );
-
-        configForViteCompiler = configFile?.config;
-      }
-      // The user is using a vite-based framework that has a custom config file
-      else {
-        configForViteCompiler = config.inlineConfig;
-      }
-
-      const viteConfig = {
-        ...configForViteCompiler,
-        plugins: configForViteCompiler?.plugins
-          ?.flat()
-          .filter(isPluginObject)
-          .filter(withUserPluginFilter({ mode: config.mode, pluginFilter })),
-      };
-
-      compiler = createCompiler({
-        root: config.root,
-        identifiers: getIdentOption(),
-        cssImportSpecifier: fileIdToVirtualId,
-        viteConfig,
-        enableFileWatcher: !isBuild,
-      });
-    })();
-
+    compilerReady ??= initializeCompiler();
     return compilerReady;
   };
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -264,10 +264,9 @@ export function vanillaExtractPlugin({
         // compiler (e.g. when another plugin emits an additional entry whose
         // module graph is transformed concurrently). Await the memoized
         // initialization rather than bailing, which would leave this `.css.ts`
-        // untransformed.
-        if (!compiler) {
-          await ensureCompiler();
-        }
+        // untransformed. `ensureCompiler` is memoized, so this is a no-op once
+        // the compiler exists.
+        await ensureCompiler();
 
         if (!compiler) {
           return null;


### PR DESCRIPTION
Fixes #1747

## Problem

`@vanilla-extract/vite-plugin` creates its compiler in an **async `buildStart`**, and `transform` bails out if the compiler isn't ready yet:

```ts
if (!compiler) {
  return null; // .css.ts passes through untransformed
}
```

Rollup normally finishes `buildStart` before `transform`, but when another plugin emits an **additional entry** whose module graph is transformed concurrently, a `transform` for a `.css.ts` can run **before** `buildStart` has created the compiler. It then returns `null`, the `.css.ts` is left untransformed, its `style()`/`globalStyle()` calls remain in the output, and at runtime the code throws `Styles were unable to be assigned to a file`.

This reproduces with [`@module-federation/vite`](https://github.com/module-federation/vite), which emits each **exposed** module as its own Rollup chunk. It is **non-deterministic** — roughly 3 in 10 clean builds fail.

Reproduction: https://github.com/smitev/vanilla-extract-mf-vite-repro (`./repro.sh 10`).

## Fix

Memoize compiler creation in an `ensureCompiler()` helper and `await` it from `transform` instead of returning `null`. `buildStart` still triggers it eagerly, so behaviour is unchanged in the common case — the change only matters when `transform` wins the race. Because `transform` no longer depends on `buildStart` having already resolved, the outcome is deterministic regardless of plugin ordering or which plugin emitted the entry.

## Verification

Using this branch built via `pnpm build` and dropped into the reproduction:

- **Before:** ~7/10 clean builds extract CSS, ~3/10 leave runtime `style()` calls.
- **After:** 15/15 clean builds extract CSS to a static file, with no runtime `getFileScope` calls in the exposed chunk.

`pnpm lint:tsc` reports no new errors in `packages/vite-plugin/src/index.ts` (the two pre-existing "Cannot find module" errors on the import lines are present on `master` too and require a prior `pnpm build`). `prettier --check` passes on the changed files. A changeset is included.
