### PR TITLE
docs: Document library building as unsupported for the Vite plugin

### DIFF
--- a/site/docs/integrations/rollup.md
+++ b/site/docs/integrations/rollup.md
@@ -7,11 +7,10 @@ parent: integrations
 
 A plugin for integrating vanilla-extract with [Rollup](https://rollupjs.org/).
 
-This plugin is useful for library development but not suitable for application bundles.
-Rollup has no built-in CSS bundling, so this plugin just outputs styles as individual CSS assets.
+> 💡&nbsp;&nbsp;This plugin is also compatible with [Rolldown](https://rolldown.rs/)
 
-For applications we instead recommend to use Vite
-(which itself uses Rollup under the hood but comes with its own CSS bundling).
+This plugin is useful for library development but not suitable for application bundles.
+For applications we instead recommend [Vite](/documentation/integrations/vite) (which itself uses Rolldown under the hood but comes with its own CSS bundling).
 
 ## Installation
 
@@ -102,7 +101,8 @@ See the [build API](https://esbuild.github.io/api/#build-api) documentation.
 
 ### extract
 
-Extract all generated `.css` into one bundle. This also removes side effect `import '*.css'` statements.
+Extract all generated `.css` into one bundle.
+This also removes side effect `import '*.css'` statements.
 
 ```ts
 vanillaExtractPlugin({

--- a/site/docs/integrations/vite.md
+++ b/site/docs/integrations/vite.md
@@ -7,6 +7,12 @@ parent: integrations
 
 A plugin for integrating vanilla-extract with [Vite](https://vitejs.dev/).
 
+> 🚧&nbsp;&nbsp;Building libraries with the vanilla-extract Vite plugin is not supported.
+> The plugin targets web applications and lacks library-specific features like injecting filescopes and combining CSS into a single file.
+> It may appear to work, but this isn't tested and can break without warning - use [the Rollup plugin] instead.
+
+[The Rollup plugin]: /documentation/integrations/rollup
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
The Vite plugin has always been app-focused: it was never intended to support building libraries. This is often a source of unexpected behaviour and/or bugs (e.g. #1574).

Formally documenting that Vite is not supported for building libraries should've been done a while ago, but we sat on our thumbs while we slowly figured out common patterns for libraries that use VE. I think pointing towards Rollup/Rolldown from the Vite page makes sense given their shared ecosystem. Building a library with esbuild is still possible, but recent effort has been put into the Rollup plugin, so that's the well-supported path at the moment.

In future we may end up needing a proper guide for building libraries, but hopefully this will do a good-enough job of preventing further library-related issues.