### PR TITLE
Upgrade pnpm to v11, fix sharding

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -104,7 +104,7 @@ jobs:
         run: pnpm install
 
       - name: Install Browsers
-        run: pnpm playwright install chromium
+        run: pnpm playwright install chromium --only-shell
 
       - name: Build packages
         run: pnpm build

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -110,7 +110,7 @@ jobs:
         run: pnpm build
 
       - name: Playwright tests
-        run: pnpm test:playwright --shard=${{ matrix.shard }}/4
+        run: pnpm test:playwright --shard=${{ matrix.shard }}/2
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ failure() }}

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:clean-next": "pnpm --filter=@fixtures/next-* run '/^clean.*/'",
     "test:build-next": "node scripts/copy-next-plugin.ts && pnpm --filter=@fixtures/next-* run '/^build.*/'",
     "format": "oxlint --fix && prettier --write .",
-    "lint": "pnpm run '/^lint:.*/'",
+    "lint": "pnpm run --no-bail '/^lint:.*/'",
     "lint:manypkg": "manypkg check",
     "lint:prettier": "prettier --cache --check .",
     "lint:tsc": "tsc",

--- a/package.json
+++ b/package.json
@@ -58,5 +58,5 @@
   "manypkg": {
     "workspaceProtocol": "require"
   },
-  "packageManager": "pnpm@10.32.0"
+  "packageManager": "pnpm@11.8.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: '9.0'
 
 settings:
   autoInstallPeers: true
+  dedupePeers: true
   excludeLinksFromLockfile: false
 
 importers:
@@ -10,10 +11,10 @@ importers:
     devDependencies:
       '@babel/core':
         specifier: ^7.23.9
-        version: 7.23.9
+        version: 7.23.9(supports-color@9.2.3)
       '@babel/preset-env':
         specifier: ^7.23.9
-        version: 7.23.9(@babel/core@7.23.9)
+        version: 7.23.9(@babel/core@7.23.9)(supports-color@9.2.3)
       '@babel/preset-react':
         specifier: ^7.23.3
         version: 7.23.3(@babel/core@7.23.9)
@@ -58,13 +59,13 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@22.15.3)(happy-dom@20.8.4)(jsdom@29.0.0)(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0))
+        version: 4.1.0(@types/node@22.15.3)(happy-dom@20.8.4)(jsdom@29.0.0)(vite@8.0.5)
 
   examples/next:
     dependencies:
       next:
         specifier: 12.3.4
-        version: 12.3.4(@babel/core@7.23.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 12.3.4(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -86,7 +87,7 @@ importers:
     dependencies:
       '@babel/preset-env':
         specifier: ^7.23.9
-        version: 7.23.9(@babel/core@7.23.9)
+        version: 7.23.9(@babel/core@7.23.9)(supports-color@9.2.3)
       '@babel/preset-react':
         specifier: ^7.23.3
         version: 7.23.3(@babel/core@7.23.9)
@@ -134,7 +135,7 @@ importers:
         version: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.104.0)
       webpack-dev-server:
         specifier: ^5.2.2
-        version: 5.2.2(webpack-cli@6.0.1)(webpack@5.104.0)
+        version: 5.2.2(supports-color@9.2.3)(webpack-cli@6.0.1)(webpack@5.104.0)
     devDependencies:
       '@types/react':
         specifier: ^18.2.55
@@ -186,7 +187,7 @@ importers:
         version: link:../../packages/sprinkles
       next:
         specifier: 12.3.4
-        version: 12.3.4(@babel/core@7.23.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 12.3.4(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -226,7 +227,7 @@ importers:
         version: link:../../packages/sprinkles
       next:
         specifier: npm:next@13.5.11
-        version: 13.5.11(@babel/core@7.23.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 13.5.11(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -266,7 +267,7 @@ importers:
         version: link:../../packages/sprinkles
       next:
         specifier: npm:next@^16.0.0
-        version: 16.1.1(@babel/core@7.23.9)(@playwright/test@1.61.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 16.1.1(@babel/core@7.23.9)(@playwright/test@1.61.0)(react-dom@19.2.3)(react@19.2.3)
       react:
         specifier: npm:react@^19.2.0
         version: 19.2.3
@@ -373,7 +374,7 @@ importers:
     dependencies:
       '@babel/core':
         specifier: ^7.23.9
-        version: 7.23.9
+        version: 7.23.9(supports-color@9.2.3)
     devDependencies:
       '@babel/plugin-syntax-typescript':
         specifier: ^7.23.3
@@ -470,7 +471,7 @@ importers:
     dependencies:
       '@babel/core':
         specifier: ^7.23.9
-        version: 7.23.9
+        version: 7.23.9(supports-color@9.2.3)
       '@babel/plugin-syntax-typescript':
         specifier: ^7.23.3
         version: 7.23.3(@babel/core@7.23.9)
@@ -533,10 +534,10 @@ importers:
         version: 7.7.1
       next:
         specifier: 12.3.4
-        version: 12.3.4(@babel/core@7.23.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 12.3.4(@babel/core@7.23.9)(react-dom@19.2.3)(react@19.2.3)
       webpack:
         specifier: ^5.90.0
-        version: 5.104.0(esbuild@0.28.0)
+        version: 5.104.0(esbuild@0.28.0)(webpack-cli@6.0.1)
 
   packages/parcel-transformer:
     dependencies:
@@ -584,7 +585,7 @@ importers:
         version: 4.59.0
       rollup-plugin-esbuild:
         specifier: ^6.1.1
-        version: 6.1.1(esbuild@0.28.0)(rollup@4.59.0)
+        version: 6.1.1(esbuild@0.28.0)(rollup@4.59.0)(supports-color@9.2.3)
 
   packages/sprinkles:
     devDependencies:
@@ -606,7 +607,7 @@ importers:
     devDependencies:
       next:
         specifier: 12.3.4
-        version: 12.3.4(@babel/core@7.23.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        version: 12.3.4(@babel/core@7.23.9)(react-dom@19.2.3)(react@19.2.3)
       vite:
         specifier: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
         version: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
@@ -646,7 +647,7 @@ importers:
         version: 4.1.7
       webpack:
         specifier: ^5.90.0
-        version: 5.104.0(esbuild@0.28.0)
+        version: 5.104.0(esbuild@0.28.0)(webpack-cli@6.0.1)
 
   scripts:
     devDependencies:
@@ -673,7 +674,7 @@ importers:
         version: 3.3.3
       '@docsearch/react':
         specifier: 3.3.3
-        version: 3.3.3(@algolia/client-search@4.22.1)(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 3.3.3(@algolia/client-search@4.22.1)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
       '@mdx-js/react':
         specifier: ^1.6.22
         version: 1.6.22(react@18.2.0)
@@ -694,23 +695,23 @@ importers:
         version: 18.2.0(react@18.2.0)
       react-head:
         specifier: ^3.4.2
-        version: 3.4.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 3.4.2(react-dom@18.2.0)(react@18.2.0)
       react-router-dom:
         specifier: ^6.22.0
-        version: 6.30.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        version: 6.30.0(react-dom@18.2.0)(react@18.2.0)
       react-router-hash-link:
         specifier: ^2.4.3
-        version: 2.4.3(react-router-dom@6.30.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 2.4.3(react-router-dom@6.30.0)(react@18.2.0)
       react-syntax-highlighter:
         specifier: ^16.1.0
         version: 16.1.0(react@18.2.0)
     devDependencies:
       '@babel/core':
         specifier: ^7.23.9
-        version: 7.23.9
+        version: 7.23.9(supports-color@9.2.3)
       '@babel/preset-env':
         specifier: ^7.23.9
-        version: 7.23.9(@babel/core@7.23.9)
+        version: 7.23.9(@babel/core@7.23.9)(supports-color@9.2.3)
       '@babel/preset-react':
         specifier: ^7.23.3
         version: 7.23.3(@babel/core@7.23.9)
@@ -782,13 +783,13 @@ importers:
         version: 3.0.2(express@4.22.1)
       mdx-loader:
         specifier: ^3.0.2
-        version: 3.0.2(react@18.2.0)
+        version: 3.0.2(react@18.2.0)(supports-color@9.2.3)
       mini-css-extract-plugin:
         specifier: ^2.9.4
         version: 2.9.4(webpack@5.104.0)
       netlify-cli:
         specifier: ^11.8.3
-        version: 11.8.3(@swc/core@1.15.8)(@types/express@4.17.21)
+        version: 11.8.3(@swc/core@1.15.8)(@types/express@4.17.21)(supports-color@9.2.3)
       null-loader:
         specifier: ^4.0.1
         version: 4.0.1(webpack@5.104.0)
@@ -815,7 +816,7 @@ importers:
     dependencies:
       '@babel/core':
         specifier: ^7.23.9
-        version: 7.23.9
+        version: 7.23.9(supports-color@9.2.3)
       '@fixtures/features':
         specifier: workspace:*
         version: link:../fixtures/features
@@ -881,10 +882,10 @@ importers:
         version: link:../packages/webpack-plugin
       babel-loader:
         specifier: ^10.0.0
-        version: 10.0.0(@babel/core@7.23.9)(webpack@5.104.0(esbuild@0.28.0))
+        version: 10.0.0(@babel/core@7.23.9)(webpack@5.104.0)
       css-loader:
         specifier: ^7.1.2
-        version: 7.1.2(webpack@5.104.0(esbuild@0.28.0))
+        version: 7.1.2(webpack@5.104.0)
       cssnano:
         specifier: ^5.1.15
         version: 5.1.15(postcss@8.5.8)
@@ -896,10 +897,10 @@ importers:
         version: 0.28.0
       html-webpack-plugin:
         specifier: ^5.3.1
-        version: 5.5.0(webpack@5.104.0(esbuild@0.28.0))
+        version: 5.5.0(webpack@5.104.0)
       mini-css-extract-plugin:
         specifier: ^2.9.4
-        version: 2.9.4(webpack@5.104.0(esbuild@0.28.0))
+        version: 2.9.4(webpack@5.104.0)
       minimist:
         specifier: ^1.2.5
         version: 1.2.8
@@ -917,19 +918,19 @@ importers:
         version: 6.1.3
       style-loader:
         specifier: ^2.0.0
-        version: 2.0.0(webpack@5.104.0(esbuild@0.28.0))
+        version: 2.0.0(webpack@5.104.0)
       vite:
         specifier: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
         version: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
       vite-plugin-inspect:
         specifier: ^11.3.0
-        version: 11.3.3(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0))
+        version: 11.3.3(supports-color@9.2.3)(vite@8.0.5)
       webpack:
         specifier: ^5.90.0
-        version: 5.104.0(esbuild@0.28.0)
+        version: 5.104.0(esbuild@0.28.0)(webpack-cli@6.0.1)
       webpack-dev-server:
         specifier: ^5.2.2
-        version: 5.2.2(webpack@5.104.0(esbuild@0.28.0))
+        version: 5.2.2(supports-color@9.2.3)(webpack-cli@6.0.1)(webpack@5.104.0)
       webpack-merge:
         specifier: ^6.0.1
         version: 6.0.1
@@ -948,7 +949,7 @@ importers:
         version: 10.0.0
       '@testing-library/jest-dom':
         specifier: ^6.4.2
-        version: 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3)))(vitest@4.1.0(@types/node@22.15.3)(happy-dom@20.8.4)(jsdom@29.0.0)(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)))
+        version: 6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0)(vitest@4.1.0)
       '@vanilla-extract-private/test-helpers':
         specifier: workspace:*
         version: link:../test-helpers
@@ -975,7 +976,7 @@ importers:
         version: link:../packages/sprinkles
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0))
+        version: 5.1.4(supports-color@9.2.3)(typescript@5.8.3)(vite@8.0.5)
 
 packages:
 
@@ -10425,6 +10426,7 @@ packages:
   tsconfck@3.1.4:
     resolution: {integrity: sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -10716,10 +10718,12 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -11272,8 +11276,8 @@ snapshots:
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
-      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0)(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0)(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
       lru-cache: 11.2.7
@@ -11295,7 +11299,7 @@ snapshots:
 
   '@babel/compat-data@7.23.5': {}
 
-  '@babel/core@7.12.9':
+  '@babel/core@7.12.9(supports-color@9.2.3)':
     dependencies:
       '@babel/code-frame': 7.24.7
       '@babel/generator': 7.23.6
@@ -11316,7 +11320,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/core@7.23.9':
+  '@babel/core@7.23.9(supports-color@9.2.3)':
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@babel/code-frame': 7.24.7
@@ -11361,7 +11365,7 @@ snapshots:
 
   '@babel/helper-create-class-features-plugin@7.23.10(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-function-name': 7.23.0
@@ -11374,14 +11378,14 @@ snapshots:
 
   '@babel/helper-create-regexp-features-plugin@7.22.15(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-annotate-as-pure': 7.22.5
       regexpu-core: 5.3.2
       semver: 6.3.1
 
-  '@babel/helper-define-polyfill-provider@0.5.0(@babel/core@7.23.9)':
+  '@babel/helper-define-polyfill-provider@0.5.0(@babel/core@7.23.9)(supports-color@9.2.3)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
       debug: 4.4.3(supports-color@9.2.3)
@@ -11411,7 +11415,7 @@ snapshots:
 
   '@babel/helper-module-transforms@7.23.3(@babel/core@7.12.9)':
     dependencies:
-      '@babel/core': 7.12.9
+      '@babel/core': 7.12.9(supports-color@9.2.3)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
@@ -11420,7 +11424,7 @@ snapshots:
 
   '@babel/helper-module-transforms@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-simple-access': 7.22.5
@@ -11437,14 +11441,14 @@ snapshots:
 
   '@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-wrap-function': 7.22.20
 
   '@babel/helper-replace-supers@7.22.20(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-member-expression-to-functions': 7.23.0
       '@babel/helper-optimise-call-expression': 7.22.5
@@ -11498,158 +11502,158 @@ snapshots:
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-transform-optional-chaining': 7.23.4(@babel/core@7.23.9)
 
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.23.7(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-proposal-object-rest-spread@7.12.1(@babel/core@7.12.9)':
     dependencies:
-      '@babel/core': 7.12.9
+      '@babel/core': 7.12.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.12.9)
 
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
     optional: true
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-import-assertions@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-import-attributes@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-jsx@7.12.1(@babel/core@7.12.9)':
     dependencies:
-      '@babel/core': 7.12.9
+      '@babel/core': 7.12.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.12.9)':
     dependencies:
-      '@babel/core': 7.12.9
+      '@babel/core': 7.12.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-typescript@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-arrow-functions@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-async-generator-functions@7.23.9(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-environment-visitor': 7.22.20
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.9)
@@ -11657,37 +11661,37 @@ snapshots:
 
   '@babel/plugin-transform-async-to-generator@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-remap-async-to-generator': 7.22.20(@babel/core@7.23.9)
 
   '@babel/plugin-transform-block-scoped-functions@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-block-scoping@7.23.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-class-properties@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-class-static-block@7.23.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.23.9)
 
   '@babel/plugin-transform-classes@7.23.8(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-environment-visitor': 7.22.20
@@ -11699,95 +11703,95 @@ snapshots:
 
   '@babel/plugin-transform-computed-properties@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/template': 7.23.9
 
   '@babel/plugin-transform-destructuring@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-dotall-regex@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-duplicate-keys@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-dynamic-import@7.23.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.23.9)
 
   '@babel/plugin-transform-exponentiation-operator@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-export-namespace-from@7.23.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.23.9)
 
   '@babel/plugin-transform-for-of@7.23.6(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
   '@babel/plugin-transform-function-name@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-function-name': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-json-strings@7.23.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.23.9)
 
   '@babel/plugin-transform-literals@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-logical-assignment-operators@7.23.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.23.9)
 
   '@babel/plugin-transform-member-expression-literals@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-modules-amd@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-modules-commonjs@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-simple-access': 7.22.5
 
   '@babel/plugin-transform-modules-systemjs@7.23.9(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-hoist-variables': 7.22.5
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
@@ -11795,37 +11799,37 @@ snapshots:
 
   '@babel/plugin-transform-modules-umd@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-module-transforms': 7.23.3(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-new-target@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.23.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.23.9)
 
   '@babel/plugin-transform-numeric-separator@7.23.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.23.9)
 
   '@babel/plugin-transform-object-rest-spread@7.23.4(@babel/core@7.23.9)':
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.23.9)
@@ -11833,42 +11837,42 @@ snapshots:
 
   '@babel/plugin-transform-object-super@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-replace-supers': 7.22.20(@babel/core@7.23.9)
 
   '@babel/plugin-transform-optional-catch-binding@7.23.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.23.9)
 
   '@babel/plugin-transform-optional-chaining@7.23.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.23.9)
 
   '@babel/plugin-transform-parameters@7.23.3(@babel/core@7.12.9)':
     dependencies:
-      '@babel/core': 7.12.9
+      '@babel/core': 7.12.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-parameters@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-private-methods@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-private-property-in-object@7.23.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
@@ -11876,22 +11880,22 @@ snapshots:
 
   '@babel/plugin-transform-property-literals@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-react-display-name@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.23.9)
 
   '@babel/plugin-transform-react-jsx@7.23.4(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-module-imports': 7.22.15
       '@babel/helper-plugin-utils': 7.22.5
@@ -11900,50 +11904,50 @@ snapshots:
 
   '@babel/plugin-transform-react-pure-annotations@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-regenerator@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.2
 
   '@babel/plugin-transform-reserved-words@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-shorthand-properties@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-spread@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
   '@babel/plugin-transform-sticky-regex@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-template-literals@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-typeof-symbol@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-typescript@7.23.6(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-annotate-as-pure': 7.22.5
       '@babel/helper-create-class-features-plugin': 7.23.10(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
@@ -11951,31 +11955,31 @@ snapshots:
 
   '@babel/plugin-transform-unicode-escapes@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-unicode-property-regex@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-unicode-regex@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
 
   '@babel/plugin-transform-unicode-sets-regex@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-create-regexp-features-plugin': 7.22.15(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.22.5
 
-  '@babel/preset-env@7.23.9(@babel/core@7.23.9)':
+  '@babel/preset-env@7.23.9(@babel/core@7.23.9)(supports-color@9.2.3)':
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.23.5
@@ -12050,7 +12054,7 @@ snapshots:
       '@babel/plugin-transform-unicode-regex': 7.23.3(@babel/core@7.23.9)
       '@babel/plugin-transform-unicode-sets-regex': 7.23.3(@babel/core@7.23.9)
       '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.23.9)
-      babel-plugin-polyfill-corejs2: 0.4.8(@babel/core@7.23.9)
+      babel-plugin-polyfill-corejs2: 0.4.8(@babel/core@7.23.9)(supports-color@9.2.3)
       babel-plugin-polyfill-corejs3: 0.9.0(@babel/core@7.23.9)
       babel-plugin-polyfill-regenerator: 0.5.5(@babel/core@7.23.9)
       core-js-compat: 3.36.0
@@ -12060,14 +12064,14 @@ snapshots:
 
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/types': 7.23.9
       esutils: 2.0.3
 
   '@babel/preset-react@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-transform-react-display-name': 7.23.3(@babel/core@7.23.9)
@@ -12077,7 +12081,7 @@ snapshots:
 
   '@babel/preset-typescript@7.23.3(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.22.5
       '@babel/helper-validator-option': 7.23.5
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.23.9)
@@ -12327,15 +12331,15 @@ snapshots:
 
   '@csstools/color-helpers@6.0.2': {}
 
-  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-calc@3.1.1(@csstools/css-parser-algorithms@4.0.0)(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0)(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/color-helpers': 6.0.2
-      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0)(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
@@ -12361,7 +12365,7 @@ snapshots:
 
   '@docsearch/css@3.3.3': {}
 
-  '@docsearch/react@3.3.3(@algolia/client-search@4.22.1)(@types/react@18.2.55)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@docsearch/react@3.3.3(@algolia/client-search@4.22.1)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)':
     dependencies:
       '@algolia/autocomplete-core': 1.7.4
       '@algolia/autocomplete-preset-algolia': 1.7.4(@algolia/client-search@4.22.1)(algoliasearch@4.14.3)
@@ -12676,7 +12680,7 @@ snapshots:
       slash: 3.0.0
     optional: true
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3))':
+  '@jest/core@29.7.0(ts-node@10.9.1)':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -12690,7 +12694,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -12812,7 +12816,7 @@ snapshots:
 
   '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
       babel-plugin-istanbul: 6.1.1
@@ -13019,9 +13023,9 @@ snapshots:
       unified: 6.2.0
       unist-util-visit: 1.4.1
 
-  '@mdx-js/mdx@1.6.22':
+  '@mdx-js/mdx@1.6.22(supports-color@9.2.3)':
     dependencies:
-      '@babel/core': 7.12.9
+      '@babel/core': 7.12.9(supports-color@9.2.3)
       '@babel/plugin-syntax-jsx': 7.12.1(@babel/core@7.12.9)
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
       '@mdx-js/util': 1.6.22
@@ -14318,7 +14322,7 @@ snapshots:
   '@preconstruct/cli@2.8.2':
     dependencies:
       '@babel/code-frame': 7.24.7
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/helper-module-imports': 7.22.15
       '@babel/runtime': 7.28.4
       '@preconstruct/hook': 0.4.0
@@ -14360,7 +14364,7 @@ snapshots:
 
   '@preconstruct/hook@0.4.0':
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/plugin-transform-modules-commonjs': 7.23.3(@babel/core@7.23.9)
       pirates: 4.0.5
       source-map-support: 0.5.21
@@ -14728,7 +14732,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3)))(vitest@4.1.0(@types/node@22.15.3)(happy-dom@20.8.4)(jsdom@29.0.0)(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)))':
+  '@testing-library/jest-dom@6.4.2(@jest/globals@29.7.0)(@types/jest@29.5.12)(jest@29.7.0)(vitest@4.1.0)':
     dependencies:
       '@adobe/css-tools': 4.3.3
       '@babel/runtime': 7.28.4
@@ -14741,8 +14745,8 @@ snapshots:
     optionalDependencies:
       '@jest/globals': 29.7.0
       '@types/jest': 29.5.12
-      jest: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3))
-      vitest: 4.1.0(@types/node@22.15.3)(happy-dom@20.8.4)(jsdom@29.0.0)(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0))
+      jest: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1)
+      vitest: 4.1.0(@types/node@22.15.3)(happy-dom@20.8.4)(jsdom@29.0.0)(vite@8.0.5)
 
   '@trysound/sax@0.2.0': {}
 
@@ -14932,7 +14936,7 @@ snapshots:
     dependencies:
       '@types/node': 22.15.3
       tapable: 2.3.0
-      webpack: 5.104.0(esbuild@0.28.0)
+      webpack: 5.104.0(esbuild@0.28.0)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -15157,7 +15161,7 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.1.0(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.0(vite@8.0.5)':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
@@ -15280,7 +15284,7 @@ snapshots:
       webpack: 5.104.0(esbuild@0.28.0)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.104.0)
     optionalDependencies:
-      webpack-dev-server: 5.2.2(webpack-cli@6.0.1)(webpack@5.104.0)
+      webpack-dev-server: 5.2.2(supports-color@9.2.3)(webpack-cli@6.0.1)(webpack@5.104.0)
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -15531,7 +15535,7 @@ snapshots:
 
   babel-jest@29.7.0(@babel/core@7.23.9):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
@@ -15543,21 +15547,15 @@ snapshots:
       - supports-color
     optional: true
 
-  babel-loader@10.0.0(@babel/core@7.23.9)(webpack@5.104.0(esbuild@0.28.0)):
-    dependencies:
-      '@babel/core': 7.23.9
-      find-up: 5.0.0
-      webpack: 5.104.0(esbuild@0.28.0)
-
   babel-loader@10.0.0(@babel/core@7.23.9)(webpack@5.104.0):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       find-up: 5.0.0
       webpack: 5.104.0(esbuild@0.28.0)(webpack-cli@6.0.1)
 
   babel-plugin-apply-mdx-type-prop@1.6.22(@babel/core@7.12.9):
     dependencies:
-      '@babel/core': 7.12.9
+      '@babel/core': 7.12.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.10.4
       '@mdx-js/util': 1.6.22
 
@@ -15583,33 +15581,33 @@ snapshots:
       '@types/babel__traverse': 7.20.5
     optional: true
 
-  babel-plugin-polyfill-corejs2@0.4.8(@babel/core@7.23.9):
+  babel-plugin-polyfill-corejs2@0.4.8(@babel/core@7.23.9)(supports-color@9.2.3):
     dependencies:
       '@babel/compat-data': 7.23.5
-      '@babel/core': 7.23.9
-      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.23.9)
+      '@babel/core': 7.23.9(supports-color@9.2.3)
+      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.23.9)(supports-color@9.2.3)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
   babel-plugin-polyfill-corejs3@0.9.0(@babel/core@7.23.9):
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.23.9)
+      '@babel/core': 7.23.9(supports-color@9.2.3)
+      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.23.9)(supports-color@9.2.3)
       core-js-compat: 3.36.0
     transitivePeerDependencies:
       - supports-color
 
   babel-plugin-polyfill-regenerator@0.5.5(@babel/core@7.23.9):
     dependencies:
-      '@babel/core': 7.23.9
-      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.23.9)
+      '@babel/core': 7.23.9(supports-color@9.2.3)
+      '@babel/helper-define-polyfill-provider': 0.5.0(@babel/core@7.23.9)(supports-color@9.2.3)
     transitivePeerDependencies:
       - supports-color
 
   babel-preset-current-node-syntax@1.0.1(@babel/core@7.23.9):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.23.9)
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.23.9)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.9)
@@ -15626,7 +15624,7 @@ snapshots:
 
   babel-preset-jest@29.6.3(@babel/core@7.23.9):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.23.9)
     optional: true
@@ -16177,7 +16175,7 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  compression@1.8.1:
+  compression@1.8.1(supports-color@9.2.3):
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
@@ -16247,7 +16245,7 @@ snapshots:
 
   copy-descriptor@0.1.1: {}
 
-  copy-template-dir@1.4.0:
+  copy-template-dir@1.4.0(supports-color@9.2.3):
     dependencies:
       end-of-stream: 1.4.4
       graceful-fs: 4.2.11
@@ -16256,7 +16254,7 @@ snapshots:
       mkdirp: 0.5.5
       noop2: 2.0.0
       pump: 1.0.3
-      readdirp: 2.2.1
+      readdirp: 2.2.1(supports-color@9.2.3)
       run-parallel: 1.2.0
     transitivePeerDependencies:
       - supports-color
@@ -16311,13 +16309,13 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 3.6.0
 
-  create-jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3)):
+  create-jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -16344,19 +16342,6 @@ snapshots:
   css-declaration-sorter@6.3.1(postcss@8.5.8):
     dependencies:
       postcss: 8.5.8
-
-  css-loader@7.1.2(webpack@5.104.0(esbuild@0.28.0)):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.8)
-      postcss: 8.5.8
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.8)
-      postcss-modules-local-by-default: 4.0.5(postcss@8.5.8)
-      postcss-modules-scope: 3.2.0(postcss@8.5.8)
-      postcss-modules-values: 4.0.0(postcss@8.5.8)
-      postcss-value-parser: 4.2.0
-      semver: 7.7.3
-    optionalDependencies:
-      webpack: 5.104.0(esbuild@0.28.0)
 
   css-loader@7.1.2(webpack@5.104.0):
     dependencies:
@@ -17823,15 +17808,6 @@ snapshots:
 
   html-void-elements@1.0.5: {}
 
-  html-webpack-plugin@5.5.0(webpack@5.104.0(esbuild@0.28.0)):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.17.21
-      pretty-error: 4.0.0
-      tapable: 2.3.0
-      webpack: 5.104.0(esbuild@0.28.0)
-
   html-webpack-plugin@5.5.0(webpack@5.104.0):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -18258,7 +18234,7 @@ snapshots:
 
   istanbul-lib-instrument@5.1.0:
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/parser': 7.23.9
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
@@ -18268,7 +18244,7 @@ snapshots:
 
   istanbul-lib-instrument@6.0.1:
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/parser': 7.23.9
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
@@ -18340,16 +18316,16 @@ snapshots:
       - supports-color
     optional: true
 
-  jest-cli@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3)):
+  jest-cli@29.7.0(@types/node@22.15.3)(ts-node@10.9.1):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3))
+      '@jest/core': 29.7.0(ts-node@10.9.1)
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3))
+      create-jest: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1)
       exit: 0.1.2
       import-local: 3.0.3
-      jest-config: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3))
+      jest-config: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -18360,9 +18336,9 @@ snapshots:
       - ts-node
     optional: true
 
-  jest-config@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3)):
+  jest-config@29.7.0(@types/node@22.15.3)(ts-node@10.9.1):
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.23.9)
@@ -18566,7 +18542,7 @@ snapshots:
 
   jest-snapshot@29.7.0:
     dependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
       '@babel/generator': 7.23.6
       '@babel/plugin-syntax-jsx': 7.23.3(@babel/core@7.23.9)
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.23.9)
@@ -18658,12 +18634,12 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3)):
+  jest@29.7.0(@types/node@22.15.3)(ts-node@10.9.1):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3))
+      '@jest/core': 29.7.0(ts-node@10.9.1)
       '@jest/types': 29.6.3
       import-local: 3.0.3
-      jest-cli: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1(@swc/core@1.15.8)(@types/node@22.15.3)(typescript@5.8.3))
+      jest-cli: 29.7.0(@types/node@22.15.3)(ts-node@10.9.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -19199,9 +19175,9 @@ snapshots:
 
   mdx-constant@0.1.0: {}
 
-  mdx-loader@3.0.2(react@18.2.0):
+  mdx-loader@3.0.2(react@18.2.0)(supports-color@9.2.3):
     dependencies:
-      '@mdx-js/mdx': 1.6.22
+      '@mdx-js/mdx': 1.6.22(supports-color@9.2.3)
       '@mdx-js/react': 1.6.22(react@18.2.0)
       gray-matter: 4.0.3
       hast-util-to-string: 1.0.4
@@ -19333,12 +19309,6 @@ snapshots:
   mimic-response@2.1.0: {}
 
   min-indent@1.0.1: {}
-
-  mini-css-extract-plugin@2.9.4(webpack@5.104.0(esbuild@0.28.0)):
-    dependencies:
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      webpack: 5.104.0(esbuild@0.28.0)
 
   mini-css-extract-plugin@2.9.4(webpack@5.104.0):
     dependencies:
@@ -19473,7 +19443,7 @@ snapshots:
 
   nested-error-stacks@2.1.1: {}
 
-  netlify-cli@11.8.3(@swc/core@1.15.8)(@types/express@4.17.21):
+  netlify-cli@11.8.3(@swc/core@1.15.8)(@types/express@4.17.21)(supports-color@9.2.3):
     dependencies:
       '@netlify/build': 27.18.5(@swc/core@1.15.8)
       '@netlify/config': 18.2.3
@@ -19500,7 +19470,7 @@ snapshots:
       configstore: 5.0.1
       content-type: 1.0.5
       cookie: 0.5.0
-      copy-template-dir: 1.4.0
+      copy-template-dir: 1.4.0(supports-color@9.2.3)
       cron-parser: 4.6.0
       debug: 4.4.3(supports-color@9.2.3)
       decache: 4.6.1
@@ -19570,7 +19540,7 @@ snapshots:
       static-server: 2.2.1
       string-similarity: 4.0.4
       strip-ansi-control-characters: 2.0.0
-      tabtab: 3.0.2
+      tabtab: 3.0.2(supports-color@9.2.3)
       tempy: 1.0.1
       terminal-link: 2.1.1
       through2-filter: 3.0.0
@@ -19580,7 +19550,7 @@ snapshots:
       unixify: 1.0.0
       update-notifier: 5.1.0
       uuid: 8.3.2
-      wait-port: 0.3.1
+      wait-port: 0.3.1(supports-color@9.2.3)
       winston: 3.8.2
       write-file-atomic: 4.0.2
     transitivePeerDependencies:
@@ -19628,7 +19598,7 @@ snapshots:
       p-wait-for: 4.1.0
       qs: 6.14.0
 
-  next@12.3.4(@babel/core@7.23.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@12.3.4(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0):
     dependencies:
       '@next/env': 12.3.4
       '@swc/helpers': 0.4.11
@@ -19656,7 +19626,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@12.3.4(@babel/core@7.23.9)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@12.3.4(@babel/core@7.23.9)(react-dom@19.2.3)(react@19.2.3):
     dependencies:
       '@next/env': 12.3.4
       '@swc/helpers': 0.4.11
@@ -19684,7 +19654,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@13.5.11(@babel/core@7.23.9)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  next@13.5.11(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0):
     dependencies:
       '@next/env': 13.5.11
       '@swc/helpers': 0.5.2
@@ -19709,7 +19679,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.1(@babel/core@7.23.9)(@playwright/test@1.61.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  next@16.1.1(@babel/core@7.23.9)(@playwright/test@1.61.0)(react-dom@19.2.3)(react@19.2.3):
     dependencies:
       '@next/env': 16.1.1
       '@swc/helpers': 0.5.15
@@ -20685,7 +20655,7 @@ snapshots:
       react: 19.2.3
       scheduler: 0.27.0
 
-  react-head@3.4.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  react-head@3.4.2(react-dom@18.2.0)(react@18.2.0):
     dependencies:
       '@babel/runtime': 7.28.4
       react: 18.2.0
@@ -20700,18 +20670,18 @@ snapshots:
 
   react-refresh@0.16.0: {}
 
-  react-router-dom@6.30.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  react-router-dom@6.30.0(react-dom@18.2.0)(react@18.2.0):
     dependencies:
       '@remix-run/router': 1.23.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-router: 6.30.0(react@18.2.0)
 
-  react-router-hash-link@2.4.3(react-router-dom@6.30.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0):
+  react-router-hash-link@2.4.3(react-router-dom@6.30.0)(react@18.2.0):
     dependencies:
       prop-types: 15.8.1
       react: 18.2.0
-      react-router-dom: 6.30.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-router-dom: 6.30.0(react-dom@18.2.0)(react@18.2.0)
 
   react-router@6.30.0(react@18.2.0):
     dependencies:
@@ -20792,7 +20762,7 @@ snapshots:
     dependencies:
       minimatch: 5.1.0
 
-  readdirp@2.2.1:
+  readdirp@2.2.1(supports-color@9.2.3):
     dependencies:
       graceful-fs: 4.2.11
       micromatch: 3.1.10(supports-color@9.2.3)
@@ -20885,7 +20855,7 @@ snapshots:
 
   remark-mdx@1.6.22:
     dependencies:
-      '@babel/core': 7.12.9
+      '@babel/core': 7.12.9(supports-color@9.2.3)
       '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-proposal-object-rest-spread': 7.12.1(@babel/core@7.12.9)
       '@babel/plugin-syntax-jsx': 7.12.1(@babel/core@7.12.9)
@@ -21088,7 +21058,7 @@ snapshots:
     optionalDependencies:
       '@babel/code-frame': 7.24.7
 
-  rollup-plugin-esbuild@6.1.1(esbuild@0.28.0)(rollup@4.59.0):
+  rollup-plugin-esbuild@6.1.1(esbuild@0.28.0)(rollup@4.59.0)(supports-color@9.2.3):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.59.0)
       debug: 4.4.3(supports-color@9.2.3)
@@ -21279,7 +21249,7 @@ snapshots:
       path-to-regexp: 2.2.1
       range-parser: 1.2.0
 
-  serve-index@1.9.1:
+  serve-index@1.9.1(supports-color@9.2.3):
     dependencies:
       accepts: 1.3.8
       batch: 0.6.1
@@ -21522,7 +21492,7 @@ snapshots:
 
   spdx-license-ids@3.0.11: {}
 
-  spdy-transport@3.0.0:
+  spdy-transport@3.0.0(supports-color@9.2.3):
     dependencies:
       debug: 4.4.3(supports-color@9.2.3)
       detect-node: 2.1.0
@@ -21533,13 +21503,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  spdy@4.0.2:
+  spdy@4.0.2(supports-color@9.2.3):
     dependencies:
       debug: 4.4.3(supports-color@9.2.3)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
-      spdy-transport: 3.0.0
+      spdy-transport: 3.0.0(supports-color@9.2.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -21692,11 +21662,11 @@ snapshots:
     dependencies:
       escape-string-regexp: 1.0.5
 
-  style-loader@2.0.0(webpack@5.104.0(esbuild@0.28.0)):
+  style-loader@2.0.0(webpack@5.104.0):
     dependencies:
       loader-utils: 2.0.2
       schema-utils: 3.3.0
-      webpack: 5.104.0(esbuild@0.28.0)
+      webpack: 5.104.0(esbuild@0.28.0)(webpack-cli@6.0.1)
 
   style-to-object@0.3.0:
     dependencies:
@@ -21706,27 +21676,27 @@ snapshots:
     dependencies:
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
 
   styled-jsx@5.0.7(@babel/core@7.23.9)(react@19.2.3):
     dependencies:
       react: 19.2.3
     optionalDependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
 
   styled-jsx@5.1.1(@babel/core@7.23.9)(react@18.2.0):
     dependencies:
       client-only: 0.0.1
       react: 18.2.0
     optionalDependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
 
   styled-jsx@5.1.6(@babel/core@7.23.9)(react@19.2.3):
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
     optionalDependencies:
-      '@babel/core': 7.23.9
+      '@babel/core': 7.23.9(supports-color@9.2.3)
 
   stylehacks@5.1.1(postcss@8.5.8):
     dependencies:
@@ -21778,7 +21748,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tabtab@3.0.2:
+  tabtab@3.0.2(supports-color@9.2.3):
     dependencies:
       debug: 4.4.3(supports-color@9.2.3)
       es6-promisify: 6.1.1
@@ -21847,17 +21817,6 @@ snapshots:
       webpack: 5.104.0(@swc/core@1.15.8)(esbuild@0.28.0)(webpack-cli@6.0.1)
     optionalDependencies:
       '@swc/core': 1.15.8
-      esbuild: 0.28.0
-
-  terser-webpack-plugin@5.3.16(esbuild@0.28.0)(webpack@5.104.0(esbuild@0.28.0)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
-      terser: 5.44.1
-      webpack: 5.104.0(esbuild@0.28.0)
-    optionalDependencies:
       esbuild: 0.28.0
 
   terser-webpack-plugin@5.3.16(esbuild@0.28.0)(webpack@5.104.0):
@@ -22389,13 +22348,13 @@ snapshots:
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
 
-  vite-dev-rpc@1.1.0(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)):
+  vite-dev-rpc@1.1.0(vite@8.0.5):
     dependencies:
       birpc: 2.9.0
       vite: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
-      vite-hot-client: 2.1.0(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0))
+      vite-hot-client: 2.1.0(vite@8.0.5)
 
-  vite-hot-client@2.1.0(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)):
+  vite-hot-client@2.1.0(vite@8.0.5):
     dependencies:
       vite: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
 
@@ -22420,7 +22379,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-inspect@11.3.3(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)):
+  vite-plugin-inspect@11.3.3(supports-color@9.2.3)(vite@8.0.5):
     dependencies:
       ansis: 4.2.0
       debug: 4.4.3(supports-color@9.2.3)
@@ -22431,11 +22390,11 @@ snapshots:
       sirv: 3.0.2
       unplugin-utils: 0.3.1
       vite: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
-      vite-dev-rpc: 1.1.0(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0))
+      vite-dev-rpc: 1.1.0(vite@8.0.5)
     transitivePeerDependencies:
       - supports-color
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)):
+  vite-tsconfig-paths@5.1.4(supports-color@9.2.3)(typescript@5.8.3)(vite@8.0.5):
     dependencies:
       debug: 4.4.3(supports-color@9.2.3)
       globrex: 0.1.2
@@ -22461,10 +22420,10 @@ snapshots:
       terser: 5.44.1
       tsx: 4.21.0
 
-  vitest@4.1.0(@types/node@22.15.3)(happy-dom@20.8.4)(jsdom@29.0.0)(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)):
+  vitest@4.1.0(@types/node@22.15.3)(happy-dom@20.8.4)(jsdom@29.0.0)(vite@8.0.5):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.0(vite@8.0.5)
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -22494,7 +22453,7 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  wait-port@0.3.1:
+  wait-port@0.3.1(supports-color@9.2.3):
     dependencies:
       chalk: 4.1.2
       commander: 9.4.0
@@ -22588,18 +22547,7 @@ snapshots:
       webpack: 5.104.0(esbuild@0.28.0)(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
     optionalDependencies:
-      webpack-dev-server: 5.2.2(webpack-cli@6.0.1)(webpack@5.104.0)
-
-  webpack-dev-middleware@7.4.5(webpack@5.104.0(esbuild@0.28.0)):
-    dependencies:
-      colorette: 2.0.16
-      memfs: 4.51.1
-      mime-types: 3.0.2
-      on-finished: 2.4.1
-      range-parser: 1.2.1
-      schema-utils: 4.3.3
-    optionalDependencies:
-      webpack: 5.104.0(esbuild@0.28.0)
+      webpack-dev-server: 5.2.2(supports-color@9.2.3)(webpack-cli@6.0.1)(webpack@5.104.0)
 
   webpack-dev-middleware@7.4.5(webpack@5.104.0):
     dependencies:
@@ -22611,6 +22559,45 @@ snapshots:
       schema-utils: 4.3.3
     optionalDependencies:
       webpack: 5.104.0(esbuild@0.28.0)(webpack-cli@6.0.1)
+
+  webpack-dev-server@5.2.2(supports-color@9.2.3)(webpack-cli@6.0.1)(webpack@5.104.0):
+    dependencies:
+      '@types/bonjour': 3.5.13
+      '@types/connect-history-api-fallback': 1.5.4
+      '@types/express': 4.17.21
+      '@types/express-serve-static-core': 4.19.5
+      '@types/serve-index': 1.9.4
+      '@types/serve-static': 1.15.7
+      '@types/sockjs': 0.3.36
+      '@types/ws': 8.18.1
+      ansi-html-community: 0.0.8
+      bonjour-service: 1.2.1
+      chokidar: 3.6.0
+      colorette: 2.0.16
+      compression: 1.8.1(supports-color@9.2.3)
+      connect-history-api-fallback: 2.0.0
+      express: 4.22.1
+      graceful-fs: 4.2.11
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.3)
+      ipaddr.js: 2.1.0
+      launch-editor: 2.6.1
+      open: 10.2.0
+      p-retry: 6.2.0
+      schema-utils: 4.3.3
+      selfsigned: 2.4.1
+      serve-index: 1.9.1(supports-color@9.2.3)
+      sockjs: 0.3.24
+      spdy: 4.0.2(supports-color@9.2.3)
+      webpack-dev-middleware: 7.4.5(webpack@5.104.0)
+      ws: 8.18.3
+    optionalDependencies:
+      webpack: 5.104.0(esbuild@0.28.0)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.104.0)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
 
   webpack-dev-server@5.2.2(webpack-cli@6.0.1)(webpack@5.104.0):
     dependencies:
@@ -22626,7 +22613,7 @@ snapshots:
       bonjour-service: 1.2.1
       chokidar: 3.6.0
       colorette: 2.0.16
-      compression: 1.8.1
+      compression: 1.8.1(supports-color@9.2.3)
       connect-history-api-fallback: 2.0.0
       express: 4.22.1
       graceful-fs: 4.2.11
@@ -22637,52 +22624,14 @@ snapshots:
       p-retry: 6.2.0
       schema-utils: 4.3.3
       selfsigned: 2.4.1
-      serve-index: 1.9.1
+      serve-index: 1.9.1(supports-color@9.2.3)
       sockjs: 0.3.24
-      spdy: 4.0.2
+      spdy: 4.0.2(supports-color@9.2.3)
       webpack-dev-middleware: 7.4.5(webpack@5.104.0)
       ws: 8.18.3
     optionalDependencies:
-      webpack: 5.104.0(esbuild@0.28.0)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.2)(webpack@5.104.0)
-    transitivePeerDependencies:
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-
-  webpack-dev-server@5.2.2(webpack@5.104.0(esbuild@0.28.0)):
-    dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 4.17.21
-      '@types/express-serve-static-core': 4.19.5
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 1.15.7
-      '@types/sockjs': 0.3.36
-      '@types/ws': 8.18.1
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.2.1
-      chokidar: 3.6.0
-      colorette: 2.0.16
-      compression: 1.8.1
-      connect-history-api-fallback: 2.0.0
-      express: 4.22.1
-      graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.3)
-      ipaddr.js: 2.1.0
-      launch-editor: 2.6.1
-      open: 10.2.0
-      p-retry: 6.2.0
-      schema-utils: 4.3.3
-      selfsigned: 2.4.1
-      serve-index: 1.9.1
-      sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(webpack@5.104.0(esbuild@0.28.0))
-      ws: 8.18.3
-    optionalDependencies:
-      webpack: 5.104.0(esbuild@0.28.0)
+      webpack: 5.104.0(@swc/core@1.15.8)(esbuild@0.28.0)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-bundle-analyzer@5.1.0)(webpack-dev-server@5.2.2)(webpack@5.104.0)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -22728,38 +22677,6 @@ snapshots:
       webpack-sources: 3.3.3
     optionalDependencies:
       webpack-cli: 6.0.1(webpack-bundle-analyzer@5.1.0)(webpack-dev-server@5.2.2)(webpack@5.104.0)
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-
-  webpack@5.104.0(esbuild@0.28.0):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.18.4
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.34
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.3.16(esbuild@0.28.0)(webpack@5.104.0(esbuild@0.28.0))
-      watchpack: 2.4.4
-      webpack-sources: 3.3.3
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,20 @@ packages:
   - 'examples/*'
   - 'tests'
   - 'scripts'
+dedupePeers: true
+
+minimumReleaseAge: 4320
+trustPolicy: no-downgrade
+trustPolicyExclude:
+  - semver
+  - undici-types
+blockExoticSubdeps: true
+allowBuilds:
+  '@netlify/esbuild': false
+  '@swc/core': false
+  esbuild: false
+  lmdb: false
+  modern-ahocorasick: false
+  msgpackr-extract: false
+  netlify-cli: false
+  sharp: false


### PR DESCRIPTION
Updates PNPM and sets some security controls in the workspace file. Also adds back `--no-bail` to the `lint` script so all scripts run even when one fails (originally removed due to a bug that has since been fixed in [11.8.0](https://github.com/pnpm/pnpm/releases/tag/v11.8.0#:~:text=no%2Dbail)).

Also fixed sharding - only 2 shard were running, but 4 where being made. I want only 2, so that's fixed now.