### PR TITLE
`ci`: Shard playwright tests

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,13 +76,13 @@ jobs:
       - name: Unit Test
         run: pnpm test:unit
   playwright:
-    name: Playwright tests (shard ${{ matrix.shard }}/4)
+    name: Playwright tests (shard ${{ matrix.shard }}/2)
     runs-on: macos-latest
     if: github.ref != 'refs/heads/changeset-release/master' && github.head_ref != 'changeset-release/master'
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2]
     env:
       CI: true
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,9 +76,13 @@ jobs:
       - name: Unit Test
         run: pnpm test:unit
   playwright:
-    name: Playwright tests
+    name: Playwright tests (shard ${{ matrix.shard }}/4)
     runs-on: macos-latest
     if: github.ref != 'refs/heads/changeset-release/master' && github.head_ref != 'changeset-release/master'
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     env:
       CI: true
     steps:
@@ -106,10 +110,10 @@ jobs:
         run: pnpm build
 
       - name: Playwright tests
-        run: pnpm test:playwright
+        run: pnpm test:playwright --shard=${{ matrix.shard }}/4
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ failure() }}
         with:
-          name: test-results
+          name: test-results-shard-${{ matrix.shard }}
           path: test-results/


### PR DESCRIPTION
CI runs can be quite long. Sharding seems to help somewhat, though some shards still take ~2x as long as others (but only sometimes?), so there's likely a specific set of tests that are slow.