### PR TITLE
vite, compiler: Add `cssFileFilter` option to customize VE module detection

### DIFF
--- a/.changeset/thin-melons-relax.md
+++ b/.changeset/thin-melons-relax.md
@@ -1,0 +1,18 @@
+---
+'@vanilla-extract/vite-plugin': minor
+'@vanilla-extract/compiler': minor
+---
+
+Add a `cssFileFilter` option to customize which files are treated as Vanilla Extract modules
+
+By default, Vanilla Extract only processes files matching `*.css.ts` (and equivalent extensions). The new `cssFileFilter` option lets you provide a custom `RegExp` — for example, to adopt a different naming convention such as `css.ts`:
+
+```ts
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+
+vanillaExtractPlugin({
+  cssFileFilter: /(?:^|[/\\])css\.(js|cjs|mjs|jsx|ts|tsx)(\?used)?$/,
+});
+```
+
+The same option is available on `createCompiler` from `@vanilla-extract/compiler`. When omitted, the default filter is used, so existing setups are unaffected.

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -24,7 +24,7 @@ type ModuleScanResult = {
   watchFiles: Set<string>;
 };
 
-const createModuleScanner = () => {
+const createModuleScanner = (fileFilter: RegExp) => {
   const cache = new Map<string, ModuleScanResult>();
 
   const scanModule = (
@@ -69,7 +69,7 @@ const createModuleScanner = () => {
 
     const cssDepsArray = Array.from(cssDeps);
 
-    if (moduleNode.id && cssFileFilter.test(moduleNode.id)) {
+    if (moduleNode.id && fileFilter.test(moduleNode.id)) {
       cssDepsArray.push(moduleNode.id);
     }
 
@@ -94,11 +94,14 @@ const createViteServer = async ({
   root,
   identifiers,
   viteConfig,
+  fileFilter,
   enableFileWatcher = true,
 }: Required<
   Pick<CreateCompilerOptions, 'root' | 'identifiers' | 'viteConfig'>
 > &
-  Pick<CreateCompilerOptions, 'enableFileWatcher'>) => {
+  Pick<CreateCompilerOptions, 'enableFileWatcher'> & {
+    fileFilter: RegExp;
+  }) => {
   const pkg = getPackageInfo(root);
   const vite = await import('vite');
 
@@ -149,7 +152,7 @@ const createViteServer = async ({
       {
         name: 'vanilla-extract-transform',
         async transform(code, id) {
-          if (cssFileFilter.test(id)) {
+          if (fileFilter.test(id)) {
             const filescopedCode = await transform({
               source: code,
               rootPath: root,
@@ -274,6 +277,13 @@ export interface CreateCompilerOptions {
    */
   unstable_splitCssPerRule?: boolean;
   identifiers?: IdentifierOption;
+  /**
+   * The regex used to detect Vanilla Extract files. Override this to use a different file naming
+   * convention (e.g. to match `css.ts` instead of the default `*.css.ts`).
+   *
+   * @default cssFileFilter
+   */
+  cssFileFilter?: RegExp;
   viteConfig?: ViteUserConfig;
   /** @deprecated */
   viteResolve?: ViteUserConfig['resolve'];
@@ -285,6 +295,7 @@ export const createCompiler = ({
   identifiers = 'debug',
   cssImportSpecifier = (filePath) => filePath + '.vanilla.css',
   unstable_splitCssPerRule: splitCssPerRule = false,
+  cssFileFilter: fileFilter = cssFileFilter,
   viteConfig,
   enableFileWatcher,
   viteResolve,
@@ -302,6 +313,7 @@ export const createCompiler = ({
       resolve: viteResolve,
       plugins: vitePlugins,
     },
+    fileFilter,
     enableFileWatcher,
   });
 
@@ -425,7 +437,7 @@ export const createCompiler = ({
           const cssImports: string[] = [];
           const orderedComposedClassLists: Composition[] = [];
 
-          const scanModule = createModuleScanner();
+          const scanModule = createModuleScanner(fileFilter);
           const { cssDeps, watchFiles } = scanModule(moduleNode);
 
           for (const cssDep of cssDeps) {

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -43,6 +43,13 @@ interface Options {
   identifiers?: IdentifierOption;
   unstable_pluginFilter?: PluginFilter;
   unstable_mode?: 'transform' | 'emitCss' | 'inlineCssInDev';
+  /**
+   * The regex used to detect Vanilla Extract files. Override this to use a different file naming
+   * convention (e.g. to match `css.ts` instead of the default `*.css.ts`).
+   *
+   * @default cssFileFilter
+   */
+  cssFileFilter?: RegExp;
 }
 
 // Plugins that we know are compatible with the `vite-node` compiler
@@ -61,6 +68,7 @@ export function vanillaExtractPlugin({
   identifiers,
   unstable_pluginFilter: pluginFilter = defaultPluginFilter,
   unstable_mode = 'emitCss',
+  cssFileFilter: fileFilter = cssFileFilter,
 }: Options = {}): Plugin[] {
   let config: ResolvedConfig;
   let configEnv: ConfigEnv;
@@ -95,7 +103,7 @@ export function vanillaExtractPlugin({
     const seen = new Set<ModuleNode>();
 
     for (const mod of importerChain) {
-      if (mod.id && cssFileFilter.test(mod.id)) {
+      if (mod.id && fileFilter.test(mod.id)) {
         const virtualModules = moduleGraph.getModulesByFile(
           fileIdToVirtualId(mod.id),
         );
@@ -149,6 +157,7 @@ export function vanillaExtractPlugin({
       root: config.root,
       identifiers: getIdentOption(),
       cssImportSpecifier: fileIdToVirtualId,
+      cssFileFilter: fileFilter,
       viteConfig,
       enableFileWatcher: !isBuild,
     });
@@ -242,7 +251,7 @@ export function vanillaExtractPlugin({
       async transform(code, id, options) {
         const [validId] = id.split('?');
 
-        if (!cssFileFilter.test(validId)) {
+        if (!fileFilter.test(validId)) {
           return null;
         }
 
@@ -280,7 +289,9 @@ export function vanillaExtractPlugin({
 
         const { source, watchFiles } = await compiler.processVanillaFile(
           absoluteId,
-          { outputCss: true },
+          {
+            outputCss: true,
+          },
         );
 
         transformedModules.add(normalizedId);

--- a/tests/compiler/compiler.test.ts
+++ b/tests/compiler/compiler.test.ts
@@ -27,6 +27,10 @@ describe('compiler', () => {
       root: __dirname,
       cssImportSpecifier: (filePath) => filePath + '.custom-extension.css',
     }),
+    cssFileFilter: createCompiler({
+      root: __dirname,
+      cssFileFilter: /\.vanilla\.ts$/,
+    }),
     shortIdentifiers: createCompiler({
       root: __dirname,
       identifiers: 'short',
@@ -292,6 +296,29 @@ describe('compiler', () => {
       import '{{__dirname}}/fixtures/class-composition/shared.css.ts.custom-extension.css';
       import '{{__dirname}}/fixtures/class-composition/styles.css.ts.custom-extension.css';
       export var className = 'styles_className__q7x3ow0 shared_shared__16bmd920';
+    `);
+  });
+
+  test('custom cssFileFilter', async () => {
+    const compiler = compilers.cssFileFilter;
+
+    // A `.vanilla.ts` file is only recognised as a Vanilla Extract module because of the custom
+    // `cssFileFilter`; the default filter would leave it untransformed.
+    const cssPath = path.join(
+      __dirname,
+      'fixtures/custom-filter/styles.vanilla.ts',
+    );
+    const output = await compiler.processVanillaFile(cssPath);
+    expect(output.source).toMatchInlineSnapshot(`
+      import '{{__dirname}}/fixtures/custom-filter/styles.vanilla.ts.vanilla.css';
+      export var className = 'className__s28xxj0';
+    `);
+
+    const { css } = compiler.getCssForFile(cssPath);
+    expect(css).toMatchInlineSnapshot(`
+      .className__s28xxj0 {
+        color: red;
+      }
     `);
   });
 

--- a/tests/compiler/fixtures/custom-filter/styles.vanilla.ts
+++ b/tests/compiler/fixtures/custom-filter/styles.vanilla.ts
@@ -1,0 +1,3 @@
+import { style } from '@vanilla-extract/css';
+
+export const className = style({ color: 'red' });


### PR DESCRIPTION
## Summary

Adds an optional `cssFileFilter` option to `vanillaExtractPlugin` (`@vanilla-extract/vite-plugin`) and `createCompiler` (`@vanilla-extract/compiler`) so consumers can customize which files are treated as Vanilla Extract modules.

Today the filter is a hardcoded `const` in `@vanilla-extract/integration`:

```ts
export const cssFileFilter = /\.css\.(js|cjs|mjs|jsx|ts|tsx)(\?used)?$/;
```

It's imported directly by the Vite plugin and the compiler, with no way to override it. The new option threads a caller-provided `RegExp` through both, defaulting to the existing filter so nothing changes when it's omitted.

```ts
vanillaExtractPlugin({
  // e.g. treat `css.ts` as the VE module convention instead of `*.css.ts`
  cssFileFilter: /(?:^|[/\\])css\.(js|cjs|mjs|jsx|ts|tsx)(\?used)?$/,
});
```

## Motivation

We use a single-filename convention (`css.ts`) rather than the `*.css.ts` suffix across a large codebase. With no public way to change the filter, our only option has been to patch `@vanilla-extract/integration` on disk after every install (rewriting the regex), which is fragile: a missed copy in a multi-repo/workspace setup silently leaves `css.ts` files untransformed, which surfaces later as `Styles were unable to be assigned to a file` at runtime. A first-class option removes the need for that patch.

## Changes

- `@vanilla-extract/vite-plugin`: new `cssFileFilter?: RegExp` option; used in the `transform` gate and HMR invalidation, and passed to `createCompiler`.
- `@vanilla-extract/compiler`: new `cssFileFilter?: RegExp` on `CreateCompilerOptions`; used by the module scanner and the internal file-scope transform.
- Both default to the existing `cssFileFilter`, so it's fully backwards compatible.
- Added a compiler unit test with a `.vanilla.ts` fixture that is only recognized via a custom filter, plus a changeset (minor for both packages).

## Notes

I've read the contributing guide's note that non-trivial changes are ideally discussed first: happy to move this to a discussion/issue if preferred. The change is small, additive, and non-breaking, so I've opened it as a PR to make the proposal concrete. Existing unit tests pass and the changed files are Prettier/oxlint clean.
