### PR TITLE
vite: Fix cache miss race condition

### DIFF
--- a/.changeset/bumpy-baboons-relax.md
+++ b/.changeset/bumpy-baboons-relax.md
@@ -1,0 +1,5 @@
+---
+'@vanilla-extract/vite-plugin': patch
+---
+
+Fixed a cache miss race condition that could sometimes cause a `No CSS for file` error

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -174,6 +174,42 @@ export function vanillaExtractPlugin({
     return compilerReady;
   };
 
+  /**
+   * Virtual `*.vanilla.css` modules are only populated after the parent
+   * `.css.ts` has been `processVanillaFile`'d. That normally happens in
+   * `transform`, but Vite can serve the parent without re-running `transform`
+   * (notably 304 Not Modified after a server restart with a warm browser
+   * cache), leaving the compiler CSS cache empty when the virtual module is
+   * requested. On miss, process the parent so virtual CSS is self-sufficient.
+   *
+   * A future (likely breaking) refactor should consider a soft-read/ensure API
+   * in the compiler so plugins don't have to catch thrown cache misses or call
+   * `processVanillaFile` themselves.
+   */
+  const ensureCssForVirtualId = async (absoluteVirtualId: string) => {
+    await ensureCompiler();
+
+    if (!compiler) {
+      return null;
+    }
+
+    const fileId = virtualIdToFileId(absoluteVirtualId);
+
+    try {
+      return compiler.getCssForFile(fileId).css;
+    } catch {
+      // Not in cache yet for this compiler lifetime
+    }
+
+    await compiler.processVanillaFile(fileId, { outputCss: true });
+
+    try {
+      return compiler.getCssForFile(fileId).css;
+    } catch {
+      return null;
+    }
+  };
+
   return [
     {
       name: `${PLUGIN_NAMESPACE}-inline-dev-css`,
@@ -328,7 +364,7 @@ export function vanillaExtractPlugin({
           timestamp,
         });
       },
-      resolveId(source) {
+      async resolveId(source) {
         const [validId, query] = source.split('?');
 
         if (!isVirtualId(validId)) return;
@@ -338,29 +374,24 @@ export function vanillaExtractPlugin({
           root: config.root,
         });
 
-        if (!compiler) return;
-
-        // The only valid scenario for a missing CSS entry is if someone had
-        // written a file in their app using the .vanilla.js/.vanilla.css
-        // extension, or the file produced no CSS output.
-        const { css } = compiler.getCssForFile(virtualIdToFileId(absoluteId));
+        const css = await ensureCssForVirtualId(absoluteId);
 
         if (css) {
           // Keep the original query string for HMR.
           return absoluteId + (query ? `?${query}` : '');
         }
       },
-      load(id) {
+      async load(id) {
         const [validId] = id.split('?');
 
-        if (!isVirtualId(validId) || !compiler) return;
+        if (!isVirtualId(validId)) return;
 
         const absoluteId = getAbsoluteId({
           filePath: validId,
           root: config.root,
         });
 
-        const { css } = compiler.getCssForFile(virtualIdToFileId(absoluteId));
+        const css = await ensureCssForVirtualId(absoluteId);
 
         if (css) {
           return css;

--- a/tests/vite-plugin/fixtures/virtual-css-cache/src/styles.css.ts
+++ b/tests/vite-plugin/fixtures/virtual-css-cache/src/styles.css.ts
@@ -1,0 +1,5 @@
+import { style } from '@vanilla-extract/css';
+
+export const root = style({
+  color: 'red',
+});

--- a/tests/vite-plugin/virtual-css-cache.test.ts
+++ b/tests/vite-plugin/virtual-css-cache.test.ts
@@ -1,0 +1,52 @@
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { createServer, type ViteDevServer } from 'vite';
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+import { normalizePath } from '@vanilla-extract/integration';
+
+describe('vite-plugin virtual CSS cache', () => {
+  const fixtureRoot = path.join(
+    import.meta.dirname,
+    'fixtures/virtual-css-cache',
+  );
+  const parentPath = normalizePath(path.join(fixtureRoot, 'src/styles.css.ts'));
+  const virtualId = `${parentPath}.vanilla.css`;
+
+  let server: ViteDevServer;
+
+  beforeAll(async () => {
+    server = await createServer({
+      root: fixtureRoot,
+      configFile: false,
+      plugins: [vanillaExtractPlugin()],
+      server: {
+        // Ephemeral port — we only use transformRequest, not HTTP
+        middlewareMode: true,
+      },
+      appType: 'custom',
+      logLevel: 'silent',
+    });
+  });
+
+  afterAll(async () => {
+    await server?.close();
+  });
+
+  test('serves virtual CSS without a prior parent transform', async () => {
+    // Intentionally skip transforming the parent `.css.ts` first — this is the
+    // cache-miss path that used to throw "No CSS for file" (e.g. Vite 304
+    // revalidation after a dev-server restart with a warm browser cache).
+    const result = await server.transformRequest(virtualId);
+
+    expect(result).not.toBeNull();
+    expect(result?.code).toMatch(/color:\s*red/);
+  });
+
+  test('second request hits the warm cache path', async () => {
+    const first = await server.transformRequest(virtualId);
+    const second = await server.transformRequest(virtualId);
+
+    expect(second?.code).toBe(first?.code);
+    expect(second?.code).toMatch(/color:\s*red/);
+  });
+});


### PR DESCRIPTION
A warm browser cache combined with a dev server restart could sometimes result in a `No CSS for file` error. It turns out the compiler's assumption that `getCssForFile` should practically always have CSS for a file isn't really true. In the future the compiler might get a refactor to integrate this cache miss logic more deeply, but for now the patch is being applied to the vite plugin.