### PR TITLE
`ci`: Don't skip playwright tests on `Version Packages` branches

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -78,7 +78,6 @@ jobs:
   playwright:
     name: Playwright tests (shard ${{ matrix.shard }}/2)
     runs-on: macos-latest
-    if: github.ref != 'refs/heads/changeset-release/master' && github.head_ref != 'changeset-release/master'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Github doesn't interpolate job names if they don't run, so our branch protection rules no longer treats the skipped playwright tests as successful. The workarounds I could find for this are messy, so I've instead opted to stop skipping playwright tests on `Version Packages` PRs for the time being.

<img width="788" height="311" alt="image" src="https://github.com/user-attachments/assets/c466668e-d0fd-4acd-a4b2-b08e218707cc" />
