### PR TITLE
sprinkles: Remove type limitation on number of `conditions`

### DIFF
--- a/.changeset/crisp-maps-judge.md
+++ b/.changeset/crisp-maps-judge.md
@@ -1,0 +1,7 @@
+---
+'@vanilla-extract/sprinkles': patch
+---
+
+`defineProperties`: Fixed a type limitation that capped `conditions` at 8
+
+The type definition previously enforced an arbitrary maximum, despite the lack of a runtime constraint. This limit is now gone.

--- a/packages/sprinkles/src/types.ts
+++ b/packages/sprinkles/src/types.ts
@@ -14,37 +14,28 @@ export interface RequiredResponsiveArray<
   length: Length;
 }
 
-export type ResponsiveArrayConfig<Value> = ResponsiveArray<
-  2 | 3 | 4 | 5 | 6 | 7 | 8,
-  Value
->;
+/**
+ * Produces the union `1 | 2 | ... | MaxLength` for a literal `MaxLength`.
+ */
+type LengthUpTo<
+  MaxLength extends number,
+  Counter extends ReadonlyArray<unknown> = [unknown],
+  Result = never,
+> = Counter['length'] extends MaxLength
+  ? Result | MaxLength
+  : LengthUpTo<MaxLength, [...Counter, unknown], Result | Counter['length']>;
 
-export type ResponsiveArrayByMaxLength<MaxLength extends number, Value> = [
-  never,
-  ResponsiveArray<1, Value | null>,
-  ResponsiveArray<1 | 2, Value | null>,
-  ResponsiveArray<1 | 2 | 3, Value | null>,
-  ResponsiveArray<1 | 2 | 3 | 4, Value | null>,
-  ResponsiveArray<1 | 2 | 3 | 4 | 5, Value | null>,
-  ResponsiveArray<1 | 2 | 3 | 4 | 5 | 6, Value | null>,
-  ResponsiveArray<1 | 2 | 3 | 4 | 5 | 6 | 7, Value | null>,
-  ResponsiveArray<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8, Value | null>,
-][MaxLength];
+export type ResponsiveArrayConfig<Value> = readonly [Value, Value, ...Value[]];
+
+export type ResponsiveArrayByMaxLength<
+  MaxLength extends number,
+  Value,
+> = ResponsiveArray<LengthUpTo<MaxLength>, Value | null>;
 
 export type RequiredResponsiveArrayByMaxLength<
   MaxLength extends number,
   Value,
-> = [
-  never,
-  RequiredResponsiveArray<1, Value | null>,
-  RequiredResponsiveArray<1 | 2, Value | null>,
-  RequiredResponsiveArray<1 | 2 | 3, Value | null>,
-  RequiredResponsiveArray<1 | 2 | 3 | 4, Value | null>,
-  RequiredResponsiveArray<1 | 2 | 3 | 4 | 5, Value | null>,
-  RequiredResponsiveArray<1 | 2 | 3 | 4 | 5 | 6, Value | null>,
-  RequiredResponsiveArray<1 | 2 | 3 | 4 | 5 | 6 | 7, Value | null>,
-  RequiredResponsiveArray<1 | 2 | 3 | 4 | 5 | 6 | 7 | 8, Value | null>,
-][MaxLength];
+> = RequiredResponsiveArray<LengthUpTo<MaxLength>, Value | null>;
 
 export type ConditionalPropertyValue = {
   defaultClass: string | undefined;

--- a/tests/sprinkles/index.css.ts
+++ b/tests/sprinkles/index.css.ts
@@ -126,3 +126,46 @@ export const shorthandsWithZeroValues = defineProperties({
     mt: ['marginTop'],
   },
 });
+
+// More than 8 conditions, to verify the responsive array types are no longer
+// capped at 8. Kept last in this file so it doesn't shift the generated
+// identifiers (and therefore snapshots) of the fixtures above it.
+export const manyConditionsProperties = defineProperties({
+  defaultCondition: 'condition1',
+  conditions: {
+    condition1: {},
+    condition2: { '@media': 'screen and (min-width: 200px)' },
+    condition3: { '@media': 'screen and (min-width: 400px)' },
+    condition4: { '@media': 'screen and (min-width: 600px)' },
+    condition5: { '@media': 'screen and (min-width: 800px)' },
+    condition6: { '@media': 'screen and (min-width: 1000px)' },
+    condition7: { '@media': 'screen and (min-width: 1200px)' },
+    condition8: { '@media': 'screen and (min-width: 1400px)' },
+    condition9: { '@media': 'screen and (min-width: 1600px)' },
+    condition10: { '@media': 'screen and (min-width: 1800px)' },
+    condition11: { '@media': 'screen and (min-width: 2000px)' },
+    condition12: { '@media': 'screen and (min-width: 2200px)' },
+  },
+  responsiveArray: [
+    'condition1',
+    'condition2',
+    'condition3',
+    'condition4',
+    'condition5',
+    'condition6',
+    'condition7',
+    'condition8',
+    'condition9',
+    'condition10',
+    'condition11',
+    'condition12',
+  ],
+  properties: {
+    display: ['block', 'none', 'flex'],
+    paddingTop: spacing,
+    paddingBottom: spacing,
+  },
+  shorthands: {
+    paddingY: ['paddingTop', 'paddingBottom'],
+  },
+});

--- a/tests/sprinkles/sprinkles-type-tests.ts
+++ b/tests/sprinkles/sprinkles-type-tests.ts
@@ -15,6 +15,7 @@ import {
   conditionalProperties,
   conditionalPropertiesWithoutDefaultCondition,
   conditionalPropertiesWithoutResponsiveArray,
+  manyConditionsProperties,
 } from './index.css';
 
 const noop = (..._args: Array<any>) => {};
@@ -277,4 +278,93 @@ const noop = (..._args: Array<any>) => {};
     ['row'];
 
   noop(invalidRequiredValue);
+};
+
+/**
+ * More than 8 conditions
+ *
+ * `conditions` (and therefore `responsiveArray`) used to be capped at 8 by
+ * the types. These tests exercise a 12-condition config to make sure the cap
+ * is gone while the connection between `conditions` and `responsiveArray`
+ * (and the responsive array prop values) is preserved.
+ */
+// oxlint-disable-next-line no-unused-expressions
+() => {
+  const sprinkles = createSprinkles(manyConditionsProperties);
+
+  // Valid value - default condition, no responsive syntax
+  sprinkles({ display: 'flex' });
+
+  // Valid value - conditions beyond the 8th are accepted as object keys
+  sprinkles({
+    display: {
+      condition1: 'block',
+      condition9: 'none',
+      condition12: 'flex',
+    },
+  });
+
+  sprinkles({
+    display: {
+      // @ts-expect-error Invalid condition name
+      condition13: 'block',
+    },
+  });
+
+  // Valid value - a responsive array with more than 8 (up to 12) elements.
+  // (`@ts-expect-error` only suppresses the following line, so the array
+  // literals below are kept on a single line to keep the directives accurate.)
+  // prettier-ignore
+  sprinkles({
+    display: ['block', 'none', 'flex', 'block', 'none', 'flex', 'block', 'none', 'flex', 'block', 'none', 'flex'],
+  });
+
+  // Valid value - responsive array shorthand beyond 8 elements
+  // prettier-ignore
+  sprinkles({
+    paddingY: ['small', 'medium', 'large', 'small', 'medium', 'large', 'small', 'medium', 'large', 'small', 'medium', 'large'],
+  });
+
+  // prettier-ignore
+  sprinkles({
+    // @ts-expect-error Too many responsive array values (13 > 12 conditions)
+    display: ['block', 'none', 'flex', 'block', 'none', 'flex', 'block', 'none', 'flex', 'block', 'none', 'flex', 'block'],
+  });
+
+  // prettier-ignore
+  sprinkles({
+    // @ts-expect-error Invalid responsive array value beyond the 8th slot
+    display: ['block', 'none', 'flex', 'block', 'none', 'flex', 'block', 'none', 'nope'],
+  });
+
+  // The connection between `conditions` and `responsiveArray` is maintained:
+  // only condition names are valid `responsiveArray` elements. `responsiveArray`
+  // is placed first so the caught error anchors to it rather than another prop.
+  defineProperties({
+    // @ts-expect-error 'd' is not a defined condition name
+    responsiveArray: ['a', 'b', 'd'],
+    defaultCondition: 'a',
+    conditions: {
+      a: {},
+      b: { '@media': 'screen and (min-width: 200px)' },
+      c: { '@media': 'screen and (min-width: 400px)' },
+    },
+    properties: {
+      display: ['block', 'flex'],
+    },
+  });
+
+  // A `responsiveArray` must contain at least two conditions.
+  defineProperties({
+    // @ts-expect-error A single-element responsive array is not allowed
+    responsiveArray: ['a'],
+    defaultCondition: 'a',
+    conditions: {
+      a: {},
+      b: { '@media': 'screen and (min-width: 200px)' },
+    },
+    properties: {
+      display: ['block', 'flex'],
+    },
+  });
 };


### PR DESCRIPTION
Fixes #1080.

Remembered that this issue existed. Hit a roadblock of some kind last time I tried to fix this, but now we have a fix. 