### PR TITLE
`rollup`: Fix build failures when emiting CSS assets with relative paths

### DIFF
--- a/.changeset/rollup-plugin-rolldown-emitfile-paths.md
+++ b/.changeset/rollup-plugin-rolldown-emitfile-paths.md
@@ -1,0 +1,7 @@
+---
+'@vanilla-extract/rollup-plugin': patch
+---
+
+Fixed an issue where rolldown builds could fail when emitted CSS asset names include relative paths, such as when processing dependency or nested `.css.ts` files.
+
+This may change filepaths in build output (directory prefixes from input paths are no longer included in emitted CSS filenames), but asset contents and import paths in JS output remain correct.

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -21,10 +21,11 @@
   },
   "devDependencies": {
     "@fixtures/themed": "workspace:*",
+    "@fixtures/thirdparty": "workspace:*",
     "@rollup/plugin-json": "^6.1.0",
     "@vanilla-extract/css": "workspace:^",
     "esbuild": "~0.28.0",
-    "rolldown": "1.0.0-beta.27",
+    "rolldown": "^1.1.4",
     "rollup": "^4.20.0",
     "rollup-plugin-esbuild": "^6.1.1"
   },

--- a/packages/rollup-plugin/src/index.ts
+++ b/packages/rollup-plugin/src/index.ts
@@ -16,7 +16,7 @@ import {
   tryGetPackageName,
 } from './lib';
 
-const { relative, normalize, dirname } = posix;
+const { relative, normalize, dirname, basename } = posix;
 
 export interface Options {
   /**
@@ -159,7 +159,8 @@ export function vanillaExtractPlugin({
 
         const assetId = this.emitFile({
           type: 'asset',
-          name: moduleInfo.id,
+          name: basename(moduleInfo.id),
+          originalFileName: moduleInfo.id,
           source: moduleInfo.meta.css,
         });
         const assetPath = this.getFileName(assetId);

--- a/packages/rollup-plugin/test/__snapshots__/rollup-plugin.test.ts.snap
+++ b/packages/rollup-plugin/test/__snapshots__/rollup-plugin.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`rollup-plugin > Rollup settings > should build with preserveModules 1`] = `
 [
   [
-    "assets/src/shared.css.ts.vanilla-G_Gyt4-e.css",
+    "assets/shared.css.ts.vanilla-G_Gyt4-e.css",
     ".shared_shadow__4dtfen0 {
   box-shadow: 0 0 5px red;
 }
@@ -15,7 +15,7 @@ body, button {
 }",
   ],
   [
-    "assets/src/styles.css.ts.vanilla-BfisGtko.css",
+    "assets/styles.css.ts.vanilla-BfisGtko.css",
     "@font-face {
   src: local("Impact");
   font-family: "styles_impact__jteyb10";
@@ -73,7 +73,7 @@ html .styles_opacity_1\\/4__jteyb17 {
 }",
   ],
   [
-    "assets/src/themes.css.ts.vanilla-s9rcEmBH.css",
+    "assets/themes.css.ts.vanilla-s9rcEmBH.css",
     "@layer themes_themeLayer__cvta177;
 @layer globalThemeLayer;
 :root, .themes_theme__cvta170 {
@@ -208,7 +208,7 @@ render();
   ],
   [
     "src/shared.css.js",
-    "import './../assets/src/shared.css.ts.vanilla-G_Gyt4-e.css';
+    "import './../assets/shared.css.ts.vanilla-G_Gyt4-e.css';
 
 var shadow = "shared_shadow__4dtfen0";
 
@@ -217,9 +217,9 @@ export { shadow };
   ],
   [
     "src/styles.css.js",
-    "import './../assets/src/shared.css.ts.vanilla-G_Gyt4-e.css';
-import './../assets/src/themes.css.ts.vanilla-s9rcEmBH.css';
-import './../assets/src/styles.css.ts.vanilla-BfisGtko.css';
+    "import './../assets/shared.css.ts.vanilla-G_Gyt4-e.css';
+import './../assets/themes.css.ts.vanilla-s9rcEmBH.css';
+import './../assets/styles.css.ts.vanilla-BfisGtko.css';
 
 var button = "styles_button__jteyb13 shared_shadow__4dtfen0 styles_iDunno__jteyb12";
 var container = "styles_container__jteyb11";
@@ -230,7 +230,7 @@ export { button, container, opacity };
   ],
   [
     "src/themes.css.js",
-    "import './../assets/src/themes.css.ts.vanilla-s9rcEmBH.css';
+    "import './../assets/themes.css.ts.vanilla-s9rcEmBH.css';
 
 var altTheme = "themes_altTheme__cvta176";
 var responsiveTheme = "themes_responsiveTheme__cvta17e";
@@ -854,15 +854,15 @@ export { altButton, altContainer, testNodes as default, dynamicVarsButton, dynam
 exports[`rollup-plugin > Rollup settings > should build with sourcemaps 1`] = `
 [
   [
-    "assets/src/shared.css.ts.vanilla-G_Gyt4-e.css",
+    "assets/shared.css.ts.vanilla-G_Gyt4-e.css",
     "",
   ],
   [
-    "assets/src/styles.css.ts.vanilla-BfisGtko.css",
+    "assets/styles.css.ts.vanilla-BfisGtko.css",
     "",
   ],
   [
-    "assets/src/themes.css.ts.vanilla-s9rcEmBH.css",
+    "assets/themes.css.ts.vanilla-s9rcEmBH.css",
     "",
   ],
   [
@@ -911,7 +911,7 @@ exports[`rollup-plugin > Rollup settings > should build with sourcemaps 1`] = `
 exports[`rollup-plugin > Rollup settings > should build without preserveModules 1`] = `
 [
   [
-    "assets/src/shared.css.ts.vanilla-G_Gyt4-e.css",
+    "assets/shared.css.ts.vanilla-G_Gyt4-e.css",
     ".shared_shadow__4dtfen0 {
   box-shadow: 0 0 5px red;
 }
@@ -923,7 +923,7 @@ body, button {
 }",
   ],
   [
-    "assets/src/styles.css.ts.vanilla-BfisGtko.css",
+    "assets/styles.css.ts.vanilla-BfisGtko.css",
     "@font-face {
   src: local("Impact");
   font-family: "styles_impact__jteyb10";
@@ -981,7 +981,7 @@ html .styles_opacity_1\\/4__jteyb17 {
 }",
   ],
   [
-    "assets/src/themes.css.ts.vanilla-s9rcEmBH.css",
+    "assets/themes.css.ts.vanilla-s9rcEmBH.css",
     "@layer themes_themeLayer__cvta177;
 @layer globalThemeLayer;
 :root, .themes_theme__cvta170 {
@@ -1033,9 +1033,9 @@ html .styles_opacity_1\\/4__jteyb17 {
   [
     "index.js",
     "import { assignInlineVars, setElementVars } from '@vanilla-extract/dynamic';
-import './assets/src/themes.css.ts.vanilla-s9rcEmBH.css';
-import './assets/src/shared.css.ts.vanilla-G_Gyt4-e.css';
-import './assets/src/styles.css.ts.vanilla-BfisGtko.css';
+import './assets/themes.css.ts.vanilla-s9rcEmBH.css';
+import './assets/shared.css.ts.vanilla-G_Gyt4-e.css';
+import './assets/styles.css.ts.vanilla-BfisGtko.css';
 
 var altTheme = "themes_altTheme__cvta176";
 var responsiveTheme = "themes_responsiveTheme__cvta17e";
@@ -1770,29 +1770,28 @@ exports[`rollup-plugin > should be compatible with rolldown > extract generates 
   [
     "app.js",
     "import "./styles/reset.css.js";
-import { Button } from "./button/button.js";
-import { Radio } from "./checkbox/checkbox.js";
-import { Radio as Radio$1 } from "./radio/radio.js";
+import Button from "./button/button.js";
+import Radio from "./checkbox/checkbox.js";
+import Radio$1 from "./radio/radio.js";
 import "./styles/utility.css.js";
-
-export { Button, Radio as Checkbox, Radio$1 as Radio };",
+export { Button, Radio as Checkbox, Radio$1 as Radio };
+",
   ],
   [
     "button/button.css.js",
     "//#region fixtures/react-library-example/src/button/button.css.ts
 var btn = "button_btn__s626q60";
-
 //#endregion
-export { btn };",
+export { btn };
+",
   ],
   [
     "button/button.js",
     "import { btn } from "./button.css.js";
 import clsx from "clsx";
 import { jsx } from "react/jsx-runtime";
-
 //#region fixtures/react-library-example/src/button/button.tsx
-function Button({ className, children, type = "button",...props }) {
+function Button({ className, children, type = "button", ...props }) {
 	return /* @__PURE__ */ jsx("button", {
 		...props,
 		type,
@@ -1800,18 +1799,18 @@ function Button({ className, children, type = "button",...props }) {
 		children
 	});
 }
-
 //#endregion
-export { Button };",
+export { Button as default };
+",
   ],
   [
     "checkbox/checkbox.css.js",
     "//#region fixtures/react-library-example/src/checkbox/checkbox.css.ts
 var input = "checkbox_input__8y0ume1";
 var label = "checkbox_label__8y0ume0";
-
 //#endregion
-export { input, label };",
+export { input, label };
+",
   ],
   [
     "checkbox/checkbox.js",
@@ -1819,9 +1818,8 @@ export { input, label };",
 import clsx from "clsx";
 import { Fragment, jsx, jsxs } from "react/jsx-runtime";
 import { useId } from "react";
-
 //#region fixtures/react-library-example/src/checkbox/checkbox.tsx
-function Radio({ children, className, id,...props }) {
+function Radio({ children, className, id, ...props }) {
 	const randomID = useId();
 	return /* @__PURE__ */ jsxs(Fragment, { children: [/* @__PURE__ */ jsx("input", {
 		...props,
@@ -1834,18 +1832,18 @@ function Radio({ children, className, id,...props }) {
 		children
 	})] });
 }
-
 //#endregion
-export { Radio };",
+export { Radio as default };
+",
   ],
   [
     "radio/radio.css.js",
     "//#region fixtures/react-library-example/src/radio/radio.css.ts
 var input = "radio_input__1uatvdb1";
 var label = "radio_label__1uatvdb0";
-
 //#endregion
-export { input, label };",
+export { input, label };
+",
   ],
   [
     "radio/radio.js",
@@ -1853,9 +1851,8 @@ export { input, label };",
 import clsx from "clsx";
 import { Fragment, jsx, jsxs } from "react/jsx-runtime";
 import { useId } from "react";
-
 //#region fixtures/react-library-example/src/radio/radio.tsx
-function Radio({ children, className, id,...props }) {
+function Radio({ children, className, id, ...props }) {
 	const randomID = useId();
 	return /* @__PURE__ */ jsxs(Fragment, { children: [/* @__PURE__ */ jsx("input", {
 		...props,
@@ -1868,9 +1865,9 @@ function Radio({ children, className, id,...props }) {
 		children
 	})] });
 }
-
 //#endregion
-export { Radio };",
+export { Radio as default };
+",
   ],
   [
     "styles/reset.css.js",
@@ -1879,6 +1876,142 @@ export { Radio };",
   [
     "styles/utility.css.js",
     "",
+  ],
+]
+`;
+
+exports[`rollup-plugin > should be compatible with rolldown > should build thirdparty dependencies 1`] = `
+[
+  [
+    "assets/styles.css.mjs.vanilla-CrOjccUD.css",
+    ".styles_depdepBlock__7q0fkw1 {
+  --depdepColor__7q0fkw0: blue;
+  background-color: var(--depdepColor__7q0fkw0);
+}",
+  ],
+  [
+    "assets/styles.css.mjs.vanilla-D9Urel4Y.css",
+    ".styles_depBlock__vg1esd1 {
+  --depColor__vg1esd0: green;
+  background-color: var(--depColor__vg1esd0);
+}",
+  ],
+  [
+    "assets/styles.css.ts.vanilla-Bah2oB25.css",
+    ".styles_block__1vrxmse1 {
+  --color__1vrxmse0: red;
+  background-color: var(--color__1vrxmse0);
+}",
+  ],
+  [
+    "src/index.js",
+    "import { block, depBlock, depdepBlock } from "./styles.css.js";
+import { first, third, thirdThird } from "../test-nodes.js";
+//#region fixtures/thirdparty/src/index.ts
+document.body.innerHTML = \`
+  <div id="\${first}" class="\${block}">
+    I'm a first-party block
+    <div id="\${third}" class="\${depBlock}">
+      I'm a third party block
+      <div id="\${thirdThird}" class="\${depdepBlock}">
+        I'm a third party of third party block
+      </div>
+    </div>
+  </div>
+\`;
+//#endregion
+",
+  ],
+  [
+    "src/styles.css.js",
+    "import "./../assets/styles.css.mjs.vanilla-D9Urel4Y.css";
+import "./../assets/styles.css.mjs.vanilla-CrOjccUD.css";
+import "./../assets/styles.css.ts.vanilla-Bah2oB25.css";
+//#region fixtures/thirdparty/src/styles.css.ts
+var block = "styles_block__1vrxmse1";
+var depBlock = "styles_depBlock__vg1esd1";
+var depdepBlock = "styles_depdepBlock__7q0fkw1";
+//#endregion
+export { block, depBlock, depdepBlock };
+",
+  ],
+  [
+    "test-nodes.js",
+    "//#region fixtures/thirdparty/test-nodes.json
+var first = "first";
+var third = "third";
+var thirdThird = "thirdThird";
+//#endregion
+export { first, third, thirdThird };
+",
+  ],
+]
+`;
+
+exports[`rollup-plugin > should be compatible with rolldown > should build thirdparty dependencies with nested cwd 1`] = `
+[
+  [
+    "assets/styles.css.mjs.vanilla-BDW24ak-.css",
+    ".styles_depBlock__mpzl121 {
+  --depColor__mpzl120: green;
+  background-color: var(--depColor__mpzl120);
+}",
+  ],
+  [
+    "assets/styles.css.mjs.vanilla-DCRy3bAw.css",
+    ".styles_depdepBlock__9lp6xd1 {
+  --depdepColor__9lp6xd0: blue;
+  background-color: var(--depdepColor__9lp6xd0);
+}",
+  ],
+  [
+    "assets/styles.css.ts.vanilla-Du-3RMhd.css",
+    ".styles_block__1dwu2ur1 {
+  --color__1dwu2ur0: red;
+  background-color: var(--color__1dwu2ur0);
+}",
+  ],
+  [
+    "src/index.js",
+    "import { block, depBlock, depdepBlock } from "./styles.css.js";
+import { first, third, thirdThird } from "../test-nodes.js";
+//#region fixtures/thirdparty/src/index.ts
+document.body.innerHTML = \`
+  <div id="\${first}" class="\${block}">
+    I'm a first-party block
+    <div id="\${third}" class="\${depBlock}">
+      I'm a third party block
+      <div id="\${thirdThird}" class="\${depdepBlock}">
+        I'm a third party of third party block
+      </div>
+    </div>
+  </div>
+\`;
+//#endregion
+",
+  ],
+  [
+    "src/styles.css.js",
+    "import "./../assets/styles.css.mjs.vanilla-BDW24ak-.css";
+import "./../assets/styles.css.mjs.vanilla-DCRy3bAw.css";
+import "./../assets/styles.css.ts.vanilla-Du-3RMhd.css";
+//#region fixtures/thirdparty/src/styles.css.ts
+var block = "styles_block__1dwu2ur1";
+var depBlock = "styles_depBlock__mpzl121";
+var depdepBlock = "styles_depdepBlock__9lp6xd1";
+//#endregion
+export { block, depBlock, depdepBlock };
+",
+  ],
+  [
+    "test-nodes.js",
+    "//#region fixtures/thirdparty/test-nodes.json
+var first = "first";
+var third = "third";
+var thirdThird = "thirdThird";
+//#endregion
+export { first, third, thirdThird };
+",
   ],
 ]
 `;
@@ -2010,9 +2143,8 @@ html .styles_opacity_1\\/4__jteyb17 {
     "import { altTheme, responsiveTheme, theme, vars } from "./themes.css.js";
 import { button, container, opacity } from "./styles.css.js";
 import { shadow } from "./shared.css.js";
-import test_nodes_default from "../test-nodes.js";
+import { altButton, altContainer, dynamicVarsButton, dynamicVarsContainer, inlineThemeButton, inlineThemeContainer, nestedRootButton, nestedRootContainer, responsiveThemeButton, responsiveThemeContainer, root, rootButton, rootContainer } from "../test-nodes.js";
 import { assignInlineVars, setElementVars } from "@vanilla-extract/dynamic";
-
 //#region fixtures/themed/src/index.ts
 const inlineTheme = assignInlineVars(vars, {
 	colors: {
@@ -2027,30 +2159,30 @@ const inlineTheme = assignInlineVars(vars, {
 });
 function render() {
 	document.body.innerHTML = \`
-  <div id="\${test_nodes_default.root}" class="\${shadow}"> 
+  <div id="\${root}" class="\${shadow}"> 
     Root theme
-    <div id="\${test_nodes_default.rootContainer}" class="\${container}">
-      <button id="\${test_nodes_default.rootButton}" class="\${button}">Main theme button</button>
+    <div id="\${rootContainer}" class="\${container}">
+      <button id="\${rootButton}" class="\${button}">Main theme button</button>
       <div class="\${altTheme}"> 
         Alt theme
-        <div id="\${test_nodes_default.altContainer}" class="\${container}">
-          <button id="\${test_nodes_default.altButton}" class="\${button}">Alt theme button</button>
+        <div id="\${altContainer}" class="\${container}">
+          <button id="\${altButton}" class="\${button}">Alt theme button</button>
           <div class="\${theme}"> 
             Back to root theme
-            <div id="\${test_nodes_default.nestedRootContainer}" class="\${container}">
-              <button id="\${test_nodes_default.nestedRootButton}" class="\${button}">Main theme button</button>
+            <div id="\${nestedRootContainer}" class="\${container}">
+              <button id="\${nestedRootButton}" class="\${button}">Main theme button</button>
             <div style="\${inlineTheme}">
               Inline theme
-                <div id="\${test_nodes_default.inlineThemeContainer}" class="\${container}">
-                  <button id="\${test_nodes_default.inlineThemeButton}" class="\${button} \${opacity["1/2"]}">Inline theme <span class="{\${opacity["1/4"]}}">button</span></button>
+                <div id="\${inlineThemeContainer}" class="\${container}">
+                  <button id="\${inlineThemeButton}" class="\${button} \${opacity["1/2"]}">Inline theme <span class="{\${opacity["1/4"]}}">button</span></button>
                   <div>
                   Dynamic vars
-                    <div id="\${test_nodes_default.dynamicVarsContainer}" class="\${container}">
-                      <button id="\${test_nodes_default.dynamicVarsButton}" class="\${button}">Dynamic vars button</button>
+                    <div id="\${dynamicVarsContainer}" class="\${container}">
+                      <button id="\${dynamicVarsButton}" class="\${button}">Dynamic vars button</button>
                   <div class="\${responsiveTheme}">
               Responsive theme
-                <div id="\${test_nodes_default.responsiveThemeContainer}" class="\${container}">
-                  <button id="\${test_nodes_default.responsiveThemeButton}" class="\${button}">Responsive theme button</button>
+                <div id="\${responsiveThemeContainer}" class="\${container}">
+                  <button id="\${responsiveThemeButton}" class="\${button}">Responsive theme button</button>
                             </div>
                           </div>
                         </div>
@@ -2066,9 +2198,9 @@ function render() {
     </div>
   </div>
 \`;
-	const dynamicVarsContainer = document.getElementById(test_nodes_default.dynamicVarsContainer);
-	if (!dynamicVarsContainer) throw new Error("Dynamic vars container not found.");
-	setElementVars(dynamicVarsContainer, vars, {
+	const dynamicVarsContainer$1 = document.getElementById(dynamicVarsContainer);
+	if (!dynamicVarsContainer$1) throw new Error("Dynamic vars container not found.");
+	setElementVars(dynamicVarsContainer$1, vars, {
 		colors: {
 			backgroundColor: "transparent",
 			text: "papayawhip"
@@ -2079,28 +2211,26 @@ function render() {
 			3: "15px"
 		}
 	});
-	setElementVars(dynamicVarsContainer, { [vars.colors.backgroundColor]: "darksalmon" });
+	setElementVars(dynamicVarsContainer$1, { [vars.colors.backgroundColor]: "darksalmon" });
 }
 render();
-
-//#endregion",
+//#endregion
+",
   ],
   [
     "src/shared.css.js",
     "import "./../assets/shared.css.ts.vanilla-G_Gyt4-e.css";
-
 //#region fixtures/themed/src/shared.css.ts
 var shadow = "shared_shadow__4dtfen0";
-
 //#endregion
-export { shadow };",
+export { shadow };
+",
   ],
   [
     "src/styles.css.js",
     "import "./../assets/themes.css.ts.vanilla-s9rcEmBH.css";
 import "./../assets/shared.css.ts.vanilla-G_Gyt4-e.css";
 import "./../assets/styles.css.ts.vanilla-BfisGtko.css";
-
 //#region fixtures/themed/src/styles.css.ts
 var button = "styles_button__jteyb13 shared_shadow__4dtfen0 styles_iDunno__jteyb12";
 var container = "styles_container__jteyb11";
@@ -2108,14 +2238,13 @@ var opacity = {
 	"1/2": "styles_opacity_1/2__jteyb16",
 	"1/4": "styles_opacity_1/4__jteyb17"
 };
-
 //#endregion
-export { button, container, opacity };",
+export { button, container, opacity };
+",
   ],
   [
     "src/themes.css.js",
     "import "./../assets/themes.css.ts.vanilla-s9rcEmBH.css";
-
 //#region fixtures/themed/src/themes.css.ts
 var altTheme = "themes_altTheme__cvta176";
 var responsiveTheme = "themes_responsiveTheme__cvta17e";
@@ -2131,9 +2260,9 @@ var vars = {
 		"3": "var(--space-3__cvta175)"
 	}
 };
-
 //#endregion
-export { altTheme, responsiveTheme, theme, vars };",
+export { altTheme, responsiveTheme, theme, vars };
+",
   ],
   [
     "test-nodes.js",
@@ -2151,24 +2280,9 @@ var dynamicVarsContainer = "dynamicVarsContainer";
 var dynamicVarsButton = "dynamicVarsButton";
 var responsiveThemeContainer = "responsiveThemeContainer";
 var responsiveThemeButton = "responsiveThemeButton";
-var test_nodes_default = {
-	root,
-	rootContainer,
-	rootButton,
-	altContainer,
-	altButton,
-	nestedRootContainer,
-	nestedRootButton,
-	inlineThemeContainer,
-	inlineThemeButton,
-	dynamicVarsContainer,
-	dynamicVarsButton,
-	responsiveThemeContainer,
-	responsiveThemeButton
-};
-
 //#endregion
-export { test_nodes_default as default };",
+export { altButton, altContainer, dynamicVarsButton, dynamicVarsContainer, inlineThemeButton, inlineThemeContainer, nestedRootButton, nestedRootContainer, responsiveThemeButton, responsiveThemeContainer, root, rootButton, rootContainer };
+",
   ],
 ]
 `;
@@ -2180,9 +2294,8 @@ exports[`rollup-plugin > should be compatible with rolldown > should build with 
     "import { altTheme, responsiveTheme, theme, vars } from "./themes.css.js";
 import { button, container, opacity } from "./styles.css.js";
 import { shadow } from "./shared.css.js";
-import test_nodes_default from "./test-nodes.js";
+import { altButton, altContainer, dynamicVarsButton, dynamicVarsContainer, inlineThemeButton, inlineThemeContainer, nestedRootButton, nestedRootContainer, responsiveThemeButton, responsiveThemeContainer, root, rootButton, rootContainer } from "./test-nodes.js";
 import { assignInlineVars, setElementVars } from "@vanilla-extract/dynamic";
-
 //#region fixtures/themed/src/index.ts
 const inlineTheme = assignInlineVars(vars, {
 	colors: {
@@ -2197,30 +2310,30 @@ const inlineTheme = assignInlineVars(vars, {
 });
 function render() {
 	document.body.innerHTML = \`
-  <div id="\${test_nodes_default.root}" class="\${shadow}"> 
+  <div id="\${root}" class="\${shadow}"> 
     Root theme
-    <div id="\${test_nodes_default.rootContainer}" class="\${container}">
-      <button id="\${test_nodes_default.rootButton}" class="\${button}">Main theme button</button>
+    <div id="\${rootContainer}" class="\${container}">
+      <button id="\${rootButton}" class="\${button}">Main theme button</button>
       <div class="\${altTheme}"> 
         Alt theme
-        <div id="\${test_nodes_default.altContainer}" class="\${container}">
-          <button id="\${test_nodes_default.altButton}" class="\${button}">Alt theme button</button>
+        <div id="\${altContainer}" class="\${container}">
+          <button id="\${altButton}" class="\${button}">Alt theme button</button>
           <div class="\${theme}"> 
             Back to root theme
-            <div id="\${test_nodes_default.nestedRootContainer}" class="\${container}">
-              <button id="\${test_nodes_default.nestedRootButton}" class="\${button}">Main theme button</button>
+            <div id="\${nestedRootContainer}" class="\${container}">
+              <button id="\${nestedRootButton}" class="\${button}">Main theme button</button>
             <div style="\${inlineTheme}">
               Inline theme
-                <div id="\${test_nodes_default.inlineThemeContainer}" class="\${container}">
-                  <button id="\${test_nodes_default.inlineThemeButton}" class="\${button} \${opacity["1/2"]}">Inline theme <span class="{\${opacity["1/4"]}}">button</span></button>
+                <div id="\${inlineThemeContainer}" class="\${container}">
+                  <button id="\${inlineThemeButton}" class="\${button} \${opacity["1/2"]}">Inline theme <span class="{\${opacity["1/4"]}}">button</span></button>
                   <div>
                   Dynamic vars
-                    <div id="\${test_nodes_default.dynamicVarsContainer}" class="\${container}">
-                      <button id="\${test_nodes_default.dynamicVarsButton}" class="\${button}">Dynamic vars button</button>
+                    <div id="\${dynamicVarsContainer}" class="\${container}">
+                      <button id="\${dynamicVarsButton}" class="\${button}">Dynamic vars button</button>
                   <div class="\${responsiveTheme}">
               Responsive theme
-                <div id="\${test_nodes_default.responsiveThemeContainer}" class="\${container}">
-                  <button id="\${test_nodes_default.responsiveThemeButton}" class="\${button}">Responsive theme button</button>
+                <div id="\${responsiveThemeContainer}" class="\${container}">
+                  <button id="\${responsiveThemeButton}" class="\${button}">Responsive theme button</button>
                             </div>
                           </div>
                         </div>
@@ -2236,9 +2349,9 @@ function render() {
     </div>
   </div>
 \`;
-	const dynamicVarsContainer = document.getElementById(test_nodes_default.dynamicVarsContainer);
-	if (!dynamicVarsContainer) throw new Error("Dynamic vars container not found.");
-	setElementVars(dynamicVarsContainer, vars, {
+	const dynamicVarsContainer$1 = document.getElementById(dynamicVarsContainer);
+	if (!dynamicVarsContainer$1) throw new Error("Dynamic vars container not found.");
+	setElementVars(dynamicVarsContainer$1, vars, {
 		colors: {
 			backgroundColor: "transparent",
 			text: "papayawhip"
@@ -2249,21 +2362,20 @@ function render() {
 			3: "15px"
 		}
 	});
-	setElementVars(dynamicVarsContainer, { [vars.colors.backgroundColor]: "darksalmon" });
+	setElementVars(dynamicVarsContainer$1, { [vars.colors.backgroundColor]: "darksalmon" });
 }
 render();
-
-//#endregion",
+//#endregion
+",
   ],
   [
     "shared.css.js",
     "import "./shared.css.ts.vanilla.css";
-
 //#region fixtures/themed/src/shared.css.ts
 var shadow = "shared_shadow__4dtfen0";
-
 //#endregion
-export { shadow };",
+export { shadow };
+",
   ],
   [
     "shared.css.ts.vanilla.css",
@@ -2282,7 +2394,6 @@ body, button {
     "import "./themes.css.ts.vanilla.css";
 import "./shared.css.ts.vanilla.css";
 import "./styles.css.ts.vanilla.css";
-
 //#region fixtures/themed/src/styles.css.ts
 var button = "styles_button__jteyb13 shared_shadow__4dtfen0 styles_iDunno__jteyb12";
 var container = "styles_container__jteyb11";
@@ -2290,9 +2401,9 @@ var opacity = {
 	"1/2": "styles_opacity_1/2__jteyb16",
 	"1/4": "styles_opacity_1/4__jteyb17"
 };
-
 //#endregion
-export { button, container, opacity };",
+export { button, container, opacity };
+",
   ],
   [
     "styles.css.ts.vanilla.css",
@@ -2368,29 +2479,13 @@ var dynamicVarsContainer = "dynamicVarsContainer";
 var dynamicVarsButton = "dynamicVarsButton";
 var responsiveThemeContainer = "responsiveThemeContainer";
 var responsiveThemeButton = "responsiveThemeButton";
-var test_nodes_default = {
-	root,
-	rootContainer,
-	rootButton,
-	altContainer,
-	altButton,
-	nestedRootContainer,
-	nestedRootButton,
-	inlineThemeContainer,
-	inlineThemeButton,
-	dynamicVarsContainer,
-	dynamicVarsButton,
-	responsiveThemeContainer,
-	responsiveThemeButton
-};
-
 //#endregion
-export { test_nodes_default as default };",
+export { altButton, altContainer, dynamicVarsButton, dynamicVarsContainer, inlineThemeButton, inlineThemeContainer, nestedRootButton, nestedRootContainer, responsiveThemeButton, responsiveThemeContainer, root, rootButton, rootContainer };
+",
   ],
   [
     "themes.css.js",
     "import "./themes.css.ts.vanilla.css";
-
 //#region fixtures/themed/src/themes.css.ts
 var altTheme = "themes_altTheme__cvta176";
 var responsiveTheme = "themes_responsiveTheme__cvta17e";
@@ -2406,9 +2501,9 @@ var vars = {
 		"3": "var(--space-3__cvta175)"
 	}
 };
-
 //#endregion
-export { altTheme, responsiveTheme, theme, vars };",
+export { altTheme, responsiveTheme, theme, vars };
+",
   ],
   [
     "themes.css.ts.vanilla.css",
@@ -2470,9 +2565,8 @@ exports[`rollup-plugin > should be compatible with rolldown > should build with 
     "import { altTheme, responsiveTheme, theme, vars } from "./themes.css.js";
 import { shadow } from "./shared.css.js";
 import { button, container, opacity } from "./styles.css.js";
-import test_nodes_default from "./test-nodes.js";
+import { altButton, altContainer, dynamicVarsButton, dynamicVarsContainer, inlineThemeButton, inlineThemeContainer, nestedRootButton, nestedRootContainer, responsiveThemeButton, responsiveThemeContainer, root, rootButton, rootContainer } from "./test-nodes.js";
 import { assignInlineVars, setElementVars } from "@vanilla-extract/dynamic";
-
 //#region fixtures/themed/src/index.ts
 const inlineTheme = assignInlineVars(vars, {
 	colors: {
@@ -2487,30 +2581,30 @@ const inlineTheme = assignInlineVars(vars, {
 });
 function render() {
 	document.body.innerHTML = \`
-  <div id="\${test_nodes_default.root}" class="\${shadow}"> 
+  <div id="\${root}" class="\${shadow}"> 
     Root theme
-    <div id="\${test_nodes_default.rootContainer}" class="\${container}">
-      <button id="\${test_nodes_default.rootButton}" class="\${button}">Main theme button</button>
+    <div id="\${rootContainer}" class="\${container}">
+      <button id="\${rootButton}" class="\${button}">Main theme button</button>
       <div class="\${altTheme}"> 
         Alt theme
-        <div id="\${test_nodes_default.altContainer}" class="\${container}">
-          <button id="\${test_nodes_default.altButton}" class="\${button}">Alt theme button</button>
+        <div id="\${altContainer}" class="\${container}">
+          <button id="\${altButton}" class="\${button}">Alt theme button</button>
           <div class="\${theme}"> 
             Back to root theme
-            <div id="\${test_nodes_default.nestedRootContainer}" class="\${container}">
-              <button id="\${test_nodes_default.nestedRootButton}" class="\${button}">Main theme button</button>
+            <div id="\${nestedRootContainer}" class="\${container}">
+              <button id="\${nestedRootButton}" class="\${button}">Main theme button</button>
             <div style="\${inlineTheme}">
               Inline theme
-                <div id="\${test_nodes_default.inlineThemeContainer}" class="\${container}">
-                  <button id="\${test_nodes_default.inlineThemeButton}" class="\${button} \${opacity["1/2"]}">Inline theme <span class="{\${opacity["1/4"]}}">button</span></button>
+                <div id="\${inlineThemeContainer}" class="\${container}">
+                  <button id="\${inlineThemeButton}" class="\${button} \${opacity["1/2"]}">Inline theme <span class="{\${opacity["1/4"]}}">button</span></button>
                   <div>
                   Dynamic vars
-                    <div id="\${test_nodes_default.dynamicVarsContainer}" class="\${container}">
-                      <button id="\${test_nodes_default.dynamicVarsButton}" class="\${button}">Dynamic vars button</button>
+                    <div id="\${dynamicVarsContainer}" class="\${container}">
+                      <button id="\${dynamicVarsButton}" class="\${button}">Dynamic vars button</button>
                   <div class="\${responsiveTheme}">
               Responsive theme
-                <div id="\${test_nodes_default.responsiveThemeContainer}" class="\${container}">
-                  <button id="\${test_nodes_default.responsiveThemeButton}" class="\${button}">Responsive theme button</button>
+                <div id="\${responsiveThemeContainer}" class="\${container}">
+                  <button id="\${responsiveThemeButton}" class="\${button}">Responsive theme button</button>
                             </div>
                           </div>
                         </div>
@@ -2526,9 +2620,9 @@ function render() {
     </div>
   </div>
 \`;
-	const dynamicVarsContainer = document.getElementById(test_nodes_default.dynamicVarsContainer);
-	if (!dynamicVarsContainer) throw new Error("Dynamic vars container not found.");
-	setElementVars(dynamicVarsContainer, vars, {
+	const dynamicVarsContainer$1 = document.getElementById(dynamicVarsContainer);
+	if (!dynamicVarsContainer$1) throw new Error("Dynamic vars container not found.");
+	setElementVars(dynamicVarsContainer$1, vars, {
 		colors: {
 			backgroundColor: "transparent",
 			text: "papayawhip"
@@ -2539,26 +2633,25 @@ function render() {
 			3: "15px"
 		}
 	});
-	setElementVars(dynamicVarsContainer, { [vars.colors.backgroundColor]: "darksalmon" });
+	setElementVars(dynamicVarsContainer$1, { [vars.colors.backgroundColor]: "darksalmon" });
 }
 render();
-
-//#endregion",
+//#endregion
+",
   ],
   [
     "shared.css.js",
     "import { endFileScope, setFileScope } from "@vanilla-extract/css/fileScope";
 import { globalStyle, style } from "@vanilla-extract/css";
-
 //#region fixtures/themed/src/shared.css.ts
 setFileScope("src/shared.css.ts", "@fixtures/themed");
 const shadow = style({ boxShadow: "0 0 5px red" }, "shadow");
 globalStyle("body", { backgroundColor: "skyblue" });
 globalStyle("body, button", { lineHeight: "16px" });
 endFileScope();
-
 //#endregion
-export { shadow };",
+export { shadow };
+",
   ],
   [
     "styles.css.js",
@@ -2566,7 +2659,6 @@ export { shadow };",
 import { shadow } from "./shared.css.js";
 import { endFileScope, setFileScope } from "@vanilla-extract/css/fileScope";
 import { createVar, fallbackVar, fontFace, globalFontFace, globalStyle, style, styleVariants } from "@vanilla-extract/css";
-
 //#region fixtures/themed/src/styles.css.ts
 setFileScope("src/styles.css.ts", "@fixtures/themed");
 const impact = fontFace({ src: "local(\\"Impact\\")" }, "impact");
@@ -2603,15 +2695,14 @@ const blankVar1 = createVar({
 	inherits: false,
 	initialValue: "0.5"
 }, "blankVar1");
-const blankVar2 = createVar("blankVar2");
 const opacity = styleVariants({
 	"1/2": blankVar1,
-	"1/4": fallbackVar(blankVar1, blankVar2, "0.25")
+	"1/4": fallbackVar(blankVar1, createVar("blankVar2"), "0.25")
 }, (value) => ({ selectors: { "html &": { opacity: value } } }), "opacity");
 endFileScope();
-
 //#endregion
-export { button, container, opacity };",
+export { button, container, opacity };
+",
   ],
   [
     "test-nodes.js",
@@ -2629,30 +2720,14 @@ var dynamicVarsContainer = "dynamicVarsContainer";
 var dynamicVarsButton = "dynamicVarsButton";
 var responsiveThemeContainer = "responsiveThemeContainer";
 var responsiveThemeButton = "responsiveThemeButton";
-var test_nodes_default = {
-	root,
-	rootContainer,
-	rootButton,
-	altContainer,
-	altButton,
-	nestedRootContainer,
-	nestedRootButton,
-	inlineThemeContainer,
-	inlineThemeButton,
-	dynamicVarsContainer,
-	dynamicVarsButton,
-	responsiveThemeContainer,
-	responsiveThemeButton
-};
-
 //#endregion
-export { test_nodes_default as default };",
+export { altButton, altContainer, dynamicVarsButton, dynamicVarsContainer, inlineThemeButton, inlineThemeContainer, nestedRootButton, nestedRootContainer, responsiveThemeButton, responsiveThemeContainer, root, rootButton, rootContainer };
+",
   ],
   [
     "themes.css.js",
     "import { endFileScope, setFileScope } from "@vanilla-extract/css/fileScope";
 import { assignVars, createGlobalTheme, createTheme, layer, style } from "@vanilla-extract/css";
-
 //#region fixtures/themed/src/themes.css.ts
 setFileScope("src/themes.css.ts", "@fixtures/themed");
 const theme = style({}, "theme");
@@ -2678,9 +2753,8 @@ const altTheme = createTheme(vars, {
 		3: "16px"
 	}
 }, "altTheme");
-const themeLayer = layer("themeLayer");
 const [altTheme2Class, altTheme2Contract] = createTheme({
-	"@layer": themeLayer,
+	"@layer": layer("themeLayer"),
 	colors: {
 		backgroundColor: "green",
 		text: "white"
@@ -2691,7 +2765,7 @@ const [altTheme2Class, altTheme2Contract] = createTheme({
 		3: "16px"
 	}
 }, "altTheme2Class");
-const altTheme3 = createGlobalTheme(":root", altTheme2Contract, {
+createGlobalTheme(":root", altTheme2Contract, {
 	"@layer": "globalThemeLayer",
 	colors: {
 		backgroundColor: "green",
@@ -2721,9 +2795,9 @@ const responsiveTheme = style({
 	}) } }
 }, "responsiveTheme");
 endFileScope();
-
 //#endregion
-export { altTheme, responsiveTheme, theme, vars };",
+export { altTheme, altTheme2Contract, responsiveTheme, theme, vars };
+",
   ],
 ]
 `;
@@ -2744,7 +2818,7 @@ exports[`rollup-plugin > should be compatible with rolldown > should build with 
   ],
   [
     "src/index.js",
-    ";;;;;;;AAiBA,MAAM,cAAc,iBAAiB,MAAM;CACzC,QAAQ;EACN,iBAAiB;EACjB,MAAM;CACP;CACD,OAAO;EACL,GAAG;EACH,GAAG;EACH,GAAG;CACJ;AACF,EAAC;AAEF,SAAS,SAAS;AAChB,UAAS,KAAK,YAAY,CAAC;WAClB,EAAEA,mBAAU,KAAK,SAAS,EAAE,OAAO;;aAEjC,EAAEA,mBAAU,cAAc,SAAS,EAAE,UAAU;kBAC1C,EAAEA,mBAAU,WAAW,SAAS,EAAE,OAAO;kBACzC,EAAE,SAAS;;iBAEZ,EAAEA,mBAAU,aAAa,SAAS,EAAE,UAAU;sBACzC,EAAEA,mBAAU,UAAU,SAAS,EAAE,OAAO;sBACxC,EAAE,MAAM;;qBAET,EAAEA,mBAAU,oBAAoB,SAAS,EAAE,UAAU;0BAChD,EAAEA,mBAAU,iBAAiB,SAAS,EAAE,OAAO;wBACjD,EAAE,YAAY;;yBAEb,EAAEA,mBAAU,qBAAqB,SAAS,EAAE,UAAU;8BACjD,EAAEA,mBAAU,kBAAkB,SAAS,EAAE,OAAO,CAAC,EAAE,QAAQ,OAAO,6BAA6B,EAAE,QAAQ,OAAO;;;6BAGjH,EAAEA,mBAAU,qBAAqB,SAAS,EAAE,UAAU;kCACjD,EAAEA,mBAAU,kBAAkB,SAAS,EAAE,OAAO;8BACpD,EAAE,gBAAgB;;yBAEvB,EAAEA,mBAAU,yBAAyB,SAAS,EAAE,UAAU;8BACrD,EAAEA,mBAAU,sBAAsB,SAAS,EAAE,OAAO;;;;;;;;;;;;;;;AAelF,CAAC;CAEC,MAAM,uBAAuB,SAAS,eACpCA,mBAAU,qBACX;AAED,MAAK,qBACH,OAAM,IAAI,MAAM;AAGlB,gBAAe,sBAAsB,MAAM;EACzC,QAAQ;GACN,iBAAiB;GACjB,MAAM;EACP;EACD,OAAO;GACL,GAAG;GACH,GAAG;GACH,GAAG;EACJ;CACF,EAAC;AAEF,gBAAe,sBAAsB,GAClC,KAAK,OAAO,kBAAkB,aAChC,EAAC;AACH;AAED,QAAQ",
+    ";;;;;;AAiBA,MAAM,cAAc,iBAAiB,MAAM;CACzC,QAAQ;EACN,iBAAiB;EACjB,MAAM;CACR;CACA,OAAO;EACL,GAAG;EACH,GAAG;EACH,GAAG;CACL;AACF,CAAC;AAED,SAAS,SAAS;CAChB,SAAS,KAAK,YAAY;aACfA,KAAe,WAAW,OAAO;;eAE/BC,cAAwB,WAAW,UAAU;oBACxCC,WAAqB,WAAW,OAAO;oBACvC,SAAS;;mBAEVC,aAAuB,WAAW,UAAU;wBACvCC,UAAoB,WAAW,OAAO;wBACtC,MAAM;;uBAEPC,oBAA8B,WAAW,UAAU;4BAC9CC,iBAA2B,WAAW,OAAO;0BAC/C,YAAY;;2BAEXC,qBAA+B,WAAW,UAAU;gCAC/CC,kBAA4B,WAAW,OAAO,GAAG,QAAQ,OAAO,+BAA+B,QAAQ,OAAO;;;+BAG/GC,qBAA+B,WAAW,UAAU;oCAC/CC,kBAA4B,WAAW,OAAO;gCAClD,gBAAgB;;2BAErBC,yBAAmC,WAAW,UAAU;gCACnDC,sBAAgC,WAAW,OAAO;;;;;;;;;;;;;;;;CAiBhF,MAAMC,yBAAuB,SAAS,eACpCJ,oBACF;CAEA,IAAI,CAACI,wBACH,MAAM,IAAI,MAAM,mCAAmC;CAGrD,eAAeA,wBAAsB,MAAM;EACzC,QAAQ;GACN,iBAAiB;GACjB,MAAM;EACR;EACA,OAAO;GACL,GAAG;GACH,GAAG;GACH,GAAG;EACL;CACF,CAAC;CAED,eAAeA,wBAAsB,GAClC,KAAK,OAAO,kBAAkB,aACjC,CAAC;AACH;AAEA,OAAO",
   ],
   [
     "src/index.js.map",
@@ -2776,7 +2850,7 @@ exports[`rollup-plugin > should be compatible with rolldown > should build with 
   ],
   [
     "test-nodes.js",
-    ";WACU;oBACS;iBACH;mBACE;gBACH;0BACU;uBACH;2BACI;wBACH;2BACG;wBACH;+BACO;4BACH;yBAb3B;;;;;;;;;;;;;;AAcC",
+    "",
   ],
   [
     "test-nodes.js.map",
@@ -2913,7 +2987,6 @@ html .styles_opacity_1\\/4__jteyb17 {
 import "./assets/themes.css.ts.vanilla-s9rcEmBH.css";
 import "./assets/shared.css.ts.vanilla-G_Gyt4-e.css";
 import "./assets/styles.css.ts.vanilla-BfisGtko.css";
-
 //#region fixtures/themed/src/themes.css.ts
 var altTheme = "themes_altTheme__cvta176";
 var responsiveTheme = "themes_responsiveTheme__cvta17e";
@@ -2929,7 +3002,6 @@ var vars = {
 		"3": "var(--space-3__cvta175)"
 	}
 };
-
 //#endregion
 //#region fixtures/themed/src/styles.css.ts
 var button = "styles_button__jteyb13 shared_shadow__4dtfen0 styles_iDunno__jteyb12";
@@ -2938,11 +3010,9 @@ var opacity = {
 	"1/2": "styles_opacity_1/2__jteyb16",
 	"1/4": "styles_opacity_1/4__jteyb17"
 };
-
 //#endregion
 //#region fixtures/themed/src/shared.css.ts
 var shadow = "shared_shadow__4dtfen0";
-
 //#endregion
 //#region fixtures/themed/test-nodes.json
 var root = "root";
@@ -2958,22 +3028,6 @@ var dynamicVarsContainer = "dynamicVarsContainer";
 var dynamicVarsButton = "dynamicVarsButton";
 var responsiveThemeContainer = "responsiveThemeContainer";
 var responsiveThemeButton = "responsiveThemeButton";
-var test_nodes_default = {
-	root,
-	rootContainer,
-	rootButton,
-	altContainer,
-	altButton,
-	nestedRootContainer,
-	nestedRootButton,
-	inlineThemeContainer,
-	inlineThemeButton,
-	dynamicVarsContainer,
-	dynamicVarsButton,
-	responsiveThemeContainer,
-	responsiveThemeButton
-};
-
 //#endregion
 //#region fixtures/themed/src/index.ts
 const inlineTheme = assignInlineVars(vars, {
@@ -2989,30 +3043,30 @@ const inlineTheme = assignInlineVars(vars, {
 });
 function render() {
 	document.body.innerHTML = \`
-  <div id="\${test_nodes_default.root}" class="\${shadow}"> 
+  <div id="\${root}" class="\${shadow}"> 
     Root theme
-    <div id="\${test_nodes_default.rootContainer}" class="\${container}">
-      <button id="\${test_nodes_default.rootButton}" class="\${button}">Main theme button</button>
+    <div id="\${rootContainer}" class="\${container}">
+      <button id="\${rootButton}" class="\${button}">Main theme button</button>
       <div class="\${altTheme}"> 
         Alt theme
-        <div id="\${test_nodes_default.altContainer}" class="\${container}">
-          <button id="\${test_nodes_default.altButton}" class="\${button}">Alt theme button</button>
+        <div id="\${altContainer}" class="\${container}">
+          <button id="\${altButton}" class="\${button}">Alt theme button</button>
           <div class="\${theme}"> 
             Back to root theme
-            <div id="\${test_nodes_default.nestedRootContainer}" class="\${container}">
-              <button id="\${test_nodes_default.nestedRootButton}" class="\${button}">Main theme button</button>
+            <div id="\${nestedRootContainer}" class="\${container}">
+              <button id="\${nestedRootButton}" class="\${button}">Main theme button</button>
             <div style="\${inlineTheme}">
               Inline theme
-                <div id="\${test_nodes_default.inlineThemeContainer}" class="\${container}">
-                  <button id="\${test_nodes_default.inlineThemeButton}" class="\${button} \${opacity["1/2"]}">Inline theme <span class="{\${opacity["1/4"]}}">button</span></button>
+                <div id="\${inlineThemeContainer}" class="\${container}">
+                  <button id="\${inlineThemeButton}" class="\${button} \${opacity["1/2"]}">Inline theme <span class="{\${opacity["1/4"]}}">button</span></button>
                   <div>
                   Dynamic vars
-                    <div id="\${test_nodes_default.dynamicVarsContainer}" class="\${container}">
-                      <button id="\${test_nodes_default.dynamicVarsButton}" class="\${button}">Dynamic vars button</button>
+                    <div id="\${dynamicVarsContainer}" class="\${container}">
+                      <button id="\${dynamicVarsButton}" class="\${button}">Dynamic vars button</button>
                   <div class="\${responsiveTheme}">
               Responsive theme
-                <div id="\${test_nodes_default.responsiveThemeContainer}" class="\${container}">
-                  <button id="\${test_nodes_default.responsiveThemeButton}" class="\${button}">Responsive theme button</button>
+                <div id="\${responsiveThemeContainer}" class="\${container}">
+                  <button id="\${responsiveThemeButton}" class="\${button}">Responsive theme button</button>
                             </div>
                           </div>
                         </div>
@@ -3028,7 +3082,7 @@ function render() {
     </div>
   </div>
 \`;
-	const dynamicVarsContainer$1 = document.getElementById(test_nodes_default.dynamicVarsContainer);
+	const dynamicVarsContainer$1 = document.getElementById(dynamicVarsContainer);
 	if (!dynamicVarsContainer$1) throw new Error("Dynamic vars container not found.");
 	setElementVars(dynamicVarsContainer$1, vars, {
 		colors: {
@@ -3044,8 +3098,8 @@ function render() {
 	setElementVars(dynamicVarsContainer$1, { [vars.colors.backgroundColor]: "darksalmon" });
 }
 render();
-
-//#endregion",
+//#endregion
+",
   ],
 ]
 `;

--- a/packages/rollup-plugin/test/rollup-plugin.test.ts
+++ b/packages/rollup-plugin/test/rollup-plugin.test.ts
@@ -7,8 +7,6 @@ import {
 import {
   rollup,
   type InputPluginOption,
-  type OutputAsset,
-  type OutputChunk,
   type OutputOptions,
   type RollupOptions,
 } from 'rollup';
@@ -22,14 +20,44 @@ import {
 } from '..';
 import { stripSideEffectImportsMatching } from '../src/lib';
 
+type BuildOutputFile = {
+  fileName: string;
+  type: string;
+  source?: string | Uint8Array;
+  code?: string;
+  map?: { mappings?: string } | null;
+};
+
+const formatOutputForSnapshot = (output: BuildOutputFile[]) =>
+  output.map((chunkOrAsset) => [
+    chunkOrAsset.fileName,
+    chunkOrAsset.type === 'asset' ? chunkOrAsset.source : chunkOrAsset.code,
+  ]);
+
+const formatSourcemapOutputForSnapshot = (output: BuildOutputFile[]) =>
+  output.map((chunkOrAsset) => [
+    chunkOrAsset.fileName,
+    chunkOrAsset.type === 'asset' ? '' : chunkOrAsset.map?.mappings,
+  ]);
+
+const filterJsChunkCodes = (output: BuildOutputFile[]) =>
+  output
+    .filter((file) => file.type === 'chunk' && file.fileName.endsWith('.js'))
+    .map((file) => file.code);
+
+const filterAssetSources = (output: BuildOutputFile[], fileName: string) =>
+  output
+    .filter((file) => file.type === 'asset' && file.fileName === fileName)
+    .map((file) => file.source);
+
 interface BuildOptions extends VanillaExtractPluginOptions {
   rollup: RollupOptions & { output: OutputOptions };
 }
 
-async function build({
+const build = async ({
   rollup: rollupOptions,
   ...pluginOptions
-}: BuildOptions) {
+}: BuildOptions) => {
   const bundle = await rollup({
     input: require.resolve('@fixtures/themed/src/index.ts'),
     external: ['@vanilla-extract/dynamic'],
@@ -48,17 +76,12 @@ async function build({
   const { output } = await bundle.generate(rollupOptions.output);
   output.sort((a, b) => a.fileName.localeCompare(b.fileName));
   return output;
-}
+};
 
-async function buildAndMatchSnapshot(options: BuildOptions) {
+const buildAndMatchSnapshot = async (options: BuildOptions) => {
   const output = await build(options);
-  expect(
-    output.map((chunkOrAsset) => [
-      chunkOrAsset.fileName,
-      chunkOrAsset.type === 'asset' ? chunkOrAsset.source : chunkOrAsset.code,
-    ]),
-  ).toMatchSnapshot();
-}
+  expect(formatOutputForSnapshot(output)).toMatchSnapshot();
+};
 
 describe('rollup-plugin', () => {
   describe('options', () => {
@@ -81,25 +104,19 @@ describe('rollup-plugin', () => {
       });
 
       // assert essential files were made
-      const bundleAsset = output.find(
-        (file) => file.type === 'asset' && file.fileName === 'app.css',
-      );
-      expect(bundleAsset).toBeTruthy();
-      const sourcemapAsset = output.find(
-        (file) => file.type === 'asset' && file.fileName === 'app.css.map',
-      );
-      expect(sourcemapAsset).toBeTruthy();
+      expect(filterAssetSources(output, 'app.css')).toHaveLength(1);
 
       // assert .css imports were removed
-      const jsFiles = output.filter(
-        (file) => file.type === 'chunk' && file.fileName.endsWith('.js'),
-      ) as OutputChunk[];
-      for (const jsFile of jsFiles) {
-        expect(jsFile.code).not.toMatch(/^import .*\.css['"]/m);
+      const jsChunkCodes = filterJsChunkCodes(output);
+      expect(jsChunkCodes.length).toBeGreaterThan(0);
+      for (const code of jsChunkCodes) {
+        expect(code).not.toMatch(/^import .*\.css['"]/m);
       }
 
       // assert bundle CSS reflects order from @fixtures/react-library-example/index.ts
-      const map = JSON.parse(String((sourcemapAsset as OutputAsset).source));
+      const sourcemapSources = filterAssetSources(output, 'app.css.map');
+      expect(sourcemapSources).toHaveLength(1);
+      const map = JSON.parse(String(sourcemapSources[0]));
       expect(map.sources).toEqual([
         'src/styles/reset.css.ts.vanilla.css',
         'src/styles/vars.css.ts.vanilla.css',
@@ -116,14 +133,11 @@ describe('rollup-plugin', () => {
 
       // snapshot output for everything else
       expect(
-        output
-          .filter((chunkOrAsset) => !chunkOrAsset.fileName.endsWith('.map')) // remove .msps
-          .map((chunkOrAsset) => [
-            chunkOrAsset.fileName,
-            chunkOrAsset.type === 'asset'
-              ? chunkOrAsset.source
-              : chunkOrAsset.code,
-          ]),
+        formatOutputForSnapshot(
+          output.filter(
+            (chunkOrAsset) => !chunkOrAsset.fileName.endsWith('.map'),
+          ),
+        ),
       ).toMatchSnapshot();
     });
   });
@@ -194,22 +208,18 @@ describe('rollup-plugin', () => {
           },
         },
       });
-      expect(
-        output.map((chunkOrAsset) => [
-          chunkOrAsset.fileName,
-          chunkOrAsset.type === 'asset' ? '' : chunkOrAsset.map?.mappings,
-        ]),
-      ).toMatchSnapshot();
+
+      expect(formatSourcemapOutputForSnapshot(output)).toMatchSnapshot();
     });
   });
 
   describe('should be compatible with rolldown', () => {
-    async function build({
+    const build = async ({
       rollup: rollupOptions,
       ...pluginOptions
     }: VanillaExtractPluginOptions & {
       rollup: RolldownInputOptions & { output: RolldownOutputOptions };
-    }) {
+    }) => {
       const bundle = await rolldown({
         external: [
           '@vanilla-extract/dynamic',
@@ -228,29 +238,57 @@ describe('rollup-plugin', () => {
       const { output } = await bundle.generate(rollupOptions.output);
       output.sort((a, b) => a.fileName.localeCompare(b.fileName));
       return output;
-    }
+    };
 
-    async function buildAndMatchSnapshot(
+    const buildAndMatchSnapshot = async (
       outputOptions: RolldownOutputOptions,
       { unstable_injectFilescopes }: { unstable_injectFilescopes?: boolean } = {
         unstable_injectFilescopes: false,
       },
-    ) {
+    ) => {
       const output = await build({
         rollup: {
           output: outputOptions,
         },
         unstable_injectFilescopes,
       });
-      expect(
-        output.map((chunkOrAsset) => [
-          chunkOrAsset.fileName,
-          chunkOrAsset.type === 'asset'
-            ? chunkOrAsset.source
-            : chunkOrAsset.code,
-        ]),
-      ).toMatchSnapshot();
-    }
+      expect(formatOutputForSnapshot(output)).toMatchSnapshot();
+    };
+
+    const buildThirdparty = async ({
+      cwd,
+      outputOptions,
+    }: {
+      cwd: string;
+      outputOptions: RolldownOutputOptions;
+    }) => {
+      const packageRoot = path.dirname(
+        require.resolve('@fixtures/thirdparty/package.json'),
+      );
+      const bundle = await rolldown({
+        input: path.join(packageRoot, 'src/index.ts'),
+        external: ['@vanilla-extract/dynamic', '@vanilla-extract/css'],
+        plugins: [vanillaExtractPlugin({ cwd })],
+      });
+
+      const { output } = await bundle.generate(outputOptions);
+      output.sort((a, b) => a.fileName.localeCompare(b.fileName));
+
+      return output;
+    };
+
+    const buildThirdpartyAndMatchSnapshot = async (cwd: string) => {
+      const output = await buildThirdparty({
+        cwd,
+        outputOptions: {
+          format: 'esm',
+          preserveModules: true,
+          assetFileNames: 'assets/[name]-[hash][extname]',
+        },
+      });
+
+      expect(formatOutputForSnapshot(output)).toMatchSnapshot();
+    };
 
     it('extract generates .css bundle', async () => {
       const cwd = path.dirname(
@@ -271,25 +309,19 @@ describe('rollup-plugin', () => {
       });
 
       // assert essential files were made
-      const bundleAsset = output.find(
-        (file) => file.type === 'asset' && file.fileName === 'app.css',
-      );
-      expect(bundleAsset).toBeTruthy();
-      const sourcemapAsset = output.find(
-        (file) => file.type === 'asset' && file.fileName === 'app.css.map',
-      );
-      expect(sourcemapAsset).toBeTruthy();
+      expect(filterAssetSources(output, 'app.css')).toHaveLength(1);
 
       // assert .css imports were removed
-      const jsFiles = output.filter(
-        (file) => file.type === 'chunk' && file.fileName.endsWith('.js'),
-      ) as OutputChunk[];
-      for (const jsFile of jsFiles) {
-        expect(jsFile.code).not.toMatch(/^import .*\.css['"]/m);
+      const jsChunkCodes = filterJsChunkCodes(output);
+      expect(jsChunkCodes.length).toBeGreaterThan(0);
+      for (const code of jsChunkCodes) {
+        expect(code).not.toMatch(/^import .*\.css['"]/m);
       }
 
       // assert bundle CSS reflects order from @fixtures/react-library-example/index.ts
-      const map = JSON.parse(String((sourcemapAsset as OutputAsset).source));
+      const sourcemapSources = filterAssetSources(output, 'app.css.map');
+      expect(sourcemapSources).toHaveLength(1);
+      const map = JSON.parse(String(sourcemapSources[0]));
       expect(map.sources).toEqual([
         'src/styles/reset.css.ts.vanilla.css',
         'src/styles/vars.css.ts.vanilla.css',
@@ -306,14 +338,11 @@ describe('rollup-plugin', () => {
 
       // snapshot output for everything else
       expect(
-        output
-          .filter((chunkOrAsset) => !chunkOrAsset.fileName.endsWith('.map')) // remove .msps
-          .map((chunkOrAsset) => [
-            chunkOrAsset.fileName,
-            chunkOrAsset.type === 'asset'
-              ? chunkOrAsset.source
-              : chunkOrAsset.code,
-          ]),
+        formatOutputForSnapshot(
+          output.filter(
+            (chunkOrAsset) => !chunkOrAsset.fileName.endsWith('.map'),
+          ),
+        ),
       ).toMatchSnapshot();
     });
 
@@ -375,12 +404,24 @@ describe('rollup-plugin', () => {
           },
         },
       });
-      expect(
-        output.map((chunkOrAsset) => [
-          chunkOrAsset.fileName,
-          chunkOrAsset.type === 'asset' ? '' : chunkOrAsset.map?.mappings,
-        ]),
-      ).toMatchSnapshot();
+
+      expect(formatSourcemapOutputForSnapshot(output)).toMatchSnapshot();
+    });
+
+    it('should build thirdparty dependencies', async () => {
+      const cwd = path.dirname(
+        require.resolve('@fixtures/thirdparty/package.json'),
+      );
+
+      await buildThirdpartyAndMatchSnapshot(cwd);
+    });
+
+    it('should build thirdparty dependencies with nested cwd', async () => {
+      const packageRoot = path.dirname(
+        require.resolve('@fixtures/thirdparty/package.json'),
+      );
+
+      await buildThirdpartyAndMatchSnapshot(path.join(packageRoot, 'src'));
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,10 +393,10 @@ importers:
         version: link:../integration
       vite:
         specifier: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-        version: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
+        version: 8.0.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
       vite-node:
         specifier: ^3.2.2 || ^5.0.0 || ^6.0.0
-        version: 6.0.0(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
+        version: 6.0.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
 
   packages/css:
     dependencies:
@@ -568,6 +568,9 @@ importers:
       '@fixtures/themed':
         specifier: workspace:*
         version: link:../../fixtures/themed
+      '@fixtures/thirdparty':
+        specifier: workspace:*
+        version: link:../../fixtures/thirdparty
       '@rollup/plugin-json':
         specifier: ^6.1.0
         version: 6.1.0(rollup@4.59.0)
@@ -578,8 +581,8 @@ importers:
         specifier: ~0.28.0
         version: 0.28.0
       rolldown:
-        specifier: 1.0.0-beta.27
-        version: 1.0.0-beta.27
+        specifier: ^1.1.4
+        version: 1.1.4
       rollup:
         specifier: ^4.20.0
         version: 4.59.0
@@ -610,7 +613,7 @@ importers:
         version: 12.3.4(@babel/core@7.23.9)(react-dom@19.2.3)(react@19.2.3)
       vite:
         specifier: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-        version: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
+        version: 8.0.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
 
   packages/utils: {}
 
@@ -625,7 +628,7 @@ importers:
     devDependencies:
       vite:
         specifier: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-        version: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
+        version: 8.0.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
 
   packages/webpack-plugin:
     dependencies:
@@ -921,7 +924,7 @@ importers:
         version: 2.0.0(webpack@5.104.0)
       vite:
         specifier: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-        version: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
+        version: 8.0.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
       vite-plugin-inspect:
         specifier: ^11.3.0
         version: 11.3.3(supports-color@9.2.3)(vite@8.0.5)
@@ -979,7 +982,7 @@ importers:
         version: link:../packages/vite-plugin
       vite:
         specifier: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
-        version: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
+        version: 8.0.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(supports-color@9.2.3)(typescript@5.8.3)(vite@8.0.5)
@@ -1894,14 +1897,17 @@ packages:
       react-dom:
         optional: true
 
-  '@emnapi/core@1.7.1':
-    resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
 
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
 
-  '@emnapi/wasi-threads@1.1.0':
-    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@emotion/hash@0.9.0':
     resolution: {integrity: sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==}
@@ -2656,11 +2662,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@napi-rs/wasm-runtime@0.2.12':
-    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
-
-  '@napi-rs/wasm-runtime@1.1.1':
-    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
 
   '@netlify/binary-info@1.0.0':
     resolution: {integrity: sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw==}
@@ -3170,15 +3176,11 @@ packages:
   '@octokit/types@6.41.0':
     resolution: {integrity: sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==}
 
-  '@oxc-project/runtime@0.77.0':
-    resolution: {integrity: sha512-cMbHs/DaomWSjxeJ79G10GA5hzJW9A7CZ+/cO+KuPZ7Trf3Rr07qSLauC4Ns8ba4DKVDjd8VSC9nVLpw6jpoGQ==}
-    engines: {node: '>=6.9.0'}
-
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
 
-  '@oxc-project/types@0.77.0':
-    resolution: {integrity: sha512-iUQj185VvCPnSba+ltUV5tVDrPX6LeZVtQywnnoGbe4oJ1VKvDKisjGkD/AvVtdm98b/BdsVS35IlJV1m2mBBA==}
+  '@oxc-project/types@0.138.0':
+    resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
 
   '@oxlint/binding-android-arm-eabi@1.55.0':
     resolution: {integrity: sha512-NhvgAhncTSOhRahQSCnkK/4YIGPjTmhPurQQ2dwt2IvwCMTvZRW5vF2K10UBOxFve4GZDMw6LtXZdC2qeuYIVQ==}
@@ -3700,21 +3702,17 @@ packages:
     resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
     engines: {node: '>=14.0.0'}
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.27':
-    resolution: {integrity: sha512-IJL3efUJmvb5MfTEi7bGK4jq3ZFAzVbSy+vmul0DcdrglUd81Tfyy7Zzq2oM0tUgmACG32d8Jz/ykbpbf+3C5A==}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.27':
-    resolution: {integrity: sha512-TXTiuHbtnHfb0c44vNfWfIyEFJ0BFUf63ip9Z4mj8T2zRcZXQYVger4OuAxnwGNGBgDyHo1VaNBG+Vxn2VrpqQ==}
+  '@rolldown/binding-android-arm64@1.1.4':
+    resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
+    os: [android]
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
@@ -3722,9 +3720,10 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.27':
-    resolution: {integrity: sha512-Jpjflgvbolh+fAaaEajPJQCOpZMawYMbNVzuZp3nidX1B7kMAP7NEKp9CWzthoL2Y8RfD7OApN6bx4+vFurTaw==}
-    cpu: [x64]
+  '@rolldown/binding-darwin-arm64@1.1.4':
+    resolution: {integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.12':
@@ -3733,10 +3732,11 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.27':
-    resolution: {integrity: sha512-07ZNlXIunyS1jCTnene7aokkzCZNBUnmnJWu4Nz5X5XQvVHJNjsDhPFJTlNmneSDzA3vGkRNwdECKXiDTH/CqA==}
+  '@rolldown/binding-darwin-x64@1.1.4':
+    resolution: {integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
-    os: [freebsd]
+    os: [darwin]
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
     resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
@@ -3744,10 +3744,11 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.27':
-    resolution: {integrity: sha512-z74ah00oyKnTUtaIbg34TaIU1PYM8tGE1bK6aUs8OLZ9sWW4g3Xo5A0nit2zyeanmYFvrAUxnt3Bpk+mTZCtlg==}
-    cpu: [arm]
-    os: [linux]
+  '@rolldown/binding-freebsd-x64@1.1.4':
+    resolution: {integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
     resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
@@ -3755,11 +3756,11 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.27':
-    resolution: {integrity: sha512-b9oKl/M5OIyAcosS73BmjOZOjvcONV97t2SnKpgwfDX/mjQO3dBgTYyvHMFA6hfhIDW1+2XVQR/k5uzBULFhoA==}
-    cpu: [arm64]
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+    resolution: {integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
@@ -3768,11 +3769,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.27':
-    resolution: {integrity: sha512-RmaNSkVmAH8u/r5Q+v4O0zL4HY8pLrvlM5wBoBrb/QHDQgksGKBqhecpg1ERER0Q7gMh/GJUz6JiiD55Q+9UOA==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+    resolution: {integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
@@ -3781,13 +3783,22 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.27':
-    resolution: {integrity: sha512-gq78fI/g0cp1UKFMk53kP/oZAgYOXbaqdadVMuCJc0CoSkDJcpO2YIasRs/QYlE91QWfcHD5RZl9zbf4ksTS/w==}
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
+    resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [openharmony]
+    os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -3800,9 +3811,10 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.27':
-    resolution: {integrity: sha512-yS/GreJ6BT44dHu1WLigc50S8jZA+pDzzsf8tqRptUTwi5YW7dX3NqcDlc/lXsZqu57aKynLljgClYAm90LEKw==}
-    cpu: [x64]
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+    resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -3813,14 +3825,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.27':
-    resolution: {integrity: sha512-6FV9To1sXewGHY4NaCPeOE5p5o1qfuAjj+m75WVIPw9HEJVsQoC5QiTL5wWVNqSMch4X0eWnQ6WsQolU6sGMIA==}
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
+    resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -3832,20 +3852,21 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.27':
-    resolution: {integrity: sha512-VcxdhF0PQda9krFJHw4DqUkdAsHWYs/Uz/Kr/zhU8zMFDzmK6OdUgl9emGj9wTzXAEHYkAMDhk+OJBRJvp424g==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
+  '@rolldown/binding-openharmony-arm64@1.1.4':
+    resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
 
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
     resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.27':
-    resolution: {integrity: sha512-3bXSARqSf8jLHrQ1/tw9pX1GwIR9jA6OEsqTgdC0DdpoZ+34sbJXE9Nse3dQ0foGLKBkh4PqDv/rm2Thu9oVBw==}
-    cpu: [arm64]
-    os: [win32]
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    resolution: {integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
     resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
@@ -3853,14 +3874,10 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.27':
-    resolution: {integrity: sha512-xPGcKb+W8NIWAf5KApsUIrhiKH5NImTarICge5jQ2m0BBxD31crio4OXy/eYVq5CZkqkqszLQz2fWZcWNmbzlQ==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.27':
-    resolution: {integrity: sha512-3y1G8ARpXBAcz4RJM5nzMU6isS/gXZl8SuX8lS2piFOnQMiOp6ajeelnciD+EgG4ej793zvNvr+WZtdnao2yrw==}
-    cpu: [x64]
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+    resolution: {integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
     os: [win32]
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
@@ -3869,11 +3886,17 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-beta.27':
-    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    resolution: {integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@rolldown/pluginutils@1.0.0-rc.12':
     resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@rollup/plugin-alias@3.1.8':
     resolution: {integrity: sha512-tf7HeSs/06wO2LPqKNY3Ckbvy0JRe7Jyn98bXnt/gfrxbe+AJucoNJlsEVi9sdgbQtXemjbakCpO/76JVgnHpA==}
@@ -4254,8 +4277,8 @@ packages:
   '@tsconfig/node16@1.0.2':
     resolution: {integrity: sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==}
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -9579,12 +9602,13 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rolldown@1.0.0-beta.27:
-    resolution: {integrity: sha512-aYiJmzKoUHoaaEZLRegYVfZkXW7gzdgSbq+u5cXQ6iXc/y8tnQ3zGffQo44Pr1lTKeLluw3bDIDUCx/NAzqKeA==}
-    hasBin: true
-
   rolldown@1.0.0-rc.12:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.1.4:
+    resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -12384,9 +12408,14 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@emnapi/core@1.7.1':
+  '@emnapi/core@1.11.1':
     dependencies:
-      '@emnapi/wasi-threads': 1.1.0
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
       tslib: 2.8.1
     optional: true
 
@@ -12395,7 +12424,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.1.0':
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -13088,18 +13117,11 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.2':
     optional: true
 
-  '@napi-rs/wasm-runtime@0.2.12':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@emnapi/core': 1.7.1
-      '@emnapi/runtime': 1.7.1
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.1':
-    dependencies:
-      '@emnapi/core': 1.7.1
-      '@emnapi/runtime': 1.7.1
-      '@tybys/wasm-util': 0.10.1
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@netlify/binary-info@1.0.0': {}
@@ -13621,11 +13643,9 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 12.11.0
 
-  '@oxc-project/runtime@0.77.0': {}
-
   '@oxc-project/types@0.122.0': {}
 
-  '@oxc-project/types@0.77.0': {}
+  '@oxc-project/types@0.138.0': {}
 
   '@oxlint/binding-android-arm-eabi@1.55.0':
     optional: true
@@ -14379,100 +14399,108 @@ snapshots:
 
   '@remix-run/router@1.23.0': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.27':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.27':
+  '@rolldown/binding-android-arm64@1.1.4':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.27':
+  '@rolldown/binding-darwin-arm64@1.1.4':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.27':
+  '@rolldown/binding-darwin-x64@1.1.4':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.27':
+  '@rolldown/binding-freebsd-x64@1.1.4':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.27':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.27':
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.27':
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     optional: true
 
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    optional: true
+
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.27':
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.27':
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.27':
-    dependencies:
-      '@napi-rs/wasm-runtime': 0.2.12
+  '@rolldown/binding-openharmony-arm64@1.1.4':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.27':
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.27':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.27':
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-beta.27': {}
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    optional: true
 
   '@rolldown/pluginutils@1.0.0-rc.12': {}
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@rollup/plugin-alias@3.1.8(rollup@2.79.1)':
     dependencies:
@@ -14764,7 +14792,7 @@ snapshots:
 
   '@tsconfig/node16@1.0.2': {}
 
-  '@tybys/wasm-util@0.10.1':
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -15173,7 +15201,7 @@ snapshots:
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
+      vite: 8.0.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -21013,29 +21041,7 @@ snapshots:
     dependencies:
       glob: 7.2.0
 
-  rolldown@1.0.0-beta.27:
-    dependencies:
-      '@oxc-project/runtime': 0.77.0
-      '@oxc-project/types': 0.77.0
-      '@rolldown/pluginutils': 1.0.0-beta.27
-      ansis: 4.2.0
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-beta.27
-      '@rolldown/binding-darwin-arm64': 1.0.0-beta.27
-      '@rolldown/binding-darwin-x64': 1.0.0-beta.27
-      '@rolldown/binding-freebsd-x64': 1.0.0-beta.27
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.27
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.27
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.27
-      '@rolldown/binding-linux-arm64-ohos': 1.0.0-beta.27
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.27
-      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.27
-      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.27
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.27
-      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.27
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.27
-
-  rolldown@1.0.0-rc.12:
+  rolldown@1.0.0-rc.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     dependencies:
       '@oxc-project/types': 0.122.0
       '@rolldown/pluginutils': 1.0.0-rc.12
@@ -21052,9 +21058,33 @@ snapshots:
       '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
       '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
       '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  rolldown@1.1.4:
+    dependencies:
+      '@oxc-project/types': 0.138.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.4
+      '@rolldown/binding-darwin-arm64': 1.1.4
+      '@rolldown/binding-darwin-x64': 1.1.4
+      '@rolldown/binding-freebsd-x64': 1.1.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.4
+      '@rolldown/binding-linux-arm64-gnu': 1.1.4
+      '@rolldown/binding-linux-arm64-musl': 1.1.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.4
+      '@rolldown/binding-linux-s390x-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-musl': 1.1.4
+      '@rolldown/binding-openharmony-arm64': 1.1.4
+      '@rolldown/binding-wasm32-wasi': 1.1.4
+      '@rolldown/binding-win32-arm64-msvc': 1.1.4
+      '@rolldown/binding-win32-x64-msvc': 1.1.4
 
   rollup-plugin-dts@6.1.1(rollup@4.59.0)(typescript@5.8.3):
     dependencies:
@@ -22357,21 +22387,23 @@ snapshots:
   vite-dev-rpc@1.1.0(vite@8.0.5):
     dependencies:
       birpc: 2.9.0
-      vite: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
+      vite: 8.0.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
       vite-hot-client: 2.1.0(vite@8.0.5)
 
   vite-hot-client@2.1.0(vite@8.0.5):
     dependencies:
-      vite: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
+      vite: 8.0.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
 
-  vite-node@6.0.0(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0):
+  vite-node@6.0.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0):
     dependencies:
       cac: 7.0.0
       es-module-lexer: 2.0.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
+      vite: 8.0.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - '@types/node'
       - '@vitejs/devtools'
       - esbuild
@@ -22395,7 +22427,7 @@ snapshots:
       perfect-debounce: 2.0.0
       sirv: 3.0.2
       unplugin-utils: 0.3.1
-      vite: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
+      vite: 8.0.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
       vite-dev-rpc: 1.1.0(vite@8.0.5)
     transitivePeerDependencies:
       - supports-color
@@ -22406,17 +22438,17 @@ snapshots:
       globrex: 0.1.2
       tsconfck: 3.1.4(typescript@5.8.3)
     optionalDependencies:
-      vite: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
+      vite: 8.0.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0):
+  vite@8.0.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.8
-      rolldown: 1.0.0-rc.12
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.15.3
@@ -22425,6 +22457,9 @@ snapshots:
       jiti: 1.21.7
       terser: 5.44.1
       tsx: 4.21.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   vitest@4.1.0(@types/node@22.15.3)(happy-dom@20.8.4)(jsdom@29.0.0)(vite@8.0.5):
     dependencies:
@@ -22446,7 +22481,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 8.0.5(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
+      vite: 8.0.5(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@22.15.3)(esbuild@0.28.0)(jiti@1.21.7)(terser@5.44.1)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.15.3


### PR DESCRIPTION
`rolldown@1.0.0-rc.12` tightened restrictions on emitted chunk and assets paths, resulting in errors such as:

```
Error: The "fileName" or "name" properties of emitted chunks and assets must be strings
that are neither absolute nor relative paths, received "../styles/src/focusRing.css.ts.vanilla.css".
```

Trimming paths to just their `basename` fixes the issue. The tradeoff here is that `preserveModules` is no longer enforced for CSS assets, but I don't think this will be a problem in practice.

Closed #1715. Supersedes #1754.