### PR TITLE
Fix duplicated word and a typo in docs

### DIFF
--- a/packages/sprinkles/README.md
+++ b/packages/sprinkles/README.md
@@ -646,7 +646,7 @@ mapResponsiveValue(
 
 ### createNormalizeValueFn
 
-Creates a function for normalizing conditional values into a consistent object stucture. Any primitive values or responsive arrays will be converted to conditional objects.
+Creates a function for normalizing conditional values into a consistent object structure. Any primitive values or responsive arrays will be converted to conditional objects.
 
 This function should be created and exported from your `sprinkles.css.ts` file using the conditions from your defined properties.
 

--- a/site/docs/api/layer.md
+++ b/site/docs/api/layer.md
@@ -71,7 +71,7 @@ export const typography = layer(
 
 In order to generate the smallest possible CSS output, Vanilla Extract will merge styles that are assigned to the same layer within the same file, if it can be done without impacting the precedence of the rules.
 
-Notice in this example, while the `themedHeading` style is created before the the `heading` style, it appears later in the stylesheet. This is due to it being assigned to the `theme` layer — which is declared after the `base` layer.
+Notice in this example, while the `themedHeading` style is created before the `heading` style, it appears later in the stylesheet. This is due to it being assigned to the `theme` layer — which is declared after the `base` layer.
 
 ```ts compiled
 // typography.css.ts

--- a/site/docs/global-api/global-layer.md
+++ b/site/docs/global-api/global-layer.md
@@ -136,7 +136,7 @@ export const typography = globalLayer(
 
 In order to generate the smallest possible CSS output, Vanilla Extract will merge styles that are assigned to the same layer within the same file, if it can be done without impacting the precedence of the rules.
 
-Notice in this example, while the `themedHeading` style is created before the the `heading` style, it appears later in the stylesheet. This is due to it being assigned to the `theme` layer — which is declared after the `base` layer.
+Notice in this example, while the `themedHeading` style is created before the `heading` style, it appears later in the stylesheet. This is due to it being assigned to the `theme` layer — which is declared after the `base` layer.
 
 ```ts compiled
 // typography.css.ts


### PR DESCRIPTION
A couple of small typos in the docs:

- `site/docs/api/layer.md` and `site/docs/global-api/global-layer.md`: "created before the the `heading` style" -> "before the `heading` style".
- `packages/sprinkles/README.md`: "a consistent object stucture" -> "structure".

Documentation only.
