### PR TITLE
fix: add fileExtension, DEFAULT_FILE_EXTENSIONS

### DIFF
--- a/.changeset/full-file-extension-option.md
+++ b/.changeset/full-file-extension-option.md
@@ -1,0 +1,40 @@
+---
+"@vanilla-extract/vite-plugin": minor
+"@vanilla-extract/integration": minor
+---
+
+Add `fileExtension` option to vite-plugin and export `DEFAULT_FILE_EXTENSIONS` constant from integration.
+
+`DEFAULT_FILE_EXTENSIONS` is now the single source of truth for which file extensions vanilla-extract processes. The `cssFileFilter` regex is derived from this array, preventing drift between them.
+
+This allows specifying exact file extensions (e.g., `.ve.ts`) for vanilla-extract files instead of the default `.css.ts`, `.css.tsx`, etc. This is useful when consuming pre-compiled vanilla-extract libraries that publish `.css.js` files - you can use a different extension for your source files to avoid reprocessing library files.
+
+Replace default extensions with custom ones:
+
+```ts
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+
+export default {
+  plugins: [
+    vanillaExtractPlugin({
+      // Process only .ve.ts and .ve.tsx files (NOT .css.ts, etc.)
+      fileExtension: ['.ve.ts', '.ve.tsx'],
+    }),
+  ],
+};
+```
+
+Or keep the defaults while adding custom extensions using `DEFAULT_FILE_EXTENSIONS`:
+
+```ts
+import { vanillaExtractPlugin, DEFAULT_FILE_EXTENSIONS } from '@vanilla-extract/vite-plugin';
+
+export default {
+  plugins: [
+    vanillaExtractPlugin({
+      // Process default extensions PLUS .ve.ts and .ve.tsx
+      fileExtension: [...DEFAULT_FILE_EXTENSIONS, '.ve.ts', '.ve.tsx'],
+    }),
+  ],
+};
+```

--- a/.changeset/full-file-extension-option.md
+++ b/.changeset/full-file-extension-option.md
@@ -1,6 +1,7 @@
 ---
 "@vanilla-extract/vite-plugin": minor
 "@vanilla-extract/integration": minor
+"@vanilla-extract/compiler": minor
 ---
 
 Add `fileExtension` option to vite-plugin and export `DEFAULT_FILE_EXTENSIONS` constant from integration.
@@ -8,6 +9,12 @@ Add `fileExtension` option to vite-plugin and export `DEFAULT_FILE_EXTENSIONS` c
 `DEFAULT_FILE_EXTENSIONS` is now the single source of truth for which file extensions vanilla-extract processes. The `cssFileFilter` regex is derived from this array, preventing drift between them.
 
 This allows specifying exact file extensions (e.g., `.ve.ts`) for vanilla-extract files instead of the default `.css.ts`, `.css.tsx`, etc. This is useful when consuming pre-compiled vanilla-extract libraries that publish `.css.js` files - you can use a different extension for your source files to avoid reprocessing library files.
+
+### Compiler
+
+Added `fileFilter` option to `createCompiler()` to support custom file extensions. This is used internally by the vite-plugin when the `fileExtension` option is specified.
+
+### Vite Plugin
 
 Replace default extensions with custom ones:
 
@@ -37,4 +44,12 @@ export default {
     }),
   ],
 };
+```
+
+Or disable processing entirely when only consuming pre-compiled libraries:
+
+```ts
+vanillaExtractPlugin({
+  fileExtension: [],
+});
 ```

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -24,7 +24,7 @@ type ModuleScanResult = {
   watchFiles: Set<string>;
 };
 
-const createModuleScanner = () => {
+const createModuleScanner = (fileFilter: RegExp) => {
   const cache = new Map<string, ModuleScanResult>();
 
   const scanModule = (
@@ -69,7 +69,7 @@ const createModuleScanner = () => {
 
     const cssDepsArray = Array.from(cssDeps);
 
-    if (moduleNode.id && cssFileFilter.test(moduleNode.id)) {
+    if (moduleNode.id && fileFilter.test(moduleNode.id)) {
       cssDepsArray.push(moduleNode.id);
     }
 
@@ -93,10 +93,11 @@ const createModuleScanner = () => {
 const createViteServer = async ({
   root,
   identifiers,
+  fileFilter,
   viteConfig,
   enableFileWatcher = true,
 }: Required<
-  Pick<CreateCompilerOptions, 'root' | 'identifiers' | 'viteConfig'>
+  Pick<CreateCompilerOptions, 'root' | 'identifiers' | 'viteConfig' | 'fileFilter'>
 > &
   Pick<CreateCompilerOptions, 'enableFileWatcher'>) => {
   const pkg = getPackageInfo(root);
@@ -149,7 +150,7 @@ const createViteServer = async ({
       {
         name: 'vanilla-extract-transform',
         async transform(code, id) {
-          if (cssFileFilter.test(id)) {
+          if (fileFilter.test(id)) {
             const filescopedCode = await transform({
               source: code,
               rootPath: root,
@@ -275,6 +276,11 @@ export interface CreateCompilerOptions {
   unstable_splitCssPerRule?: boolean;
   identifiers?: IdentifierOption;
   viteConfig?: ViteUserConfig;
+  /**
+   * A RegExp to match vanilla-extract style files. Defaults to cssFileFilter.
+   * Use this to support custom file extensions like `.styles.ts`.
+   */
+  fileFilter?: RegExp;
   /** @deprecated */
   viteResolve?: ViteUserConfig['resolve'];
   /** @deprecated */
@@ -287,6 +293,7 @@ export const createCompiler = ({
   unstable_splitCssPerRule: splitCssPerRule = false,
   viteConfig,
   enableFileWatcher,
+  fileFilter = cssFileFilter,
   viteResolve,
   vitePlugins,
 }: CreateCompilerOptions): Compiler => {
@@ -298,6 +305,7 @@ export const createCompiler = ({
   const vitePromise = createViteServer({
     root,
     identifiers,
+    fileFilter,
     viteConfig: viteConfig ?? {
       resolve: viteResolve,
       plugins: vitePlugins,
@@ -425,7 +433,7 @@ export const createCompiler = ({
           const cssImports: string[] = [];
           const orderedComposedClassLists: Composition[] = [];
 
-          const scanModule = createModuleScanner();
+          const scanModule = createModuleScanner(fileFilter);
           const { cssDeps, watchFiles } = scanModule(moduleNode);
 
           for (const cssDep of cssDeps) {

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -97,7 +97,10 @@ const createViteServer = async ({
   viteConfig,
   enableFileWatcher = true,
 }: Required<
-  Pick<CreateCompilerOptions, 'root' | 'identifiers' | 'viteConfig' | 'fileFilter'>
+  Pick<
+    CreateCompilerOptions,
+    'root' | 'identifiers' | 'viteConfig' | 'fileFilter'
+  >
 > &
   Pick<CreateCompilerOptions, 'enableFileWatcher'>) => {
   const pkg = getPackageInfo(root);

--- a/packages/integration/src/filters.test.ts
+++ b/packages/integration/src/filters.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { cssFileFilter, DEFAULT_FILE_EXTENSIONS } from './filters';
+
+describe('filters', () => {
+  describe('DEFAULT_FILE_EXTENSIONS and cssFileFilter sync', () => {
+    it('exports DEFAULT_FILE_EXTENSIONS', () => {
+      expect(DEFAULT_FILE_EXTENSIONS).toBeDefined();
+      expect(Array.isArray(DEFAULT_FILE_EXTENSIONS)).toBe(true);
+    });
+
+    it('cssFileFilter matches every extension in DEFAULT_FILE_EXTENSIONS', () => {
+      for (const ext of DEFAULT_FILE_EXTENSIONS) {
+        const testFile = `some/path/styles${ext}`;
+        expect(cssFileFilter.test(testFile)).toBe(true);
+      }
+    });
+
+    it('cssFileFilter matches every extension with ?used suffix', () => {
+      for (const ext of DEFAULT_FILE_EXTENSIONS) {
+        const testFile = `some/path/styles${ext}?used`;
+        expect(cssFileFilter.test(testFile)).toBe(true);
+      }
+    });
+
+    it('cssFileFilter does not match extensions outside DEFAULT_FILE_EXTENSIONS', () => {
+      const nonMatchingExtensions = [
+        '.ts',
+        '.tsx',
+        '.js',
+        '.jsx',
+        '.css',
+        '.scss',
+        '.ve.ts',
+        '.styles.ts',
+      ];
+      for (const ext of nonMatchingExtensions) {
+        const testFile = `some/path/styles${ext}`;
+        expect(cssFileFilter.test(testFile)).toBe(false);
+      }
+    });
+  });
+});

--- a/packages/integration/src/filters.ts
+++ b/packages/integration/src/filters.ts
@@ -1,4 +1,24 @@
+/**
+ * The default file extensions that vanilla-extract processes.
+ * This is the single source of truth — cssFileFilter is derived from this.
+ */
+export const DEFAULT_FILE_EXTENSIONS = [
+  '.css.ts',
+  '.css.tsx',
+  '.css.js',
+  '.css.jsx',
+  '.css.mjs',
+  '.css.cjs',
+] as const;
+
+// Derive regex pattern from the array to prevent drift
+const extensionPattern = DEFAULT_FILE_EXTENSIONS.map((ext) =>
+  ext.replace(/\./g, '\\.'),
+).join('|');
+
 // Vite adds a "?used" to CSS files it detects, this isn't relevant for
 // .css.ts files but it's added anyway so we need to allow for it in the file match
-export const cssFileFilter: RegExp = /\.css\.(js|cjs|mjs|jsx|ts|tsx)(\?used)?$/;
+export const cssFileFilter: RegExp = new RegExp(
+  `(${extensionPattern})(\\?used)?$`,
+);
 export const virtualCssFileFilter: RegExp = /\.vanilla\.css\?source=.*$/;

--- a/packages/integration/src/index.ts
+++ b/packages/integration/src/index.ts
@@ -15,5 +15,9 @@ export { hash } from './hash';
 export { addFileScope, normalizePath } from './addFileScope';
 export { serializeCss, deserializeCss } from './serialize';
 export { transformSync, transform } from './transform';
-export { cssFileFilter, virtualCssFileFilter } from './filters';
+export {
+  cssFileFilter,
+  virtualCssFileFilter,
+  DEFAULT_FILE_EXTENSIONS,
+} from './filters';
 export type { IdentifierOption } from './types';

--- a/packages/vite-plugin/src/fileExtension.test.ts
+++ b/packages/vite-plugin/src/fileExtension.test.ts
@@ -1,0 +1,339 @@
+import { describe, expect, it } from 'vitest';
+import type { Plugin } from 'vite';
+
+/**
+ * Helper to create a minimal mock plugin context for testing transform hooks.
+ */
+function createMockPluginContext() {
+  return {
+    meta: { watchMode: false },
+    moduleIds: [],
+    getModuleIds: () => [][Symbol.iterator](),
+    getModuleInfo: () => null,
+    parse: () => ({}),
+    resolve: async () => null,
+    load: async () => ({ code: '' }),
+    addWatchFile: () => {},
+    emitFile: () => '',
+    setAssetSource: () => {},
+    getFileName: () => '',
+    error: () => {},
+    warn: () => {},
+    getCombinedSourcemap: () => ({ mappings: '' }),
+  };
+}
+
+describe('vanillaExtractPlugin fileExtension option (full extension)', () => {
+  /**
+   * Test that the Options interface includes fileExtension.
+   */
+  it('accepts fileExtension option in plugin options type', async () => {
+    const { vanillaExtractPlugin } = await import('./index');
+
+    const plugins = vanillaExtractPlugin({
+      fileExtension: '.ve.ts',
+    });
+
+    expect(plugins).toBeDefined();
+    expect(Array.isArray(plugins)).toBe(true);
+  });
+
+  /**
+   * Test that transform returns null for .css.ts files when fileExtension is '.ve.ts'
+   */
+  it('does NOT process .css.ts files when fileExtension is set to .ve.ts', async () => {
+    const { vanillaExtractPlugin } = await import('./index');
+
+    const plugins = vanillaExtractPlugin({
+      fileExtension: '.ve.ts',
+    });
+
+    const mainPlugin = plugins.find(
+      (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
+    );
+    expect(mainPlugin).toBeDefined();
+    expect(mainPlugin?.transform).toBeDefined();
+
+    const transformFn = mainPlugin!.transform as Function;
+    const mockContext = createMockPluginContext();
+
+    const result = await transformFn.call(
+      mockContext,
+      'import { style } from "@vanilla-extract/css";',
+      '/project/src/styles.css.ts',
+    );
+
+    // Should return null because .css.ts doesn't match .ve.ts
+    expect(result).toBeNull();
+  });
+
+  /**
+   * Test that transform DOES process .ve.ts files when fileExtension is '.ve.ts'
+   */
+  it('processes .ve.ts files when fileExtension is set to .ve.ts', async () => {
+    const { vanillaExtractPlugin } = await import('./index');
+
+    const plugins = vanillaExtractPlugin({
+      fileExtension: '.ve.ts',
+    });
+
+    const mainPlugin = plugins.find(
+      (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const transformFn = mainPlugin!.transform as Function;
+    const mockContext = createMockPluginContext();
+
+    // The transform should attempt to process .ve.ts files (will throw because no compiler,
+    // but the key is it doesn't return null early like it would for non-matching files)
+    let didAttemptTransform = false;
+    try {
+      await transformFn.call(
+        mockContext,
+        'import { style } from "@vanilla-extract/css";',
+        '/project/src/styles.ve.ts',
+      );
+    } catch {
+      // An error means the transform was attempted (compiler not set up)
+      didAttemptTransform = true;
+    }
+
+    expect(didAttemptTransform).toBe(true);
+  });
+
+  /**
+   * Test that .ve.tsx is NOT matched when only .ve.ts is specified
+   */
+  it('does NOT process .ve.tsx when only .ve.ts is specified', async () => {
+    const { vanillaExtractPlugin } = await import('./index');
+
+    const plugins = vanillaExtractPlugin({
+      fileExtension: '.ve.ts', // Only .ve.ts, not .ve.tsx
+    });
+
+    const mainPlugin = plugins.find(
+      (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const transformFn = mainPlugin!.transform as Function;
+    const mockContext = createMockPluginContext();
+
+    // .ve.tsx should NOT be matched since only .ve.ts was specified
+    const result = await transformFn.call(
+      mockContext,
+      'export const x = 1;',
+      '/project/src/styles.ve.tsx',
+    );
+
+    expect(result).toBeNull();
+  });
+
+  /**
+   * Test that default behavior (no fileExtension) still processes .css.ts files
+   */
+  it('processes .css.ts files by default when fileExtension is not specified', async () => {
+    const { vanillaExtractPlugin } = await import('./index');
+
+    const plugins = vanillaExtractPlugin({});
+
+    const mainPlugin = plugins.find(
+      (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const transformFn = mainPlugin!.transform as Function;
+    const mockContext = createMockPluginContext();
+
+    let didAttemptTransform = false;
+    try {
+      await transformFn.call(
+        mockContext,
+        'import { style } from "@vanilla-extract/css";',
+        '/project/src/styles.css.ts',
+      );
+    } catch {
+      didAttemptTransform = true;
+    }
+
+    expect(didAttemptTransform).toBe(true);
+  });
+
+  /**
+   * Test that multiple full extensions can be specified
+   */
+  it('supports array of full file extensions', async () => {
+    const { vanillaExtractPlugin } = await import('./index');
+
+    const plugins = vanillaExtractPlugin({
+      fileExtension: ['.ve.ts', '.ve.tsx', '.styles.ts'],
+    });
+
+    const mainPlugin = plugins.find(
+      (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const transformFn = mainPlugin!.transform as Function;
+    const mockContext = createMockPluginContext();
+
+    // .ve.ts should be processed
+    let veAttempted = false;
+    try {
+      await transformFn.call(
+        mockContext,
+        'export const x = 1;',
+        '/project/src/styles.ve.ts',
+      );
+    } catch {
+      veAttempted = true;
+    }
+    expect(veAttempted).toBe(true);
+
+    // .ve.tsx should be processed
+    let veTsxAttempted = false;
+    try {
+      await transformFn.call(
+        mockContext,
+        'export const x = 1;',
+        '/project/src/styles.ve.tsx',
+      );
+    } catch {
+      veTsxAttempted = true;
+    }
+    expect(veTsxAttempted).toBe(true);
+
+    // .styles.ts should be processed
+    let stylesAttempted = false;
+    try {
+      await transformFn.call(
+        mockContext,
+        'export const x = 1;',
+        '/project/src/button.styles.ts',
+      );
+    } catch {
+      stylesAttempted = true;
+    }
+    expect(stylesAttempted).toBe(true);
+
+    // .css.ts should NOT be processed
+    const cssResult = await transformFn.call(
+      mockContext,
+      'export const x = 1;',
+      '/project/src/styles.css.ts',
+    );
+    expect(cssResult).toBeNull();
+  });
+
+  /**
+   * Test handling of Vite's ?used query parameter
+   */
+  it('handles Vite ?used query parameter', async () => {
+    const { vanillaExtractPlugin } = await import('./index');
+
+    const plugins = vanillaExtractPlugin({
+      fileExtension: '.ve.ts',
+    });
+
+    const mainPlugin = plugins.find(
+      (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const transformFn = mainPlugin!.transform as Function;
+    const mockContext = createMockPluginContext();
+
+    // Files with ?used should still be processed (Vite adds this)
+    let didAttemptTransform = false;
+    try {
+      await transformFn.call(
+        mockContext,
+        'export const x = 1;',
+        '/project/src/styles.ve.ts?used',
+      );
+    } catch {
+      didAttemptTransform = true;
+    }
+
+    expect(didAttemptTransform).toBe(true);
+  });
+});
+
+describe('DEFAULT_FILE_EXTENSIONS', () => {
+  it('exports DEFAULT_FILE_EXTENSIONS constant', async () => {
+    const { DEFAULT_FILE_EXTENSIONS } = await import('./index');
+
+    expect(DEFAULT_FILE_EXTENSIONS).toBeDefined();
+    expect(Array.isArray(DEFAULT_FILE_EXTENSIONS)).toBe(true);
+  });
+
+  it('contains all standard vanilla-extract extensions', async () => {
+    const { DEFAULT_FILE_EXTENSIONS } = await import('./index');
+
+    expect(DEFAULT_FILE_EXTENSIONS).toContain('.css.ts');
+    expect(DEFAULT_FILE_EXTENSIONS).toContain('.css.tsx');
+    expect(DEFAULT_FILE_EXTENSIONS).toContain('.css.js');
+    expect(DEFAULT_FILE_EXTENSIONS).toContain('.css.jsx');
+    expect(DEFAULT_FILE_EXTENSIONS).toContain('.css.mjs');
+    expect(DEFAULT_FILE_EXTENSIONS).toContain('.css.cjs');
+  });
+
+  it('can be spread with custom extensions', async () => {
+    const { vanillaExtractPlugin, DEFAULT_FILE_EXTENSIONS } = await import(
+      './index'
+    );
+
+    // Should work with spread operator to combine defaults + custom
+    const plugins = vanillaExtractPlugin({
+      fileExtension: [...DEFAULT_FILE_EXTENSIONS, '.ve.ts', '.ve.tsx'],
+    });
+
+    expect(plugins).toBeDefined();
+    expect(Array.isArray(plugins)).toBe(true);
+  });
+
+  it('processes default extensions when combined with custom ones', async () => {
+    const { vanillaExtractPlugin, DEFAULT_FILE_EXTENSIONS } = await import(
+      './index'
+    );
+
+    const plugins = vanillaExtractPlugin({
+      fileExtension: [...DEFAULT_FILE_EXTENSIONS, '.ve.ts'],
+    });
+
+    const mainPlugin = plugins.find(
+      (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const transformFn = mainPlugin!.transform as Function;
+    const mockContext = createMockPluginContext();
+
+    // .css.ts should still be processed
+    let cssAttempted = false;
+    try {
+      await transformFn.call(
+        mockContext,
+        'export const x = 1;',
+        '/project/src/styles.css.ts',
+      );
+    } catch {
+      cssAttempted = true;
+    }
+    expect(cssAttempted).toBe(true);
+
+    // .ve.ts should also be processed
+    let veAttempted = false;
+    try {
+      await transformFn.call(
+        mockContext,
+        'export const x = 1;',
+        '/project/src/styles.ve.ts',
+      );
+    } catch {
+      veAttempted = true;
+    }
+    expect(veAttempted).toBe(true);
+  });
+});

--- a/packages/vite-plugin/src/fileExtension.test.ts
+++ b/packages/vite-plugin/src/fileExtension.test.ts
@@ -51,10 +51,10 @@ describe('vanillaExtractPlugin fileExtension option (full extension)', () => {
     const mainPlugin = plugins.find(
       (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
     );
-    expect(mainPlugin).toBeDefined();
     expect(mainPlugin?.transform).toBeDefined();
+    if (!mainPlugin?.transform) throw new Error('unreachable');
 
-    const transformFn = mainPlugin!.transform as Function;
+    const transformFn = mainPlugin.transform as Function;
     const mockContext = createMockPluginContext();
 
     const result = await transformFn.call(
@@ -80,9 +80,10 @@ describe('vanillaExtractPlugin fileExtension option (full extension)', () => {
     const mainPlugin = plugins.find(
       (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
     );
-    expect(mainPlugin).toBeDefined();
+    expect(mainPlugin?.transform).toBeDefined();
+    if (!mainPlugin?.transform) throw new Error('unreachable');
 
-    const transformFn = mainPlugin!.transform as Function;
+    const transformFn = mainPlugin.transform as Function;
     const mockContext = createMockPluginContext();
 
     // The transform should attempt to process .ve.ts files (will throw because no compiler,
@@ -115,9 +116,10 @@ describe('vanillaExtractPlugin fileExtension option (full extension)', () => {
     const mainPlugin = plugins.find(
       (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
     );
-    expect(mainPlugin).toBeDefined();
+    expect(mainPlugin?.transform).toBeDefined();
+    if (!mainPlugin?.transform) throw new Error('unreachable');
 
-    const transformFn = mainPlugin!.transform as Function;
+    const transformFn = mainPlugin.transform as Function;
     const mockContext = createMockPluginContext();
 
     // .ve.tsx should NOT be matched since only .ve.ts was specified
@@ -141,9 +143,10 @@ describe('vanillaExtractPlugin fileExtension option (full extension)', () => {
     const mainPlugin = plugins.find(
       (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
     );
-    expect(mainPlugin).toBeDefined();
+    expect(mainPlugin?.transform).toBeDefined();
+    if (!mainPlugin?.transform) throw new Error('unreachable');
 
-    const transformFn = mainPlugin!.transform as Function;
+    const transformFn = mainPlugin.transform as Function;
     const mockContext = createMockPluginContext();
 
     let didAttemptTransform = false;
@@ -173,9 +176,10 @@ describe('vanillaExtractPlugin fileExtension option (full extension)', () => {
     const mainPlugin = plugins.find(
       (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
     );
-    expect(mainPlugin).toBeDefined();
+    expect(mainPlugin?.transform).toBeDefined();
+    if (!mainPlugin?.transform) throw new Error('unreachable');
 
-    const transformFn = mainPlugin!.transform as Function;
+    const transformFn = mainPlugin.transform as Function;
     const mockContext = createMockPluginContext();
 
     // .ve.ts should be processed
@@ -239,9 +243,10 @@ describe('vanillaExtractPlugin fileExtension option (full extension)', () => {
     const mainPlugin = plugins.find(
       (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
     );
-    expect(mainPlugin).toBeDefined();
+    expect(mainPlugin?.transform).toBeDefined();
+    if (!mainPlugin?.transform) throw new Error('unreachable');
 
-    const transformFn = mainPlugin!.transform as Function;
+    const transformFn = mainPlugin.transform as Function;
     const mockContext = createMockPluginContext();
 
     // Files with ?used should still be processed (Vite adds this)
@@ -273,9 +278,10 @@ describe('vanillaExtractPlugin fileExtension option (full extension)', () => {
     const mainPlugin = plugins.find(
       (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
     );
-    expect(mainPlugin).toBeDefined();
+    expect(mainPlugin?.transform).toBeDefined();
+    if (!mainPlugin?.transform) throw new Error('unreachable');
 
-    const transformFn = mainPlugin!.transform as Function;
+    const transformFn = mainPlugin.transform as Function;
     const mockContext = createMockPluginContext();
 
     // .css.ts should NOT be processed
@@ -324,9 +330,8 @@ describe('DEFAULT_FILE_EXTENSIONS', () => {
   });
 
   it('can be spread with custom extensions', async () => {
-    const { vanillaExtractPlugin, DEFAULT_FILE_EXTENSIONS } = await import(
-      './index'
-    );
+    const { vanillaExtractPlugin, DEFAULT_FILE_EXTENSIONS } =
+      await import('./index');
 
     // Should work with spread operator to combine defaults + custom
     const plugins = vanillaExtractPlugin({
@@ -338,9 +343,8 @@ describe('DEFAULT_FILE_EXTENSIONS', () => {
   });
 
   it('processes default extensions when combined with custom ones', async () => {
-    const { vanillaExtractPlugin, DEFAULT_FILE_EXTENSIONS } = await import(
-      './index'
-    );
+    const { vanillaExtractPlugin, DEFAULT_FILE_EXTENSIONS } =
+      await import('./index');
 
     const plugins = vanillaExtractPlugin({
       fileExtension: [...DEFAULT_FILE_EXTENSIONS, '.ve.ts'],
@@ -349,9 +353,10 @@ describe('DEFAULT_FILE_EXTENSIONS', () => {
     const mainPlugin = plugins.find(
       (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
     );
-    expect(mainPlugin).toBeDefined();
+    expect(mainPlugin?.transform).toBeDefined();
+    if (!mainPlugin?.transform) throw new Error('unreachable');
 
-    const transformFn = mainPlugin!.transform as Function;
+    const transformFn = mainPlugin.transform as Function;
     const mockContext = createMockPluginContext();
 
     // .css.ts should still be processed

--- a/packages/vite-plugin/src/fileExtension.test.ts
+++ b/packages/vite-plugin/src/fileExtension.test.ts
@@ -258,6 +258,50 @@ describe('vanillaExtractPlugin fileExtension option (full extension)', () => {
 
     expect(didAttemptTransform).toBe(true);
   });
+
+  /**
+   * Test that empty array processes no files (useful when consuming
+   * pre-compiled libraries without any local vanilla-extract styles)
+   */
+  it('processes no files when fileExtension is empty array', async () => {
+    const { vanillaExtractPlugin } = await import('./index');
+
+    const plugins = vanillaExtractPlugin({
+      fileExtension: [],
+    });
+
+    const mainPlugin = plugins.find(
+      (p): p is Plugin => p.name === 'vite-plugin-vanilla-extract',
+    );
+    expect(mainPlugin).toBeDefined();
+
+    const transformFn = mainPlugin!.transform as Function;
+    const mockContext = createMockPluginContext();
+
+    // .css.ts should NOT be processed
+    const cssResult = await transformFn.call(
+      mockContext,
+      'export const x = 1;',
+      '/project/src/styles.css.ts',
+    );
+    expect(cssResult).toBeNull();
+
+    // .ve.ts should NOT be processed
+    const veResult = await transformFn.call(
+      mockContext,
+      'export const x = 1;',
+      '/project/src/styles.ve.ts',
+    );
+    expect(veResult).toBeNull();
+
+    // Any file should NOT be processed
+    const anyResult = await transformFn.call(
+      mockContext,
+      'export const x = 1;',
+      '/project/src/styles.anything.ts',
+    );
+    expect(anyResult).toBeNull();
+  });
 });
 
 describe('DEFAULT_FILE_EXTENSIONS', () => {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -82,6 +82,11 @@ function createFileExtensionFilter(fileExtension: string | string[]): RegExp {
     ? fileExtension
     : [fileExtension];
 
+  // Empty array means match nothing
+  if (extensions.length === 0) {
+    return /(?!)/; // Regex that never matches
+  }
+
   // Escape special regex characters and normalize extensions (ensure leading dot)
   const escapedExtensions = extensions.map((ext) => {
     const normalizedExt = ext.startsWith('.') ? ext : `.${ext}`;
@@ -206,6 +211,7 @@ export function vanillaExtractPlugin({
       cssImportSpecifier: fileIdToVirtualId,
       viteConfig,
       enableFileWatcher: !isBuild,
+      fileFilter: veFileFilter,
     });
   };
 

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -11,12 +11,15 @@ import type {
 import { type Compiler, createCompiler } from '@vanilla-extract/compiler';
 import {
   cssFileFilter,
+  DEFAULT_FILE_EXTENSIONS,
   type IdentifierOption,
   getPackageInfo,
   transform,
   normalizePath,
 } from '@vanilla-extract/integration';
 import { getAbsoluteId } from './ids';
+
+export { DEFAULT_FILE_EXTENSIONS };
 
 const PLUGIN_NAMESPACE = 'vite-plugin-vanilla-extract';
 const virtualExtCss = '.vanilla.css';
@@ -43,6 +46,52 @@ interface Options {
   identifiers?: IdentifierOption;
   unstable_pluginFilter?: PluginFilter;
   unstable_mode?: 'transform' | 'emitCss' | 'inlineCssInDev';
+  /**
+   * Custom file extension(s) for vanilla-extract files. When specified, only
+   * files ending with these exact extensions will be processed instead of the
+   * default `.css.ts`, `.css.tsx`, etc.
+   *
+   * Unlike the default behavior which matches `.css.(ts|tsx|js|jsx|mjs|cjs)`,
+   * this option requires you to specify each exact extension you want to match.
+   *
+   * @example
+   * // Process only .ve.ts and .ve.tsx files
+   * vanillaExtractPlugin({ fileExtension: ['.ve.ts', '.ve.tsx'] })
+   *
+   * @example
+   * // Process only .styles.ts files
+   * vanillaExtractPlugin({ fileExtension: '.styles.ts' })
+   *
+   * @example
+   * // Add custom extensions while keeping the defaults
+   * import { DEFAULT_FILE_EXTENSIONS } from '@vanilla-extract/vite-plugin';
+   * vanillaExtractPlugin({ fileExtension: [...DEFAULT_FILE_EXTENSIONS, '.ve.ts'] })
+   */
+  fileExtension?: string | string[];
+}
+
+/**
+ * Creates a RegExp that matches files ending with the specified exact extension(s).
+ *
+ * @example
+ * createFileExtensionFilter('.ve.ts') // matches: foo.ve.ts
+ * createFileExtensionFilter(['.ve.ts', '.ve.tsx']) // matches: foo.ve.ts, bar.ve.tsx
+ */
+function createFileExtensionFilter(fileExtension: string | string[]): RegExp {
+  const extensions = Array.isArray(fileExtension)
+    ? fileExtension
+    : [fileExtension];
+
+  // Escape special regex characters and normalize extensions (ensure leading dot)
+  const escapedExtensions = extensions.map((ext) => {
+    const normalizedExt = ext.startsWith('.') ? ext : `.${ext}`;
+    return normalizedExt.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  });
+
+  // Build pattern that matches exact extensions with optional ?used suffix (Vite adds this)
+  // e.g., (\.ve\.ts|\.ve\.tsx)(\?used)?$
+  const extensionPattern = escapedExtensions.join('|');
+  return new RegExp(`(${extensionPattern})(\\?used)?$`);
 }
 
 // Plugins that we know are compatible with the `vite-node` compiler
@@ -61,7 +110,13 @@ export function vanillaExtractPlugin({
   identifiers,
   unstable_pluginFilter: pluginFilter = defaultPluginFilter,
   unstable_mode = 'emitCss',
+  fileExtension,
 }: Options = {}): Plugin[] {
+  // Create file filter based on fileExtension option or use default
+  const veFileFilter = fileExtension
+    ? createFileExtensionFilter(fileExtension)
+    : cssFileFilter;
+
   let config: ResolvedConfig;
   let configEnv: ConfigEnv;
   let server: ViteDevServer;
@@ -95,7 +150,7 @@ export function vanillaExtractPlugin({
     const seen = new Set<ModuleNode>();
 
     for (const mod of importerChain) {
-      if (mod.id && cssFileFilter.test(mod.id)) {
+      if (mod.id && veFileFilter.test(mod.id)) {
         const virtualModules = moduleGraph.getModulesByFile(
           fileIdToVirtualId(mod.id),
         );
@@ -242,7 +297,7 @@ export function vanillaExtractPlugin({
       async transform(code, id, options) {
         const [validId] = id.split('?');
 
-        if (!cssFileFilter.test(validId)) {
+        if (!veFileFilter.test(validId)) {
           return null;
         }
 

--- a/tests/compiler/compiler.test.ts
+++ b/tests/compiler/compiler.test.ts
@@ -834,7 +834,7 @@ describe('compiler', () => {
     expect(importerTree.size).toBe(0);
   });
 
-test('fileFilter option restricts which files get file scope transform', async () => {
+  test('fileFilter option restricts which files get file scope transform', async () => {
     const compiler = compilers.customFileFilter;
 
     // The compiler was created with fileFilter: /\.styles\.ts$/

--- a/tests/compiler/compiler.test.ts
+++ b/tests/compiler/compiler.test.ts
@@ -89,6 +89,10 @@ describe('compiler', () => {
     importerTree: createCompiler({
       root: __dirname,
     }),
+    customFileFilter: createCompiler({
+      root: __dirname,
+      fileFilter: /\.styles\.ts$/,
+    }),
   } as const;
 
   afterAll(async () => {
@@ -829,5 +833,21 @@ describe('compiler', () => {
     );
 
     expect(importerTree.size).toBe(0);
+  });
+
+  test('fileFilter option restricts which files get file scope transform', async () => {
+    const compiler = compilers.customFileFilter;
+
+    // The compiler was created with fileFilter: /\.styles\.ts$/
+    // So .css.ts files should NOT get the setFileScope transform applied,
+    // causing processVanillaFile to fail with "Styles were unable to be assigned to a file"
+    const cssPath = path.join(
+      __dirname,
+      'fixtures/class-composition/styles.css.ts',
+    );
+
+    await expect(compiler.processVanillaFile(cssPath)).rejects.toThrow(
+      'Styles were unable to be assigned to a file',
+    );
   });
 });


### PR DESCRIPTION
## Problem

When consuming pre-compiled vanilla-extract libraries that publish `.css.js` files, the vite plugin would reprocess those library files unnecessarily. Users needed a way to use a different extension (like `.ve.ts`) for their source files so only their code gets processed.

## Solution

Added a `fileExtension` option to `@vanilla-extract/vite-plugin` that lets users specify exactly which file extensions should be processed.

## Changes

### `@vanilla-extract/integration`

- Added `DEFAULT_FILE_EXTENSIONS` constant — a readonly array of the 6 standard extensions:
  - `.css.ts`, `.css.tsx`, `.css.js`, `.css.jsx`, `.css.mjs`, `.css.cjs`
- Refactored `cssFileFilter` to be **derived** from `DEFAULT_FILE_EXTENSIONS` rather than a separate hand-written regex. This prevents the two from drifting out of sync.

### `@vanilla-extract/vite-plugin`

- Added `fileExtension` option accepting a string or array of strings
- Re-exports `DEFAULT_FILE_EXTENSIONS` from integration for convenience
- When `fileExtension` is provided, only files matching those exact extensions are processed
- When omitted, behavior is unchanged (uses `cssFileFilter` from integration)

## Usage

### Replace default extensions entirely

```ts
import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';

export default {
  plugins: [
    vanillaExtractPlugin({
      // Only process .ve.ts and .ve.tsx files
      fileExtension: ['.ve.ts', '.ve.tsx'],
    }),
  ],
};
```

### Keep defaults and add custom extensions

```ts
import { vanillaExtractPlugin, DEFAULT_FILE_EXTENSIONS } from '@vanilla-extract/vite-plugin';

export default {
  plugins: [
    vanillaExtractPlugin({
      // Process all default extensions PLUS .ve.ts and .ve.tsx
      fileExtension: [...DEFAULT_FILE_EXTENSIONS, '.ve.ts', '.ve.tsx'],
    }),
  ],
};
```

Fixes #1574 