### PR TITLE
fix(rollup-plugin): use basename for emitFile name to avoid rolldown rejecting relative paths

### DIFF
--- a/.changeset/rollup-plugin-emitfile-relative-path.md
+++ b/.changeset/rollup-plugin-emitfile-relative-path.md
@@ -1,0 +1,7 @@
+---
+'@vanilla-extract/rollup-plugin': patch
+---
+
+Fixed an issue where builds using rolldown could fail when a `.css.ts` file imports across packages
+
+`renderChunk` passed `moduleInfo.id` directly as the `name` for `emitFile`, which can be a relative path (e.g. `../styles/foo.css.ts.vanilla.css`) for cross-package imports. Recent rolldown versions reject relative or absolute paths in the `name` field, throwing `The "fileName" or "name" properties of emitted chunks and assets must be strings that are neither absolute nor relative paths`. The `name` is now stripped to its basename, which rolldown accepts and which still produces the same final asset filename via `assetFileNames`.

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -16,7 +16,7 @@ import {
   tryGetPackageName,
 } from './lib';
 
-const { relative, normalize, dirname } = posix;
+const { relative, normalize, dirname, basename } = posix;
 
 export interface Options {
   /**
@@ -157,9 +157,11 @@ export function vanillaExtractPlugin({
           return codeResult;
         }
 
+        // Strip directory: rolldown rejects relative/absolute paths in `name`,
+        // and `moduleInfo.id` can be relative for cross-package `.css.ts` imports.
         const assetId = this.emitFile({
           type: 'asset',
-          name: moduleInfo.id,
+          name: basename(moduleInfo.id),
           source: moduleInfo.meta.css,
         });
         const assetPath = this.getFileName(assetId);

--- a/packages/rollup-plugin/test/__snapshots__/rollup-plugin.test.ts.snap
+++ b/packages/rollup-plugin/test/__snapshots__/rollup-plugin.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`rollup-plugin > Rollup settings > should build with preserveModules 1`] = `
 [
   [
-    "assets/src/shared.css.ts.vanilla-G_Gyt4-e.css",
+    "assets/shared.css.ts.vanilla-G_Gyt4-e.css",
     ".shared_shadow__4dtfen0 {
   box-shadow: 0 0 5px red;
 }
@@ -15,7 +15,7 @@ body, button {
 }",
   ],
   [
-    "assets/src/styles.css.ts.vanilla-BfisGtko.css",
+    "assets/styles.css.ts.vanilla-BfisGtko.css",
     "@font-face {
   src: local("Impact");
   font-family: "styles_impact__jteyb10";
@@ -73,7 +73,7 @@ html .styles_opacity_1\\/4__jteyb17 {
 }",
   ],
   [
-    "assets/src/themes.css.ts.vanilla-s9rcEmBH.css",
+    "assets/themes.css.ts.vanilla-s9rcEmBH.css",
     "@layer themes_themeLayer__cvta177;
 @layer globalThemeLayer;
 :root, .themes_theme__cvta170 {
@@ -208,7 +208,7 @@ render();
   ],
   [
     "src/shared.css.js",
-    "import './../assets/src/shared.css.ts.vanilla-G_Gyt4-e.css';
+    "import './../assets/shared.css.ts.vanilla-G_Gyt4-e.css';
 
 var shadow = "shared_shadow__4dtfen0";
 
@@ -217,9 +217,9 @@ export { shadow };
   ],
   [
     "src/styles.css.js",
-    "import './../assets/src/shared.css.ts.vanilla-G_Gyt4-e.css';
-import './../assets/src/themes.css.ts.vanilla-s9rcEmBH.css';
-import './../assets/src/styles.css.ts.vanilla-BfisGtko.css';
+    "import './../assets/shared.css.ts.vanilla-G_Gyt4-e.css';
+import './../assets/themes.css.ts.vanilla-s9rcEmBH.css';
+import './../assets/styles.css.ts.vanilla-BfisGtko.css';
 
 var button = "styles_button__jteyb13 shared_shadow__4dtfen0 styles_iDunno__jteyb12";
 var container = "styles_container__jteyb11";
@@ -230,7 +230,7 @@ export { button, container, opacity };
   ],
   [
     "src/themes.css.js",
-    "import './../assets/src/themes.css.ts.vanilla-s9rcEmBH.css';
+    "import './../assets/themes.css.ts.vanilla-s9rcEmBH.css';
 
 var altTheme = "themes_altTheme__cvta176";
 var responsiveTheme = "themes_responsiveTheme__cvta17e";
@@ -854,15 +854,15 @@ export { altButton, altContainer, testNodes as default, dynamicVarsButton, dynam
 exports[`rollup-plugin > Rollup settings > should build with sourcemaps 1`] = `
 [
   [
-    "assets/src/shared.css.ts.vanilla-G_Gyt4-e.css",
+    "assets/shared.css.ts.vanilla-G_Gyt4-e.css",
     "",
   ],
   [
-    "assets/src/styles.css.ts.vanilla-BfisGtko.css",
+    "assets/styles.css.ts.vanilla-BfisGtko.css",
     "",
   ],
   [
-    "assets/src/themes.css.ts.vanilla-s9rcEmBH.css",
+    "assets/themes.css.ts.vanilla-s9rcEmBH.css",
     "",
   ],
   [
@@ -911,7 +911,7 @@ exports[`rollup-plugin > Rollup settings > should build with sourcemaps 1`] = `
 exports[`rollup-plugin > Rollup settings > should build without preserveModules 1`] = `
 [
   [
-    "assets/src/shared.css.ts.vanilla-G_Gyt4-e.css",
+    "assets/shared.css.ts.vanilla-G_Gyt4-e.css",
     ".shared_shadow__4dtfen0 {
   box-shadow: 0 0 5px red;
 }
@@ -923,7 +923,7 @@ body, button {
 }",
   ],
   [
-    "assets/src/styles.css.ts.vanilla-BfisGtko.css",
+    "assets/styles.css.ts.vanilla-BfisGtko.css",
     "@font-face {
   src: local("Impact");
   font-family: "styles_impact__jteyb10";
@@ -981,7 +981,7 @@ html .styles_opacity_1\\/4__jteyb17 {
 }",
   ],
   [
-    "assets/src/themes.css.ts.vanilla-s9rcEmBH.css",
+    "assets/themes.css.ts.vanilla-s9rcEmBH.css",
     "@layer themes_themeLayer__cvta177;
 @layer globalThemeLayer;
 :root, .themes_theme__cvta170 {
@@ -1033,9 +1033,9 @@ html .styles_opacity_1\\/4__jteyb17 {
   [
     "index.js",
     "import { assignInlineVars, setElementVars } from '@vanilla-extract/dynamic';
-import './assets/src/themes.css.ts.vanilla-s9rcEmBH.css';
-import './assets/src/shared.css.ts.vanilla-G_Gyt4-e.css';
-import './assets/src/styles.css.ts.vanilla-BfisGtko.css';
+import './assets/themes.css.ts.vanilla-s9rcEmBH.css';
+import './assets/shared.css.ts.vanilla-G_Gyt4-e.css';
+import './assets/styles.css.ts.vanilla-BfisGtko.css';
 
 var altTheme = "themes_altTheme__cvta176";
 var responsiveTheme = "themes_responsiveTheme__cvta17e";

--- a/packages/rollup-plugin/test/rollup-plugin.test.ts
+++ b/packages/rollup-plugin/test/rollup-plugin.test.ts
@@ -382,6 +382,30 @@ describe('rollup-plugin', () => {
         ]),
       ).toMatchSnapshot();
     });
+
+    it('strips directory prefix from emitted .css asset names for cross-package .css.ts imports', async () => {
+      const cwd = path.dirname(
+        require.resolve('@fixtures/thirdparty/package.json'),
+      );
+      const bundle = await rolldown({
+        input: path.join(cwd, 'src/index.ts'),
+        external: ['@vanilla-extract/dynamic', '@vanilla-extract/css'],
+        plugins: [vanillaExtractPlugin({ cwd })],
+      });
+      const { output } = await bundle.generate({
+        format: 'esm',
+        assetFileNames: '[name][extname]',
+      });
+      const cssAssets = output.filter(
+        (file): file is OutputAsset =>
+          file.type === 'asset' && file.fileName.endsWith('.css'),
+      );
+      expect(cssAssets.length).toBeGreaterThan(0);
+      for (const asset of cssAssets) {
+        expect(asset.name).toBeDefined();
+        expect(asset.name).not.toContain('/');
+      }
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

When a `.css.ts` file imports from another package, `moduleInfo.id` in `renderChunk` resolves to a relative path like `../thirdparty-dep/styles.css.ts.vanilla.css`. This was passed directly as the `name` field to `emitFile`. Recent rolldown versions (rc.12+) reject relative or absolute paths in `name`, throwing:

```
Error: The "fileName" or "name" properties of emitted chunks and assets must be strings
that are neither absolute nor relative paths, received "../thirdparty-dep/styles.css.ts.vanilla.css".
```

Stripping `moduleInfo.id` to its basename keeps the resolved filename identical (via `assetFileNames`) and avoids the rejected prefix.

Closes #1715

## Test plan

- [x] Added a regression test under the existing rolldown describe block that builds the `@fixtures/thirdparty` fixture (which imports `.css.ts` across package boundaries) and asserts emitted CSS asset names contain no `/` separator. Verified the test fails on master and passes with this fix.
- [x] All 16 `packages/rollup-plugin` tests pass.
- [x] Existing rolldown snapshots updated to reflect basenames replacing prefixed paths in emitted asset filenames (the `src/` prefix dropped).