### PR TITLE
perf(integration): skip no-op debug-ids Babel pass on files with no debuggable calls

### DIFF
--- a/.changeset/skip-noop-debug-id-babel-pass.md
+++ b/.changeset/skip-noop-debug-id-babel-pass.md
@@ -1,0 +1,19 @@
+---
+'@vanilla-extract/babel-plugin-debug-ids': minor
+'@vanilla-extract/integration': patch
+---
+
+Skip the debug-ids Babel pass on files that provably contain no debuggable calls
+
+In `debug` mode, `@vanilla-extract/integration`'s `transform`/`transformSync` ran
+every `*.css.ts` file through Babel to let `@vanilla-extract/babel-plugin-debug-ids`
+attach debug IDs. Files that only use non-debuggable APIs (e.g. `globalStyle`,
+`globalKeyframes`, `createThemeContract`) were parsed and regenerated for nothing —
+and large generated stylesheets additionally triggered Babel's ">500KB" code-generator
+deopt (`[BABEL] Note: The code generator has deoptimised the styling of … as it exceeds
+the max of 500KB`), making that no-op pass especially slow.
+
+`@vanilla-extract/babel-plugin-debug-ids` now exports `mightHaveDebuggableCalls(source)`,
+a cheap word-bounded pre-check, and `@vanilla-extract/integration` uses it to skip the
+Babel transform when it can have no effect. Output (class/var debug identifiers and
+emitted CSS) is unchanged.

--- a/packages/babel-plugin-debug-ids/src/index.ts
+++ b/packages/babel-plugin-debug-ids/src/index.ts
@@ -75,6 +75,28 @@ const styleFunctions = [
 
 type StyleFunction = (typeof styleFunctions)[number];
 
+// Word-bounded so it never matches the intentionally-excluded `global*`
+// variants (`globalStyle`, `globalKeyframes`, …), whose calls never receive a
+// debug ID. Built once at module load from the debuggable names.
+const debuggableCallRE = new RegExp(
+  `\\b(?:${Object.keys(debuggableFunctionConfig).join('|')})\\b`,
+);
+
+/**
+ * A cheap, conservative pre-check for whether {@link default this plugin} could
+ * add a debug ID to any call in `source`. Returns `false` only when the source
+ * provably contains none of the debuggable function names, letting callers skip
+ * an otherwise no-op Babel transform.
+ *
+ * It is safe against false negatives: a call the plugin acts on must reference a
+ * debuggable name literally — as a named import (`import { style }` /
+ * `import { style as s }`) or a namespace member access (`ns.style(...)`) — so
+ * the name always appears in the source text. False positives (running Babel
+ * when nothing changes) are harmless.
+ */
+export const mightHaveDebuggableCalls = (source: string): boolean =>
+  debuggableCallRE.test(source);
+
 const extractName = (node: t.Node) => {
   if (t.isObjectProperty(node) && t.isIdentifier(node.key)) {
     return node.key.name;

--- a/packages/babel-plugin-debug-ids/src/mightHaveDebuggableCalls.test.ts
+++ b/packages/babel-plugin-debug-ids/src/mightHaveDebuggableCalls.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { mightHaveDebuggableCalls } from './index';
+
+describe('mightHaveDebuggableCalls', () => {
+  it.each([
+    ['named debuggable import', `import { style } from '@vanilla-extract/css';`],
+    ['aliased debuggable import', `import { style as s } from '@vanilla-extract/css';`],
+    ['namespace member call', `import * as css from '@vanilla-extract/css'; css.style({});`],
+    ['styleVariants', `import { styleVariants } from '@vanilla-extract/css';`],
+    ['createVar', `const v = createVar();`],
+    ['layer', `const l = layer();`],
+  ])('returns true for %s', (_label, source) => {
+    expect(mightHaveDebuggableCalls(source)).toBe(true);
+  });
+
+  it.each([
+    ['globalStyle only', `import { globalStyle } from '@vanilla-extract/css'; globalStyle(a, {});`],
+    ['globalKeyframes only', `globalKeyframes('spin', {});`],
+    ['globalFontFace only', `globalFontFace('x', {});`],
+    ['createThemeContract only', `createThemeContract({});`],
+    ['fallbackVar only', `fallbackVar(a, b);`],
+    ['no vanilla-extract at all', `export const x = 1;`],
+  ])('returns false for %s', (_label, source) => {
+    expect(mightHaveDebuggableCalls(source)).toBe(false);
+  });
+});

--- a/packages/integration/src/transform.ts
+++ b/packages/integration/src/transform.ts
@@ -1,5 +1,7 @@
 import * as babel from '@babel/core';
-import vanillaBabelPlugin from '@vanilla-extract/babel-plugin-debug-ids';
+import vanillaBabelPlugin, {
+  mightHaveDebuggableCalls,
+} from '@vanilla-extract/babel-plugin-debug-ids';
 // @ts-expect-error
 import typescriptSyntax from '@babel/plugin-syntax-typescript';
 
@@ -23,7 +25,11 @@ export const transformSync = ({
 }: TransformParams): string => {
   let code = source;
 
-  if (identOption === 'debug') {
+  // Skip the Babel pass entirely when the source provably contains no calls
+  // the debug-ids plugin could touch (e.g. files using only `globalStyle`).
+  // This avoids parsing + regenerating large generated stylesheets for nothing
+  // — and sidesteps Babel's ">500KB" code-generator deopt on such files.
+  if (identOption === 'debug' && mightHaveDebuggableCalls(source)) {
     const result = babel.transformSync(source, {
       filename: filePath,
       cwd: rootPath,
@@ -57,7 +63,8 @@ export const transform = async ({
 }: TransformParams): Promise<string> => {
   let code = source;
 
-  if (identOption === 'debug') {
+  // See `transformSync` above — same no-op-Babel bail-out.
+  if (identOption === 'debug' && mightHaveDebuggableCalls(source)) {
     const result = await babel.transformAsync(source, {
       filename: filePath,
       cwd: rootPath,


### PR DESCRIPTION
In `debug` mode (the default outside production), @vanilla-extract/integration's `transform`/`transformSync` ran every `*.css.ts` module through Babel so that @vanilla-extract/babel-plugin-debug-ids could attach debug IDs to calls like `style()`, `createVar()`, and `createTheme()`.

But the plugin only ever mutates the functions in its `debuggableFunctionConfig`. A module that uses only non-debuggable APIs — `globalStyle`, `globalKeyframes`, `globalFontFace`, `createThemeContract`, `fallbackVar`, … — was parsed and fully regenerated to produce byte-identical output. For large generated stylesheets this no-op pass is expensive and also trips Babel's code-generator deopt:

```
[BABEL] Note: The code generator has deoptimised the styling of …/styles.css.ts as it exceeds the max of 500KB.
```

This shows up when vanilla-extract is **generated** programmatically from another source
rather than hand-authored — e.g. converting an existing CSS framework to vanilla-extract —
where the emitted per-theme stylesheets can be large and built almost entirely from
`globalStyle`.

### Real-world case

The repo where I ran into this:
https://github.com/arijs/bootswatch-solid/tree/ve-literal-converter
(https://github.com/arijs/bootswatch-solid/commit/8cc4201e07da6560aab7a5f806ebeaaef51fc781)

Run
```sh
npm install
npm run ve2:build
```

Without this optimization, the build is slower than it could optimally be.

### Change

- `@vanilla-extract/babel-plugin-debug-ids` exports a new helper
  `mightHaveDebuggableCalls(source: string): boolean` — a cheap, word-bounded regex built
  from the keys of `debuggableFunctionConfig` (the single source of truth for which calls get
  debug IDs).
- `@vanilla-extract/integration`'s `transform`/`transformSync` gate the Babel call on it:
  `if (identOption === 'debug' && mightHaveDebuggableCalls(source))`.

### Why it's safe (no false negatives)

For the plugin to add a debug ID, the call must reference a debuggable name **literally** in
the source: either as a named import (`import { style }` or `import { style as s }`) or a
namespace member access (`ns.style(...)`). In every case the debuggable name appears verbatim
in the source text, so the pre-check sees it. The regex is word-bounded specifically so it
does **not** match the intentionally-excluded `global*` siblings (`globalStyle` contains
`Style`, not a `\bstyle\b`; `styleVariants` matches its own alternative, not `style`).
False *positives* (running Babel when nothing changes) are harmless — they just fall back to
today's behavior.

### Verification

Applied to the built packages and run against a real 27-theme project (~925 `*.css.ts`,
several literal stylesheets >500KB, overwhelmingly `globalStyle`):

- **Output unchanged.** A chunk-independent canonical signature of all emitted CSS — every
  rule normalized and sorted, plus the full set of VE debug class/var identifiers — is
  **byte-identical** with and without the change:
  - filtered single-theme build: `ruleSetSig` and `identSetSig` identical across runs.
  - full 27-theme build: **70,531 rules / 2,619 debug identifiers, identical signatures**
    (`ruleSetSig=f2f7b46a…`, `identSetSig=6592fb7f…`) before and after.
- **`[BABEL] … deoptimised …` notes:** 15 → **0** on the full build.
- **Build time:** full build 1m15s → 1m8s here; the single-theme dev/capture loop dropped
  ~2× on the files that previously hit the >500KB deopt (each such file went from a
  multi-second cold Babel compile to being skipped). The win scales with how much of a
  codebase is generated `globalStyle`.

A focused unit test for the helper is included
(`packages/babel-plugin-debug-ids/src/mightHaveDebuggableCalls.test.ts`).

### Test suite status

- **New helper test — `mightHaveDebuggableCalls.test.ts` (12 cases, all pass).** Covers the
  six ways a debuggable name can appear (named import, aliased import, namespace member call,
  the `styleVariants`/`createVar`/`layer` alternatives) and the six that must *not* match
  (`globalStyle`, `globalKeyframes`, `globalFontFace`, `createThemeContract`, `fallbackVar`,
  and a file with no vanilla-extract at all). The `createThemeContract` case pins the
  word-boundary guarantee — `\bcreateTheme\b` deliberately does **not** match across the
  `Contract` suffix.
  - The file follows this repo's convention of importing the test globals explicitly
    (`import { describe, expect, it } from 'vitest'`); vitest is configured **without**
    `globals: true`, so a bare-globals test would `ReferenceError` at runtime.

- **Full unit run (`pnpm test:unit`): 436 passed, 1 skipped.** The change introduces no
  regressions across the suite.

- **Pre-existing, unrelated flakes — not introduced by this PR.** Two cases in
  `packages/turbopack-plugin/src/index.test.ts` (a self-described race-condition *stress
  test*, added in #1639 / migrated in #1694 — untouched by this branch) fail only inside the
  full 26-file run and **pass in isolation** (`pnpm vitest run packages/turbopack-plugin`
  → 2/2). One is a tight timeout (`10 × 250ms`) that the compiler-warmup iteration blows
  under full-suite CPU contention; the other is the shared-compiler staleness race the test
  exists to catch. Both are orthogonal to the debug-ids Babel path and out of scope here —
  recommend running the turbopack stress test in isolation in CI rather than masking it.

### Notes

- Only affects `identOption === 'debug'`. `short` (production) already skips Babel.
- The esbuild integration path (`vanillaExtractTransformPlugin`) goes through the same
  `transform`, so it benefits automatically.


### Local-setup-only changes — **NOT** included in the PR

To get `pnpm install` to complete on my machine (pnpm 11.8), some edits to
`pnpm-workspace.yaml` were required. These are unrelated to the change itself and are
**left out of the PR**:

- **`trustPolicyExclude` additions.** The repo sets `trustPolicy: no-downgrade`, which pnpm
  enforces against every transitive dependency. Several old packages that predate npm
  provenance tripped `ERR_PNPM_TRUST_DOWNGRADE` (a package whose earlier version had a trusted
  publisher but the pinned version has no trust evidence). To install, each flagged name was
  added to `trustPolicyExclude`: `rollup`, `algoliasearch` and the `@algolia/*` family
  (`@algolia/recommend`, `@algolia/client-common`, `@algolia/client-search`,
  `@algolia/logger-console`, `@algolia/client-analytics`, `@algolia/requester-node-http`,
  `@algolia/requester-browser-xhr`, `@algolia/client-personalization`), and
  `css-declaration-sorter`. These are all pinned by upstream and mostly pulled in by the
  docs `site/`.
- **`allowBuilds: '@parcel/watcher': false`.** After deps resolved, pnpm's
  `ERR_PNPM_IGNORED_BUILDS` demanded an explicit build-script decision for `@parcel/watcher`.
  Set to `false` to match every other native dep in that map (esbuild, sharp, lmdb, … all
  `false`); the prebuilt binary is used, no local compile.
- **`pnpm-lock.yaml` churn / `pnpm-lock-git.yaml`.** Any local lockfile drift is likewise a
  setup artifact and should not be part of the PR.

None of the above touches the debug-ids Babel path; they only reflect this environment's
supply-chain policy gates.
