### PR TITLE
`vite`: Fix empty CSS emit fixture

### DIFF
--- a/.changeset/fixy-apples-sing.md
+++ b/.changeset/fixy-apples-sing.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/compiler': patch
+---
+
+`processVanillaFile`: Don't serialize CSS imports for modules whose CSS objects transform to an empty string (e.g. files that only compose existing atomic classes from a recipe)

--- a/.changeset/lovely-olives-sink.md
+++ b/.changeset/lovely-olives-sink.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Update `@vanilla-extract/compiler` dependency to fix a bug that caused Vite to try (and fail) to emit an empty CSS file

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -477,8 +477,12 @@ export const createCompiler = ({
             const { css = '', cssRules = [] } =
               cssCache.get(cssDepModuleId) ?? {};
 
-            const depEmitsCss = Boolean(cssObjs?.length || css);
-            if (depEmitsCss) {
+            // Check the transformed CSS, not `cssObjs.length`. A module can
+            // register CSS objects that transform to nothing (e.g. `recipe()`
+            // calls `style({})` for a default base class, or variants that only
+            // compose existing atomic classes). Emitting an import for empty CSS
+            // leaves a dangling virtual module that bundlers fail to resolve.
+            if (css) {
               if (splitCssPerRule) {
                 const importSpecifiers = await Promise.all(
                   cssRules.map((rule, i) =>

--- a/tests/compiler/compiler.test.ts
+++ b/tests/compiler/compiler.test.ts
@@ -835,28 +835,59 @@ describe('compiler', () => {
       root: __dirname,
     });
 
-    try {
-      const cssPath = path.join(__dirname, 'fixtures/no-css-output/a.css.ts');
-      const dependencyCssPath = path.join(
-        __dirname,
-        'fixtures/no-css-output/contract.css.ts',
-      );
+    const cssPath = path.join(__dirname, 'fixtures/no-css-output/a.css.ts');
+    const dependencyCssPath = path.join(
+      __dirname,
+      'fixtures/no-css-output/contract.css.ts',
+    );
 
-      const output = await compiler.processVanillaFile(cssPath);
+    const output = await compiler.processVanillaFile(cssPath);
 
-      expect(output.source).not.toContain(
-        normalizePath(`${dependencyCssPath}.vanilla.css`),
-      );
-      expect(output.source).toContain(normalizePath(`${cssPath}.vanilla.css`));
+    expect(output.source).not.toContain(
+      normalizePath(`${dependencyCssPath}.vanilla.css`),
+    );
+    expect(output.source).toContain(normalizePath(`${cssPath}.vanilla.css`));
 
-      const { css } = compiler.getCssForFile(cssPath);
-      expect(css).toMatchInlineSnapshot(`
+    const { css } = compiler.getCssForFile(cssPath);
+    expect(css).toMatchInlineSnapshot(`
         .a_a__1mnazgr0 {
           --component-token: var(--global-token);
         }
       `);
-    } finally {
-      await compiler.close();
-    }
+
+    await compiler.close();
+  });
+
+  test('should not emit a CSS import when a module only composes existing classes', async () => {
+    const compiler = createCompiler({
+      root: __dirname,
+    });
+
+    const cssPath = path.join(
+      __dirname,
+      'fixtures/empty-recipe-css/recipe.css.ts',
+    );
+    const sprinklesCssPath = path.join(
+      __dirname,
+      'fixtures/empty-recipe-css/sprinkles.css.ts',
+    );
+
+    const output = await compiler.processVanillaFile(cssPath);
+
+    expect(output.source).not.toContain(
+      normalizePath(`${cssPath}.vanilla.css`),
+    );
+    expect(output.source).toContain(
+      normalizePath(`${sprinklesCssPath}.vanilla.css`),
+    );
+
+    const { css } = compiler.getCssForFile(cssPath);
+    expect(css).toBe('');
+
+    const { css: sprinklesCss } = compiler.getCssForFile(sprinklesCssPath);
+    expect(sprinklesCss).toContain('.sprinkles_padding_0');
+    expect(sprinklesCss).toContain('padding: 16px');
+
+    await compiler.close();
   });
 });

--- a/tests/compiler/fixtures/empty-recipe-css/recipe.css.ts
+++ b/tests/compiler/fixtures/empty-recipe-css/recipe.css.ts
@@ -1,0 +1,12 @@
+import { recipe } from '@vanilla-extract/recipes';
+
+import { sprinkles } from './sprinkles.css';
+
+// Only composes pre-existing sprinkles atomic classes and emits no CSS of its own.
+export const root = recipe({
+  variants: {
+    padded: {
+      true: sprinkles({ padding: 16 }),
+    },
+  },
+});

--- a/tests/compiler/fixtures/empty-recipe-css/sprinkles.css.ts
+++ b/tests/compiler/fixtures/empty-recipe-css/sprinkles.css.ts
@@ -1,0 +1,9 @@
+import { defineProperties, createSprinkles } from '@vanilla-extract/sprinkles';
+
+const properties = defineProperties({
+  properties: {
+    padding: [0, 8, 16],
+  },
+});
+
+export const sprinkles = createSprinkles(properties);

--- a/tests/vite-plugin/fixtures/empty-recipe-css/src/main.ts
+++ b/tests/vite-plugin/fixtures/empty-recipe-css/src/main.ts
@@ -1,0 +1,3 @@
+import { root } from './recipe.css.ts';
+
+console.log(root({ padded: true }));

--- a/tests/vite-plugin/fixtures/empty-recipe-css/src/recipe.css.ts
+++ b/tests/vite-plugin/fixtures/empty-recipe-css/src/recipe.css.ts
@@ -1,0 +1,12 @@
+import { recipe } from '@vanilla-extract/recipes';
+
+import { sprinkles } from './sprinkles.css';
+
+// Only composes pre-existing sprinkles atomic classes and emits no CSS of its own.
+export const root = recipe({
+  variants: {
+    padded: {
+      true: sprinkles({ padding: 16 }),
+    },
+  },
+});

--- a/tests/vite-plugin/fixtures/empty-recipe-css/src/sprinkles.css.ts
+++ b/tests/vite-plugin/fixtures/empty-recipe-css/src/sprinkles.css.ts
@@ -1,0 +1,9 @@
+import { defineProperties, createSprinkles } from '@vanilla-extract/sprinkles';
+
+const properties = defineProperties({
+  properties: {
+    padding: [0, 8, 16],
+  },
+});
+
+export const sprinkles = createSprinkles(properties);

--- a/tests/vite-plugin/no-empty-chunks.test.ts
+++ b/tests/vite-plugin/no-empty-chunks.test.ts
@@ -76,3 +76,47 @@ describe('vite-plugin lib build', () => {
     `);
   });
 });
+
+describe('vite-plugin empty recipe CSS', () => {
+  const fixtureRoot = path.join(__dirname, 'fixtures/empty-recipe-css');
+  let outDir: string;
+
+  afterAll(async () => {
+    if (outDir) {
+      await fs.rm(outDir, { recursive: true, force: true });
+    }
+  });
+
+  test('builds when a file only composes existing classes', async () => {
+    outDir = await fs.mkdtemp(path.join(os.tmpdir(), 've-empty-recipe-css-'));
+
+    await build({
+      root: fixtureRoot,
+      configFile: false,
+      plugins: [vanillaExtractPlugin()],
+      build: {
+        outDir,
+        emptyOutDir: true,
+        rollupOptions: {
+          input: path.join(fixtureRoot, 'src/main.ts'),
+        },
+      },
+      logLevel: 'silent',
+    });
+
+    const assets = await fs.readdir(path.join(outDir, 'assets'));
+    const cssFile = assets.find((file) => file.endsWith('.css'));
+    expect(cssFile).toBeDefined();
+
+    const css = await fs.readFile(
+      // The previous assertion ensures that `cssFile` will be defined
+      // oxlint-disable-next-line typescript/no-non-null-assertion
+      path.join(outDir, 'assets', cssFile!),
+      'utf-8',
+    );
+
+    expect(css).toMatchInlineSnapshot(
+      `._4yrjge0{padding:0}._4yrjge1{padding:8px}._4yrjge2{padding:16px}`,
+    );
+  });
+});


### PR DESCRIPTION
Fixes a bug introduced in #1767. Fixes #1770.

Files that don't emit CSS but _do_ emit composed classnames, e.g. a recipe that uses sprinkles, were causing `vite build` to fail. We now only serialize CSS imports when there is CSS to emit.