### PR TITLE
`vite`: Don't emit empty chunks

### DIFF
--- a/.changeset/humble-rocks-agree.md
+++ b/.changeset/humble-rocks-agree.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/compiler': patch
+---
+
+`processVanillaFile`: Don't serialize import specifiers for module dependencies that emit no CSS

--- a/.changeset/real-geckos-sneeze.md
+++ b/.changeset/real-geckos-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Fixed a bug that caused Vite to emit empty CSS files when processing Vanilla Extract modules that emit no CSS

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -456,6 +456,9 @@ export const createCompiler = ({
                 });
               }
 
+              // `cssObjs` will be defined for every VE module with an injected file scope,
+              // so `cssRules` is always defined. VE modules that don't emit any CSS will have
+              // `css` set to an empty string.
               cssCache.set(cssDepModuleId, {
                 css: cssRules.join('\n'),
                 cssRules,
@@ -474,7 +477,8 @@ export const createCompiler = ({
             const { css = '', cssRules = [] } =
               cssCache.get(cssDepModuleId) ?? {};
 
-            if (cssObjs || css) {
+            const depEmitsCss = Boolean(cssObjs?.length || css);
+            if (depEmitsCss) {
               if (splitCssPerRule) {
                 const importSpecifiers = await Promise.all(
                   cssRules.map((rule, i) =>

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -338,12 +338,14 @@ export function vanillaExtractPlugin({
           root: config.root,
         });
 
-        if (
-          // We should always have CSS for a file here.
-          // The only valid scenario for a missing one is if someone had written
-          // a file in their app using the .vanilla.js/.vanilla.css extension
-          compiler?.getCssForFile(virtualIdToFileId(absoluteId))
-        ) {
+        if (!compiler) return;
+
+        // The only valid scenario for a missing CSS entry is if someone had
+        // written a file in their app using the .vanilla.js/.vanilla.css
+        // extension, or the file produced no CSS output.
+        const { css } = compiler.getCssForFile(virtualIdToFileId(absoluteId));
+
+        if (css) {
           // Keep the original query string for HMR.
           return absoluteId + (query ? `?${query}` : '');
         }
@@ -360,7 +362,9 @@ export function vanillaExtractPlugin({
 
         const { css } = compiler.getCssForFile(virtualIdToFileId(absoluteId));
 
-        return css;
+        if (css) {
+          return css;
+        }
       },
     },
   ];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -974,6 +974,12 @@ importers:
       '@vanilla-extract/sprinkles':
         specifier: workspace:*
         version: link:../packages/sprinkles
+      '@vanilla-extract/vite-plugin':
+        specifier: workspace:*
+        version: link:../packages/vite-plugin
+      vite:
+        specifier: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+        version: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(supports-color@9.2.3)(typescript@5.8.3)(vite@8.0.5)

--- a/tests/compiler/compiler.test.ts
+++ b/tests/compiler/compiler.test.ts
@@ -482,7 +482,6 @@ describe('compiler', () => {
     const { css } = compiler.getCssForFile(cssPath);
 
     expect(output.source).toMatchInlineSnapshot(`
-      import '{{__dirname}}/fixtures/vite-config/util/vars.css.ts.vanilla.css';
       import '{{__dirname}}/fixtures/vite-config/alias.css.ts.vanilla.css';
       export var root = 'alias_root__ez4dr20';
     `);
@@ -829,5 +828,35 @@ describe('compiler', () => {
     );
 
     expect(importerTree.size).toBe(0);
+  });
+
+  test('should not emit CSS imports for dependencies that produce no CSS', async () => {
+    const compiler = createCompiler({
+      root: __dirname,
+    });
+
+    try {
+      const cssPath = path.join(__dirname, 'fixtures/no-css-output/a.css.ts');
+      const dependencyCssPath = path.join(
+        __dirname,
+        'fixtures/no-css-output/contract.css.ts',
+      );
+
+      const output = await compiler.processVanillaFile(cssPath);
+
+      expect(output.source).not.toContain(
+        normalizePath(`${dependencyCssPath}.vanilla.css`),
+      );
+      expect(output.source).toContain(normalizePath(`${cssPath}.vanilla.css`));
+
+      const { css } = compiler.getCssForFile(cssPath);
+      expect(css).toMatchInlineSnapshot(`
+        .a_a__1mnazgr0 {
+          --component-token: var(--global-token);
+        }
+      `);
+    } finally {
+      await compiler.close();
+    }
   });
 });

--- a/tests/compiler/fixtures/no-css-output/a.css.ts
+++ b/tests/compiler/fixtures/no-css-output/a.css.ts
@@ -1,0 +1,18 @@
+import {
+  style,
+  createGlobalThemeContract,
+  assignVars,
+} from '@vanilla-extract/css';
+import { contract } from './contract.css';
+
+export const componentContract = createGlobalThemeContract({
+  color: {
+    primary: 'component-token',
+  },
+});
+
+export const a = style({
+  vars: assignVars(componentContract.color, {
+    primary: contract.color.primary,
+  }),
+});

--- a/tests/compiler/fixtures/no-css-output/contract.css.ts
+++ b/tests/compiler/fixtures/no-css-output/contract.css.ts
@@ -1,0 +1,7 @@
+import { createGlobalThemeContract } from '@vanilla-extract/css';
+
+export const contract = createGlobalThemeContract({
+  color: {
+    primary: 'global-token',
+  },
+});

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,6 +15,8 @@
     "@vanilla-extract/private": "workspace:*",
     "@vanilla-extract/recipes": "workspace:*",
     "@vanilla-extract/sprinkles": "workspace:*",
+    "@vanilla-extract/vite-plugin": "workspace:*",
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
     "vite-tsconfig-paths": "^5.1.4"
   }
 }

--- a/tests/vite-plugin/fixtures/lib-build/src/a.css.ts
+++ b/tests/vite-plugin/fixtures/lib-build/src/a.css.ts
@@ -1,0 +1,18 @@
+import {
+  style,
+  createGlobalThemeContract,
+  assignVars,
+} from '@vanilla-extract/css';
+import { contract } from './contract.css';
+
+export const componentContract = createGlobalThemeContract({
+  color: {
+    primary: 'component-token',
+  },
+});
+
+export const a = style({
+  vars: assignVars(componentContract.color, {
+    primary: contract.color.primary,
+  }),
+});

--- a/tests/vite-plugin/fixtures/lib-build/src/b.css.ts
+++ b/tests/vite-plugin/fixtures/lib-build/src/b.css.ts
@@ -1,0 +1,8 @@
+import { style, assignVars } from '@vanilla-extract/css';
+import { componentContract } from './a.css';
+
+export const b = style({
+  vars: assignVars(componentContract.color, {
+    primary: 'red',
+  }),
+});

--- a/tests/vite-plugin/fixtures/lib-build/src/contract.css.ts
+++ b/tests/vite-plugin/fixtures/lib-build/src/contract.css.ts
@@ -1,0 +1,7 @@
+import { createGlobalThemeContract } from '@vanilla-extract/css';
+
+export const contract = createGlobalThemeContract({
+  color: {
+    primary: 'global-token',
+  },
+});

--- a/tests/vite-plugin/no-empty-chunks.test.ts
+++ b/tests/vite-plugin/no-empty-chunks.test.ts
@@ -1,0 +1,78 @@
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+import { afterAll, describe, expect, test } from 'vitest';
+import { build } from 'vite';
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+import { normalizePath } from '@vanilla-extract/integration';
+
+describe('vite-plugin lib build', () => {
+  const fixtureRoot = path.join(__dirname, 'fixtures/lib-build');
+  let outDir: string;
+
+  expect.addSnapshotSerializer({
+    test: (val) => typeof val === 'string',
+    print: (val) =>
+      (val as string).replaceAll(normalizePath(fixtureRoot), '{{fixtureRoot}}'),
+  });
+
+  afterAll(async () => {
+    if (outDir) {
+      await fs.rm(outDir, { recursive: true, force: true });
+    }
+  });
+
+  test('does not emit empty entry CSS chunk with cssCodeSplit', async () => {
+    outDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 've-lib-build-empty-chunk-'),
+    );
+
+    const entryA = path.join(fixtureRoot, 'src/a.css.ts');
+    const entryB = path.join(fixtureRoot, 'src/b.css.ts');
+
+    await build({
+      root: fixtureRoot,
+      configFile: false,
+      plugins: [vanillaExtractPlugin()],
+      build: {
+        outDir,
+        lib: {
+          entry: [entryA, entryB],
+          formats: ['es'],
+        },
+      },
+      logLevel: 'silent',
+    });
+
+    const files = (await fs.readdir(outDir)).sort();
+    expect(files).toMatchInlineSnapshot(`
+      [
+        a.css.mjs,
+        b.css.mjs,
+        tests.css,
+      ]
+    `);
+
+    expect(await fs.readFile(path.join(outDir, 'a.css.mjs'), 'utf-8'))
+      .toMatchInlineSnapshot(`
+      /* empty css                           */
+      //#region tests/vite-plugin/fixtures/lib-build/src/a.css.ts
+      var e = { color: { primary: "var(--component-token)" } }, t = "_158fg7h0";
+      //#endregion
+      export { t as a, e as componentContract };
+    `);
+    expect(await fs.readFile(path.join(outDir, 'b.css.mjs'), 'utf-8'))
+      .toMatchInlineSnapshot(`
+      /* empty css                           */
+      //#region tests/vite-plugin/fixtures/lib-build/src/b.css.ts
+      var e = "xbgeyk0";
+      //#endregion
+      export { e as b };
+    `);
+    expect(await fs.readFile(path.join(outDir, 'tests.css'), 'utf-8'))
+      .toMatchInlineSnapshot(`
+      ._158fg7h0{--component-token:var(--global-token)}.xbgeyk0{--component-token:red}
+      /*$vite$:1*/
+    `);
+  });
+});


### PR DESCRIPTION
Empty chunks would sometimes be generated when building a library with the vite plugin. If a VE modules emits no CSS (e.g. it only defines CSS variables and doesn't call `style`), then sometimes Vite would emit an empty CSS file, but sometimes it wouldn't.

This was fixed by simply checking if there is any CSS to emit.

Fixes #1729.