### PR TITLE
feat: add @page at-rule support

### DIFF
--- a/.changeset/add-page-at-rule-support.md
+++ b/.changeset/add-page-at-rule-support.md
@@ -1,0 +1,29 @@
+---
+"@vanilla-extract/css": minor
+---
+
+Add `page()` and `globalPage()` functions for `@page` at-rule support
+
+```ts
+import { page, globalPage, style } from '@vanilla-extract/css';
+
+// Scoped page — returns a unique page name
+const printPage = page({
+  size: 'A4',
+  margin: '2cm',
+});
+
+export const printable = style({
+  page: printPage,
+});
+
+// Global @page rule
+globalPage({
+  margin: '1in',
+});
+
+// Global @page with selector
+globalPage(':first', {
+  marginTop: '3cm',
+});
+```

--- a/packages/css/src/index.ts
+++ b/packages/css/src/index.ts
@@ -4,6 +4,7 @@ export type {
   StyleRule,
   ComplexStyleRule,
   GlobalStyleRule,
+  GlobalPageStyleRule,
   Adapter,
   FileScope,
   CSSProperties,

--- a/packages/css/src/style.ts
+++ b/packages/css/src/style.ts
@@ -6,6 +6,7 @@ import type {
   CSSKeyframes,
   StyleRule,
   GlobalStyleRule,
+  GlobalPageStyleRule,
   ClassNames,
   ComplexStyleRule,
 } from './types';
@@ -156,6 +157,30 @@ export function keyframes(rule: CSSKeyframes, debugId?: string): string {
 
 export function globalKeyframes(name: string, rule: CSSKeyframes): void {
   appendCss({ type: 'keyframes', name, rule }, getFileScope());
+}
+
+export function page(rule: GlobalPageStyleRule, debugId?: string): string {
+  const name = cssesc(generateIdentifier(debugId), { isIdentifier: true });
+
+  appendCss({ type: 'page', selector: name, rule }, getFileScope());
+
+  return name;
+}
+
+export function globalPage(rule: GlobalPageStyleRule): void;
+export function globalPage(selector: string, rule: GlobalPageStyleRule): void;
+export function globalPage(
+  selectorOrRule: string | GlobalPageStyleRule,
+  rule?: GlobalPageStyleRule,
+): void {
+  if (typeof selectorOrRule === 'string') {
+    appendCss(
+      { type: 'page', selector: selectorOrRule, rule: rule! },
+      getFileScope(),
+    );
+  } else {
+    appendCss({ type: 'page', selector: '', rule: selectorOrRule }, getFileScope());
+  }
 }
 
 export function styleVariants<

--- a/packages/css/src/transformCss.test.ts
+++ b/packages/css/src/transformCss.test.ts
@@ -3463,6 +3463,95 @@ describe('transformCss', () => {
       `[Error: Nested at-rules (e.g. "@media") are not allowed inside @starting-style.]`,
     );
   });
+  it('should handle @page rules', () => {
+    expect(
+      transformCss({
+        composedClassLists: [],
+        localClassNames: [],
+        cssObjs: [
+          {
+            type: 'page',
+            selector: '',
+            rule: {
+              margin: '1cm',
+              size: 'A4',
+            },
+          },
+        ],
+      }).join('\n'),
+    ).toMatchInlineSnapshot(`
+      @page {
+        margin: 1cm;
+        size: A4;
+      }
+    `);
+  });
+
+  it('should handle @page rules with a selector', () => {
+    expect(
+      transformCss({
+        composedClassLists: [],
+        localClassNames: [],
+        cssObjs: [
+          {
+            type: 'page',
+            selector: ':first',
+            rule: {
+              marginTop: '5cm',
+            },
+          },
+        ],
+      }).join('\n'),
+    ).toMatchInlineSnapshot(`
+      @page :first {
+        margin-top: 5cm;
+      }
+    `);
+  });
+
+  it('should handle named @page rules', () => {
+    expect(
+      transformCss({
+        composedClassLists: [],
+        localClassNames: [],
+        cssObjs: [
+          {
+            type: 'page',
+            selector: 'myPage',
+            rule: {
+              size: 'landscape',
+            },
+          },
+        ],
+      }).join('\n'),
+    ).toMatchInlineSnapshot(`
+      @page myPage {
+        size: landscape;
+      }
+    `);
+  });
+
+  it('should pixelify @page rule values', () => {
+    expect(
+      transformCss({
+        composedClassLists: [],
+        localClassNames: [],
+        cssObjs: [
+          {
+            type: 'page',
+            selector: '',
+            rule: {
+              margin: 10,
+            },
+          },
+        ],
+      }).join('\n'),
+    ).toMatchInlineSnapshot(`
+      @page {
+        margin: 10px;
+      }
+    `);
+  });
 });
 
 endFileScope();

--- a/packages/css/src/transformCss.ts
+++ b/packages/css/src/transformCss.ts
@@ -13,6 +13,7 @@ import type {
   Composition,
   WithQueries,
   CSSPropertyBlock,
+  CSSPageBlock,
 } from './types';
 import { markCompositionUsed } from './adapter';
 import { nestingSelectorRegex } from './nestingSelectorRegex';
@@ -120,6 +121,7 @@ class Stylesheet {
   currConditionalRuleset: ConditionalRuleset | undefined;
   fontFaceRules: Array<GlobalFontFaceRule>;
   keyframesRules: Array<CSSKeyframesBlock>;
+  pageRules: Array<CSSPageBlock>;
   localClassNamesMap: Map<string, string>;
   localClassNamesSearch: AhoCorasick;
   composedClassLists: Array<{ identifier: string; regex: RegExp }>;
@@ -134,6 +136,7 @@ class Stylesheet {
     this.conditionalRulesets = [new ConditionalRuleset()];
     this.fontFaceRules = [];
     this.keyframesRules = [];
+    this.pageRules = [];
     this.propertyRules = [];
     this.localClassNamesMap = new Map(
       localClassNames.map((localClassName) => [localClassName, localClassName]),
@@ -171,6 +174,13 @@ class Stylesheet {
         }),
       );
       this.keyframesRules.push(root);
+
+      return;
+    }
+
+    if (root.type === 'page') {
+      root.rule = this.transformVars(this.transformProperties(root.rule));
+      this.pageRules.push(root);
 
       return;
     }
@@ -727,6 +737,11 @@ class Stylesheet {
     // Render keyframes
     for (const keyframe of this.keyframesRules) {
       css.push(renderCss({ [`@keyframes ${keyframe.name}`]: keyframe.rule }));
+    }
+
+    // Render page rules
+    for (const { selector, rule } of this.pageRules) {
+      css.push(renderCss({ [selector ? `@page ${selector}` : '@page']: rule }));
     }
 
     // Render layer definitions

--- a/packages/css/src/types.ts
+++ b/packages/css/src/types.ts
@@ -108,13 +108,22 @@ export type CSSPropertyBlock = {
   rule: AtRule.Property;
 };
 
+export type GlobalPageStyleRule = CSSPropertiesWithVars;
+
+export type CSSPageBlock = {
+  type: 'page';
+  selector: string;
+  rule: GlobalPageStyleRule;
+};
+
 export type CSS =
   | CSSStyleBlock
   | CSSFontFaceBlock
   | CSSKeyframesBlock
   | CSSSelectorBlock
   | CSSLayerDeclaration
-  | CSSPropertyBlock;
+  | CSSPropertyBlock
+  | CSSPageBlock;
 
 export type FileScope = {
   packageName?: string;


### PR DESCRIPTION
Closes #1279

Adds `page()` and `globalPage()` functions for defining CSS `@page` rules.

- `page(rule, debugId?)` — creates a scoped page name (similar to `keyframes()`), which can be referenced via the `page` CSS property
- `globalPage(rule)` — defines a global `@page {}` rule
- `globalPage(selector, rule)` — defines a global `@page` rule with a page selector (e.g. `:first`, `:left`, `:right`, `:blank`)

## Usage

```ts
import { page, globalPage, style } from '@vanilla-extract/css';

// Scoped @page
const printPage = page({
  size: 'A4',
  margin: '2cm',
});

export const printable = style({
  page: printPage,
});

// Global @page
globalPage({
  margin: '1in',
});

// Global @page with selector
globalPage(':first', {
  marginTop: '3cm',
});
