### PR TITLE
fix: escape packageName and normalizedPath in addFileScope to prevent code injection

### DIFF
--- a/packages/integration/src/addFileScope.ts
+++ b/packages/integration/src/addFileScope.ts
@@ -29,20 +29,20 @@ export function addFileScope({
   if (source.includes('@vanilla-extract/css/fileScope')) {
     source = source.replace(
       /setFileScope\(((\n|.)*?)\)/,
-      `setFileScope("${normalizedPath}", "${packageName}")`,
+      `setFileScope(${JSON.stringify(normalizedPath)}, ${JSON.stringify(packageName)})`,
     );
   } else {
     if (hasESM && !isMixed) {
       source = dedent(`
         import { setFileScope, endFileScope } from "@vanilla-extract/css/fileScope";
-        setFileScope("${normalizedPath}", "${packageName}");
+        setFileScope(${JSON.stringify(normalizedPath)}, ${JSON.stringify(packageName)});
         ${source}
         endFileScope();
       `);
     } else {
       source = dedent(`
         const __vanilla_filescope__ = require("@vanilla-extract/css/fileScope");
-        __vanilla_filescope__.setFileScope("${normalizedPath}", "${packageName}");
+        __vanilla_filescope__.setFileScope(${JSON.stringify(normalizedPath)}, ${JSON.stringify(packageName)});
         ${source}
         __vanilla_filescope__.endFileScope();
       `);


### PR DESCRIPTION
The `packageName` (from `package.json`) and `normalizedPath` values are interpolated directly into generated JavaScript string literals in `addFileScope.ts` without escaping. A malicious `package.json` `name` field containing double quotes can break out of the string literal and inject arbitrary code that gets executed by `evalCode()` in `processVanillaFile.ts`.

## Fix

Replace `"${var}"` interpolation with `JSON.stringify(var)` in all 3
locations in `addFileScope.ts`:

| Line | Before | After |
|------|--------|-------|
| 32 | `"${normalizedPath}", "${packageName}"` | `${JSON.stringify(normalizedPath)}, ${JSON.stringify(packageName)}` |
| 38 | `"${normalizedPath}", "${packageName}"` | `${JSON.stringify(normalizedPath)}, ${JSON.stringify(packageName)}` |
| 45 | `"${normalizedPath}", "${packageName}"` | `${JSON.stringify(normalizedPath)}, ${JSON.stringify(packageName)}` |

`JSON.stringify` handles all escaping edge cases (double quotes,
backslashes, newlines, Unicode) and is the standard safe way to embed
arbitrary strings into generated JavaScript source.

## Before / After

With `package.json` name set to `test"); evil_code; //`:

Before (injection succeeds):
```js
setFileScope("src/file.css.ts", "test"); evil_code; //");
```

After (payload safely escaped):
```js
setFileScope("src/file.css.ts", "test\"); evil_code; //");
```
