### PR TITLE
Skip module graph invalidation in production builds

### DIFF
--- a/.changeset/lucky-pandas-listen.md
+++ b/.changeset/lucky-pandas-listen.md
@@ -2,8 +2,4 @@
 '@vanilla-extract/turbopack-plugin': patch
 ---
 
-Stop invalidating the compiler's module graph on every file during production builds
-
-Production builds now reuse the shared compiler's module graph across files instead of dropping it before each one. On an app with 634 `.css.ts` files, this cut time spent in the loader from 256s to 84s and total Turbopack compile time by a third, with byte-identical CSS output.
-
-Development builds are unaffected: the file watcher is disabled there, so the manual invalidation is still required to pick up edits between loader invocations.
+perf: Don't invalidate the compiler's module graph each time a file is processed during production builds

--- a/.changeset/lucky-pandas-listen.md
+++ b/.changeset/lucky-pandas-listen.md
@@ -1,0 +1,9 @@
+---
+'@vanilla-extract/turbopack-plugin': patch
+---
+
+Stop invalidating the compiler's module graph on every file during production builds
+
+Production builds now reuse the shared compiler's module graph across files instead of dropping it before each one. On an app with 634 `.css.ts` files, this cut time spent in the loader from 256s to 84s and total Turbopack compile time by a third, with byte-identical CSS output.
+
+Development builds are unaffected: the file watcher is disabled there, so the manual invalidation is still required to pick up edits between loader invocations.

--- a/packages/turbopack-plugin/src/index.ts
+++ b/packages/turbopack-plugin/src/index.ts
@@ -206,8 +206,14 @@ export default async function turbopackVanillaExtractLoader(
   });
 
   // if turbopack invokes the loader quickly, vite can't invalidate the module fast enough
-  // so we disable the internal file watcher and manually invalidate the module instead
-  await compiler.unstable_invalidateAllModules();
+  // so we disable the internal file watcher and manually invalidate the module instead.
+  //
+  // A production build never mutates its inputs, so there is nothing to invalidate: dropping the
+  // whole module graph before every file only forces the shared compiler to re-evaluate each
+  // file's imports from scratch, which is quadratic in the number of `.css.ts` files.
+  if (process.env.NODE_ENV !== 'production') {
+    await compiler.unstable_invalidateAllModules();
+  }
 
   const { source, watchFiles } = await compiler.processVanillaFile(
     this.resourcePath,


### PR DESCRIPTION
Production builds spend most of their compile time re-evaluating .css.ts files that have not changed.

The loader invalidates the shared compiler's entire module graph before every file. Dev needs that, since the file watcher is disabled and a file can change between invocations. A production build never mutates its inputs, so the invalidation only forces each file's imports to be re-evaluated from scratch.

Measured on an app with 634 .css.ts files, Next 16 and Turbopack, cold builds:

| | before | after |
| --- | --- | --- |
| time in loader | 256.3s | 83.6s |
| wall compile | 266s | 177s |

CSS output is identical: same 311 files, same 2,594,429 bytes, same content hash.

Dev is unchanged, the invalidation still runs there. The stress test in index.test.ts still covers it, since vitest sets NODE_ENV to test.

Happy to gate this some other way if you would rather not read NODE_ENV in the loader, though identifiers just above it does the same.
