### PR TITLE
fix: add exclude

### DIFF
--- a/.changeset/add-include-exclude-options.md
+++ b/.changeset/add-include-exclude-options.md
@@ -1,0 +1,20 @@
+---
+'@vanilla-extract/vite-plugin': minor
+---
+
+Add `include` and `exclude` options to control which files the plugin processes
+
+These options use the same filter syntax as `@rollup/pluginutils` and allow you to:
+
+- Skip pre-compiled `.css.js` files from libraries that export non-serializable values (like recipe functions)
+- Restrict processing to specific directories
+
+Example:
+
+```ts
+vanillaExtractPlugin({
+  exclude: [/node_modules\/my-design-system/]
+});
+```
+
+This is particularly useful when consuming design system libraries that publish pre-compiled vanilla-extract CSS, which would otherwise cause "Invalid exports" errors during build.

--- a/fixtures/precompiled-exclude/index.html
+++ b/fixtures/precompiled-exclude/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Precompiled Exclude Test</title>
+  </head>
+  <body>
+    <script type="module" src="./src/index.ts"></script>
+  </body>
+</html>

--- a/fixtures/precompiled-exclude/package.json
+++ b/fixtures/precompiled-exclude/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@fixtures/precompiled-exclude",
+  "version": "0.0.1",
+  "main": "src/index.ts",
+  "author": "SEEK",
+  "private": true,
+  "dependencies": {
+    "@fixtures/precompiled-lib": "workspace:*",
+    "@vanilla-extract/css": "workspace:*"
+  }
+}

--- a/fixtures/precompiled-exclude/precompiled-lib/index.mjs
+++ b/fixtures/precompiled-exclude/precompiled-lib/index.mjs
@@ -1,0 +1,1 @@
+export { buttonRecipe } from './styles.css.mjs';

--- a/fixtures/precompiled-exclude/precompiled-lib/package.json
+++ b/fixtures/precompiled-exclude/precompiled-lib/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@fixtures/precompiled-lib",
+  "version": "0.0.1",
+  "exports": {
+    ".": {
+      "import": "./index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "author": "SEEK",
+  "private": true,
+  "dependencies": {
+    "@vanilla-extract/recipes": "workspace:*"
+  }
+}

--- a/fixtures/precompiled-exclude/precompiled-lib/styles.css.mjs
+++ b/fixtures/precompiled-exclude/precompiled-lib/styles.css.mjs
@@ -1,0 +1,24 @@
+// Simulated pre-compiled output from a library using vanilla-extract recipes.
+// This file contains a recipe runtime function which is NOT serializable.
+// When vanilla-extract vite-plugin tries to process this file, it will fail
+// because recipe functions cannot be serialized to JSON.
+//
+// This simulates what happens when consuming a library like @my-design/system
+// that publishes pre-compiled .css.js files with recipe exports.
+
+import { createRuntimeFn } from '@vanilla-extract/recipes/createRuntimeFn';
+
+// This is the pre-compiled output of a recipe - it's a function, not serializable data
+export const buttonRecipe = createRuntimeFn({
+  defaultClassName: 'button_precompiled_abc123',
+  variantClassNames: {
+    size: {
+      small: 'button_size_small_def456',
+      large: 'button_size_large_ghi789',
+    },
+  },
+  defaultVariants: {
+    size: 'small',
+  },
+  compoundVariants: [],
+});

--- a/fixtures/precompiled-exclude/src/index.ts
+++ b/fixtures/precompiled-exclude/src/index.ts
@@ -1,0 +1,15 @@
+import testNodes from '../test-nodes.json';
+import { buttonRecipe } from '@fixtures/precompiled-lib';
+import { container } from './styles.css';
+
+const root = document.createElement('div');
+root.id = testNodes.container;
+root.className = container;
+
+const button = document.createElement('button');
+button.id = testNodes.button;
+button.className = buttonRecipe({ size: 'large' });
+button.textContent = 'Click me';
+
+root.appendChild(button);
+document.body.appendChild(root);

--- a/fixtures/precompiled-exclude/src/styles.css.ts
+++ b/fixtures/precompiled-exclude/src/styles.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  padding: '20px',
+  backgroundColor: '#f0f0f0',
+});

--- a/fixtures/precompiled-exclude/test-nodes.json
+++ b/fixtures/precompiled-exclude/test-nodes.json
@@ -1,0 +1,4 @@
+{
+  "container": "container",
+  "button": "button"
+}

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -16,6 +16,7 @@
   "author": "SEEK",
   "license": "MIT",
   "dependencies": {
+    "@rollup/pluginutils": "^5.0.0",
     "@vanilla-extract/compiler": "workspace:^",
     "@vanilla-extract/integration": "workspace:^"
   },

--- a/packages/vite-plugin/src/exclude.test.ts
+++ b/packages/vite-plugin/src/exclude.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+// We'll test the filter behavior by checking if transform returns null for excluded files
+describe('vanillaExtractPlugin exclude option', () => {
+  // These tests verify the exclude option works correctly
+  // They will FAIL until the exclude option is implemented
+
+  it('should accept exclude option in plugin configuration', async () => {
+    const { vanillaExtractPlugin } = await import('./index');
+
+    // This should not throw - the plugin should accept exclude option
+    const plugins = vanillaExtractPlugin({
+      exclude: ['**/node_modules/**'],
+    });
+
+    expect(plugins).toBeInstanceOf(Array);
+    expect(plugins.length).toBeGreaterThan(0);
+  });
+
+  it('should accept include option in plugin configuration', async () => {
+    const { vanillaExtractPlugin } = await import('./index');
+
+    // This should not throw - the plugin should accept include option
+    const plugins = vanillaExtractPlugin({
+      include: ['src/**/*.css.ts'],
+    });
+
+    expect(plugins).toBeInstanceOf(Array);
+    expect(plugins.length).toBeGreaterThan(0);
+  });
+
+  it('should accept both include and exclude options', async () => {
+    const { vanillaExtractPlugin } = await import('./index');
+
+    const plugins = vanillaExtractPlugin({
+      include: ['src/**/*.css.ts'],
+      exclude: ['**/node_modules/**'],
+    });
+
+    expect(plugins).toBeInstanceOf(Array);
+  });
+});

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -8,6 +8,7 @@ import type {
   ModuleNode,
   ViteDevServer,
 } from 'vite';
+import { createFilter, type FilterPattern } from '@rollup/pluginutils';
 import { type Compiler, createCompiler } from '@vanilla-extract/compiler';
 import {
   cssFileFilter,
@@ -43,6 +44,18 @@ interface Options {
   identifiers?: IdentifierOption;
   unstable_pluginFilter?: PluginFilter;
   unstable_mode?: 'transform' | 'emitCss' | 'inlineCssInDev';
+  /**
+   * Files to include in processing. Defaults to all .css.ts/.css.js files.
+   * Uses the same glob pattern syntax as @rollup/pluginutils.
+   */
+  include?: FilterPattern;
+  /**
+   * Files to exclude from processing. Useful for excluding pre-compiled
+   * .css.js files from node_modules that shouldn't be reprocessed.
+   * Uses the same glob pattern syntax as @rollup/pluginutils.
+   * @example [/node_modules\/my-library/]
+   */
+  exclude?: FilterPattern;
 }
 
 // Plugins that we know are compatible with the `vite-node` compiler
@@ -57,12 +70,17 @@ const withUserPluginFilter =
   (plugin: Plugin) =>
     pluginFilter({ name: plugin.name, mode });
 
+export type VanillaExtractPluginOptions = Options;
+
 export function vanillaExtractPlugin({
   identifiers,
   unstable_pluginFilter: pluginFilter = defaultPluginFilter,
   unstable_mode = 'emitCss',
+  include,
+  exclude,
 }: Options = {}): Plugin[] {
   let config: ResolvedConfig;
+  const filter = createFilter(include, exclude);
   let configEnv: ConfigEnv;
   let server: ViteDevServer;
   let packageName: string;
@@ -242,7 +260,7 @@ export function vanillaExtractPlugin({
       async transform(code, id, options) {
         const [validId] = id.split('?');
 
-        if (!cssFileFilter.test(validId)) {
+        if (!cssFileFilter.test(validId) || !filter(validId)) {
           return null;
         }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,21 @@ importers:
         specifier: workspace:*
         version: link:../../packages/webpack-plugin
 
+  fixtures/precompiled-exclude:
+    dependencies:
+      '@fixtures/precompiled-lib':
+        specifier: workspace:*
+        version: link:precompiled-lib
+      '@vanilla-extract/css':
+        specifier: workspace:*
+        version: link:../../packages/css
+
+  fixtures/precompiled-exclude/precompiled-lib:
+    dependencies:
+      '@vanilla-extract/recipes':
+        specifier: workspace:*
+        version: link:../../../packages/recipes
+
   fixtures/react-library-example:
     dependencies:
       '@vanilla-extract/css':
@@ -616,6 +631,9 @@ importers:
 
   packages/vite-plugin:
     dependencies:
+      '@rollup/pluginutils':
+        specifier: ^5.0.0
+        version: 5.1.4(rollup@4.59.0)
       '@vanilla-extract/compiler':
         specifier: workspace:^
         version: link:../compiler

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - 'test-helpers'
   - 'fixtures/*'
   - 'fixtures/thirdparty/**'
+  - 'fixtures/precompiled-exclude/**'
   - 'site'
   - 'examples/*'
   - 'tests'

--- a/site/docs/integrations/vite.md
+++ b/site/docs/integrations/vite.md
@@ -60,3 +60,27 @@ vanillaExtractPlugin({
 ```
 
 Each integration will set a default value based on the configuration options passed to the bundler.
+
+### include / exclude
+
+Control which files the plugin processes using glob patterns or regular expressions. This uses the same filter syntax as [@rollup/pluginutils](https://github.com/rollup/plugins/tree/master/packages/pluginutils#createfilter).
+
+By default, the plugin processes all files matching `.css.ts`, `.css.js`, `.css.mjs`, etc. Use `exclude` to skip pre-compiled `.css.js` files from libraries that shouldn't be reprocessed:
+
+```ts
+vanillaExtractPlugin({
+  // Skip processing pre-compiled CSS from a specific library
+  exclude: [/node_modules\/my-design-system/]
+});
+```
+
+This is useful when consuming libraries that publish pre-compiled vanilla-extract CSS with non-serializable exports (like recipe functions). Without `exclude`, the plugin would try to reprocess these files and fail with "Invalid exports" errors.
+
+```ts
+vanillaExtractPlugin({
+  // Only process files in src/
+  include: ['src/**/*.css.ts'],
+  // But skip any vendor styles
+  exclude: ['src/vendor/**']
+});
+```

--- a/test-helpers/src/startFixture/index.ts
+++ b/test-helpers/src/startFixture/index.ts
@@ -58,6 +58,8 @@ export async function startFixture(
       type,
       port,
       mode: options.mode,
+      vanillaExtractOptions: (options as ViteFixtureOptions)
+        .vanillaExtractOptions,
     });
   }
 

--- a/test-helpers/src/startFixture/vite.ts
+++ b/test-helpers/src/startFixture/vite.ts
@@ -3,7 +3,10 @@ import http from 'http';
 
 import type { InlineConfig } from 'vite';
 import handler from 'serve-handler';
-import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+import {
+  vanillaExtractPlugin,
+  type VanillaExtractPluginOptions,
+} from '@vanilla-extract/vite-plugin';
 import inspect from 'vite-plugin-inspect';
 
 import type { TestServer } from './types';
@@ -30,10 +33,18 @@ export interface ViteFixtureOptions {
   type: 'vite';
   mode?: 'development' | 'production';
   port: number;
+  /**
+   * Options to pass to the vanilla-extract plugin.
+   */
+  vanillaExtractOptions?: VanillaExtractPluginOptions;
 }
 export const startViteFixture = async (
   fixtureName: string,
-  { mode = 'development', port = 3000 }: ViteFixtureOptions,
+  {
+    mode = 'development',
+    port = 3000,
+    vanillaExtractOptions,
+  }: ViteFixtureOptions,
 ): Promise<TestServer> => {
   const root = path.dirname(
     require.resolve(`@fixtures/${fixtureName}/package.json`),
@@ -43,7 +54,10 @@ export const startViteFixture = async (
     configFile: false,
     root,
     logLevel: 'error',
-    plugins: [vanillaExtractPlugin(), mode === 'development' && inspect()],
+    plugins: [
+      vanillaExtractPlugin(vanillaExtractOptions),
+      mode === 'development' && inspect(),
+    ],
     server: {
       port,
       strictPort: true,

--- a/test-helpers/src/test-exclude-option.ts
+++ b/test-helpers/src/test-exclude-option.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env tsx
+/**
+ * Test script to verify the exclude option works for the precompiled-exclude fixture.
+ *
+ * Usage: tsx test-exclude-option.ts
+ */
+
+import { startFixture } from './startFixture';
+
+async function main() {
+  console.log('=== Testing precompiled-exclude fixture ===\n');
+
+  // Test 1: Build SHOULD FAIL without exclude option
+  console.log('Test 1: Build without exclude option (should fail)...');
+  try {
+    const server = await startFixture('precompiled-exclude', {
+      type: 'vite',
+      mode: 'production',
+      basePort: 9000,
+    } as any);
+    await server.close();
+    console.log('❌ UNEXPECTED: Build succeeded without exclude option');
+    process.exit(1);
+  } catch (err: any) {
+    if (
+      err.message?.includes('Invalid exports') ||
+      err.toString().includes('Invalid exports')
+    ) {
+      console.log('✅ Build correctly failed with "Invalid exports" error\n');
+    } else {
+      console.log('❌ Build failed with unexpected error:', err.message);
+      process.exit(1);
+    }
+  }
+
+  // Test 2: Build SHOULD SUCCEED with exclude option
+  console.log('Test 2: Build with exclude option (should succeed)...');
+  try {
+    const server = await startFixture('precompiled-exclude', {
+      type: 'vite',
+      mode: 'production',
+      basePort: 9001,
+      vanillaExtractOptions: {
+        exclude: ['**/precompiled-lib/**'],
+      },
+    } as any);
+    console.log('✅ Build succeeded with exclude option');
+    console.log('   Server URL:', server.url);
+    await server.close();
+  } catch (err: any) {
+    console.log('❌ Build failed with exclude option:', err.message);
+    process.exit(1);
+  }
+
+  console.log('\n=== All tests passed! ===');
+}
+
+main();

--- a/tests/e2e/precompiled-exclude.playwright.ts
+++ b/tests/e2e/precompiled-exclude.playwright.ts
@@ -1,0 +1,69 @@
+import { expect } from '@playwright/test';
+import {
+  getStylesheet,
+  startFixture,
+  type TestServer,
+} from '@vanilla-extract-private/test-helpers';
+import type { VanillaExtractPluginOptions } from '@vanilla-extract/vite-plugin';
+
+import test from './fixture';
+
+// Test cases for vite only - we're testing the vite plugin exclude option
+const viteTestCases = [
+  { type: 'vite' as const, mode: 'development' as const },
+  { type: 'vite' as const, mode: 'production' as const },
+];
+
+viteTestCases.forEach(({ type, mode }) => {
+  test.describe(`precompiled-exclude - ${type} (${mode})`, () => {
+    let server: TestServer;
+
+    test.beforeAll(async ({ port }) => {
+      // Use the exclude option to prevent processing the precompiled library
+      server = await startFixture('precompiled-exclude', {
+        type,
+        mode,
+        basePort: port,
+        vanillaExtractOptions: {
+          exclude: ['**/precompiled-lib/**'],
+        } satisfies VanillaExtractPluginOptions,
+      } as any);
+    });
+
+    test('screenshot', async ({ page }) => {
+      await page.goto(server.url);
+
+      expect(await page.screenshot()).toMatchSnapshot(
+        'precompiled-exclude.png',
+      );
+    });
+
+    test('CSS @agnostic', async () => {
+      expect(
+        await getStylesheet(server.url, server.stylesheet),
+      ).toMatchSnapshot(`precompiled-exclude-${type}--${mode}.css`);
+    });
+
+    test.afterAll(async () => {
+      await server.close();
+    });
+  });
+});
+
+// Test that the build FAILS without the exclude option
+test.describe('precompiled-exclude - without exclude option (should fail)', () => {
+  test('build fails when precompiled library is processed', async ({
+    port,
+  }) => {
+    // This test verifies that without the exclude option, the build fails
+    // with "Invalid exports" error because the recipe function can't be serialized
+    await expect(
+      startFixture('precompiled-exclude', {
+        type: 'vite',
+        mode: 'production',
+        basePort: port,
+        // No exclude option - should fail
+      }),
+    ).rejects.toThrow(/Invalid exports/);
+  });
+});


### PR DESCRIPTION
## Problem

When consuming libraries that publish pre-compiled vanilla-extract CSS (`.css.js`/`.css.mjs` files), the vite plugin attempts to reprocess these files during the consumer's build. This works fine for simple exports like strings from `style()`, but fails for libraries that export **recipe functions** from `@vanilla-extract/recipes`.

Recipe functions use `createRuntimeFn` which returns a function—not serializable data. When the plugin tries to serialize these exports, it throws:

```
Error: Invalid exports.
You can only export plain objects, arrays, strings, numbers and null/undefined.
```

This is a breaking issue for design system libraries that publish pre-compiled vanilla-extract CSS with recipe exports. Consumers have no way to exclude these files from reprocessing.

## Solution

Add `include` and `exclude` options to the vite plugin using `@rollup/pluginutils` (the standard approach used by most Vite/Rollup plugins). These options filter which files pass through the `transform` hook.

```ts
vanillaExtractPlugin({
  exclude: [/node_modules\/my-design-system/]
})
```

### Why not fix the serialization instead?

Recipe functions are intentionally non-serializable—they're runtime code that maps variant props to class names. The pre-compiled `.css.js` file already contains the correct output; reprocessing it is unnecessary and causes this failure. The `exclude` option lets consumers tell the plugin "this file is already compiled, skip it."

## Changes

- Add `@rollup/pluginutils` dependency for `createFilter`
- Add `include`/`exclude` options to the `Options` interface  
- Apply filter in `transform` hook before processing
- Add documentation to `site/docs/integrations/vite.md`
- Add test fixture with non-serializable recipe export
- Add unit tests and integration test

## Testing

The new `precompiled-exclude` fixture contains a simulated pre-compiled library with a recipe export. Tests verify:

1. Build **fails** without the exclude option (confirming the problem exists)
2. Build **succeeds** with `exclude: ['**/precompiled-lib/**']`

Also tested successfully in a real production app consuming a design system library with recipe exports.

While this works. I think one other way to do this is for files to be marked as already compiled at the top of them and then you wouldn't need such a thing as your consumers could just filter out already processed files. In that world you'd still need to read the files, so it would perhaps be less performant. Open to ideas and feedback. Relates to #1574 