### PR TITLE
fix(sprinkles): reject duplicate property definitions

### DIFF
--- a/packages/sprinkles/src/createSprinkles.ts
+++ b/packages/sprinkles/src/createSprinkles.ts
@@ -67,11 +67,36 @@ export type SprinklesFn<Args extends ReadonlyArray<SprinklesProperties>> = ((
   props: SprinkleProps<Args>,
 ) => string) & { properties: Set<keyof SprinkleProps<Args>> };
 
+class SprinklesError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SprinklesError';
+  }
+}
+
+function validateUniqueProperties(args: ReadonlyArray<SprinklesProperties>) {
+  const propertyNames = new Set<string>();
+
+  for (const { styles } of args) {
+    for (const property of Object.keys(styles)) {
+      if (propertyNames.has(property)) {
+        throw new SprinklesError(
+          `"${property}" is defined in multiple properties collections. Properties and shorthands must be unique across all collections passed to createSprinkles`,
+        );
+      }
+
+      propertyNames.add(property);
+    }
+  }
+}
+
 export const createSprinkles =
   <Args extends ReadonlyArray<SprinklesProperties>>(
     composeStyles: (classList: string) => string,
   ) =>
   (...args: Args): SprinklesFn<Args> => {
+    validateUniqueProperties(args);
+
     const sprinklesStyles = Object.assign({}, ...args.map((a) => a.styles));
     const sprinklesKeys = Object.keys(sprinklesStyles) as Array<
       keyof SprinkleProps<Args>
@@ -163,13 +188,6 @@ export const createSprinkles =
           }
         } catch (e) {
           if (process.env.NODE_ENV !== 'production') {
-            class SprinklesError extends Error {
-              constructor(message: string) {
-                super(message);
-                this.name = 'SprinklesError';
-              }
-            }
-
             const invalidPropValue = (
               prop: string,
               value: string | number,

--- a/tests/sprinkles/index.css.ts
+++ b/tests/sprinkles/index.css.ts
@@ -126,3 +126,29 @@ export const shorthandsWithZeroValues = defineProperties({
     mt: ['marginTop'],
   },
 });
+
+export const responsiveBackgroundProperties = defineProperties({
+  defaultCondition: 'mobile',
+  conditions: {
+    mobile: {},
+    tablet: {
+      '@media': 'screen and (min-width: 786px)',
+    },
+  },
+  properties: {
+    backgroundColor: ['red', 'blue'],
+  },
+});
+
+export const stateBackgroundProperties = defineProperties({
+  defaultCondition: 'default',
+  conditions: {
+    default: {},
+    focus: {
+      selector: '&:focus',
+    },
+  },
+  properties: {
+    backgroundColor: ['red', 'blue'],
+  },
+});

--- a/tests/sprinkles/sprinkles.test.ts
+++ b/tests/sprinkles/sprinkles.test.ts
@@ -13,7 +13,9 @@ import {
   conditionalPropertiesWithMultipleDefaultConditions,
   conditionalPropertiesWithoutDefaultCondition,
   conditionalPropertiesWithoutResponsiveArray,
+  responsiveBackgroundProperties,
   shorthandsWithZeroValues,
+  stateBackgroundProperties,
 } from './index.css';
 
 describe('sprinkles', () => {
@@ -437,6 +439,17 @@ describe('sprinkles', () => {
         }),
       ).toThrowErrorMatchingInlineSnapshot(
         `[SprinklesError: "paddingTop" has no condition named "ultraWide". Possible values are "mobile", "tablet", "desktop"]`,
+      );
+    });
+
+    it('should handle duplicate properties across collections', () => {
+      expect(() =>
+        createSprinkles(
+          responsiveBackgroundProperties,
+          stateBackgroundProperties,
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[SprinklesError: "backgroundColor" is defined in multiple properties collections. Properties and shorthands must be unique across all collections passed to createSprinkles]`,
       );
     });
   });


### PR DESCRIPTION
## Summary
- detect duplicate sprinkles property/shorthand names across `createSprinkles` property collections before they can be overwritten
- throw a clear `SprinklesError` that explains properties must be unique across collections
- add regression coverage for duplicate `backgroundColor` definitions with different condition sets

Refs #590

## Testing
- `pnpm build`
- `pnpm test:unit tests/sprinkles/sprinkles.test.ts`
- `pnpm exec oxlint packages/sprinkles/src/createSprinkles.ts tests/sprinkles/index.css.ts tests/sprinkles/sprinkles.test.ts`
- `pnpm lint:prettier`
- `git diff --check`

Note: `pnpm lint:tsc` currently fails on pre-existing site typing/generated-docs issues (for example `site/src/docs-store.ts` cannot find `../docs-manifest.json`, plus several implicit-any errors in `site/src/DocsPage/DocsPage.tsx` and `site/src/HomePage/HomePage.tsx`).