### PR TITLE
fix: treat boxOrdinalGroup as a unitless property

### DIFF
--- a/.changeset/unitless-box-ordinal-group.md
+++ b/.changeset/unitless-box-ordinal-group.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/css': patch
+---
+
+Add `boxOrdinalGroup` to the list of unitless properties so numeric values are no longer suffixed with `px`

--- a/packages/css/src/transformCss.test.ts
+++ b/packages/css/src/transformCss.test.ts
@@ -2749,6 +2749,7 @@ describe('transformCss', () => {
               display: 'block',
               paddingTop: 10,
               lineHeight: 20,
+              boxOrdinalGroup: 2,
               vars: {
                 '--my-var': '12',
                 [testVar]: '24',
@@ -2764,6 +2765,7 @@ describe('transformCss', () => {
         display: block;
         padding-top: 10px;
         line-height: 20;
+        box-ordinal-group: 2;
       }
     `);
   });

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -33,6 +33,7 @@ const UNITLESS: Record<string, boolean> = {
   borderImageWidth: true,
   boxFlex: true,
   boxFlexGroup: true,
+  boxOrdinalGroup: true,
   columnCount: true,
   columns: true,
   flex: true,


### PR DESCRIPTION
`boxOrdinalGroup` is missing from the `UNITLESS` map in `transformCss`, even though its two siblings from the same legacy flexbox box model, `boxFlex` and `boxFlexGroup`, are both there.

Because of that, a numeric value gets a `px` suffix it shouldn't:

```ts
style({ boxOrdinalGroup: 2 });
// box-ordinal-group: 2px;   <- invalid, the browser drops the declaration
```

`box-ordinal-group` takes an `<integer>`, so the output should be `box-ordinal-group: 2`. csstype types it as a number-accepting property (`Property.BoxOrdinalGroup = Globals | number | string`), the same as `boxFlex` and `boxFlexGroup`, so it is reachable from the public `CSSProperties` type.

Added `boxOrdinalGroup: true` next to the other two and extended the existing "should cast property values to pixels when relevant" test to cover it.
